### PR TITLE
Auto-discover CSV/Parquet in CWD on landing page

### DIFF
--- a/docs/end-user/how-to/install.md
+++ b/docs/end-user/how-to/install.md
@@ -17,7 +17,10 @@ Models, and Ollama support.
 
 ## Configure an LLM provider
 
-Set one of these in your shell or in the project `.env`:
+Run `datasight config init` to create `~/.config/datasight/.env`, then add
+your API key there — every project on this machine will pick it up.
+Alternatively, paste the key into the project `.env` or export it in your
+shell. Pick one of:
 
 === "Anthropic"
 

--- a/docs/project-developer/set-up-project.md
+++ b/docs/project-developer/set-up-project.md
@@ -259,7 +259,7 @@ options, and diagnostics.
 
 ```mermaid
 flowchart TB
-    A[datasight run] --> B[Load project .env, then global .env]
+    A[datasight run] --> B[Load .env: project values override global]
     B --> C[Connect to database]
     C --> D[Introspect schema]
     D --> E[Load schema_description.md]

--- a/docs/project-developer/set-up-project.md
+++ b/docs/project-developer/set-up-project.md
@@ -19,6 +19,24 @@ Don't have [uv](https://docs.astral.sh/uv/) yet? See
 backends (DuckDB, SQLite, PostgreSQL) and LLM providers (Anthropic,
 GitHub Models, Ollama) are included.
 
+## Store API keys once (recommended)
+
+If you haven't already, create a user-global config file for your API keys
+and tokens. You only do this once per machine:
+
+```bash
+datasight config init
+```
+
+This writes `~/.config/datasight/.env` (honors `XDG_CONFIG_HOME`). Edit it
+and uncomment the credentials you actually use — `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, and/or `GITHUB_TOKEN`. Every datasight project on this
+machine will pick up these values automatically, so each project's `.env`
+only has to set provider, model, and database. Per-project `.env` values
+still override the global file when you need a different key for one
+project. See [Configuration reference](../reference/configuration.md) for
+the full precedence rules.
+
 ## Create a project
 
 ```bash
@@ -42,14 +60,17 @@ This creates four template files:
 
 ## Configure
 
-Edit `.env` with your database path and LLM settings. For guidance on
-picking a provider — data sensitivity, cost tiers, local vs hosted —
-see [Choosing an LLM](../concepts/choosing-an-llm.md).
+Edit `.env` with your database path and LLM settings. The examples below
+assume you've already run `datasight config init` and put your API keys in
+`~/.config/datasight/.env`. If not, you can also paste the key directly
+into the project `.env` — both work. For guidance on picking a provider —
+data sensitivity, cost tiers, local vs hosted — see
+[Choosing an LLM](../concepts/choosing-an-llm.md).
 
 **Option A — Anthropic (cloud API):**
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-...
+# LLM_PROVIDER=anthropic is the default
 DB_MODE=duckdb
 DB_PATH=./my_database.duckdb
 ```
@@ -58,7 +79,6 @@ DB_PATH=./my_database.duckdb
 
 ```bash
 LLM_PROVIDER=openai
-OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-4o-mini
 DB_MODE=duckdb
 DB_PATH=./my_database.duckdb
@@ -68,7 +88,6 @@ DB_PATH=./my_database.duckdb
 
 ```bash
 LLM_PROVIDER=github
-GITHUB_TOKEN=ghp_...
 GITHUB_MODELS_MODEL=gpt-4o
 DB_MODE=duckdb
 DB_PATH=./my_database.duckdb
@@ -240,7 +259,7 @@ options, and diagnostics.
 
 ```mermaid
 flowchart TB
-    A[datasight run] --> B[Load .env]
+    A[datasight run] --> B[Load project .env, then global .env]
     B --> C[Connect to database]
     C --> D[Introspect schema]
     D --> E[Load schema_description.md]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,6 +54,7 @@ datasight [OPTIONS] COMMAND [ARGS]...
 **Subcommands**
 
 - `init`: Create blank datasight project template files.
+- `config`: Manage user-global datasight configuration.
 - `demo`: Create ready-to-run demo projects with sample datasets.
 - `generate`: Generate schema_description.md, queries.yaml, measures.yaml, and time_series.yaml from your database.
 - `run`: Start the datasight web UI.
@@ -100,6 +101,54 @@ datasight init [OPTIONS] [PROJECT_DIR]
 | --- | --- |
 | `PROJECT_DIR` |   |
 | `--overwrite` | Overwrite existing files. |
+
+### `datasight config`
+
+Manage user-global datasight configuration.
+
+The user-global config file (~/.config/datasight/.env) holds API
+keys and tokens shared across every datasight project. Per-project
+.env files override its values, so each project can still pick its
+own LLM provider, model, and database.
+
+Examples:
+
+    datasight config init
+    datasight config show
+
+```bash
+datasight config [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands**
+
+- `init`: Create the user-global config file (~/.config/datasight/.env).
+- `show`: Show the resolved datasight configuration and where it loaded from.
+
+#### `datasight config init`
+
+Create the user-global config file (~/.config/datasight/.env).
+
+Stores API keys and tokens in one place so per-project .env files only
+need to set provider, model, and database settings.
+
+```bash
+datasight config init [OPTIONS]
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `--overwrite` | Overwrite the existing global config file. |
+
+#### `datasight config show`
+
+Show the resolved datasight configuration and where it loaded from.
+
+```bash
+datasight config show [OPTIONS]
+```
 
 ### `datasight demo`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,7 +1,40 @@
 # Configuration reference
 
-datasight is configured via environment variables, typically in a `.env` file
-in the project directory. CLI flags override `.env` values.
+datasight is configured via environment variables, loaded from two `.env`
+files: a per-project `.env` in the project directory, and an optional
+**user-global** `.env` shared across every project. CLI flags override both.
+
+## Global vs project config
+
+Most users want to store API keys and tokens **once**, not in every project.
+Run:
+
+```bash
+datasight config init
+```
+
+…to create `~/.config/datasight/.env` (honors `XDG_CONFIG_HOME`) from a
+template. Put credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and
+`GITHUB_TOKEN` there. Then each project's `.env` only needs to set provider,
+model, and database — for example:
+
+```bash
+# project .env
+LLM_PROVIDER=openai
+OPENAI_MODEL=gpt-4o
+DB_MODE=duckdb
+DB_PATH=./my_database.duckdb
+```
+
+Per-project values **override** the global file, so you can still pin a
+specific API key or model on a single project when needed.
+
+To inspect which provider, model, and database you'd connect to right now —
+and which config files were loaded — run:
+
+```bash
+datasight config show
+```
 
 ## Environment variables
 
@@ -121,6 +154,7 @@ project directory. This is created automatically and should be added to
 Settings are resolved in this order (highest priority first):
 
 1. CLI flags (`--port`, `--db-mode`, `--db-path`, `--model`)
-2. Environment variables
+2. Environment variables (shell exports)
 3. `.env` file in the project directory
-4. Built-in defaults
+4. User-global `.env` (`~/.config/datasight/.env`)
+5. Built-in defaults

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -162,6 +162,14 @@
     sessionStore.projectLoaded = true;
     sessionStore.isEphemeralSession = true;
 
+    // Fresh session = fresh editor/chat state. Without this, SQL from a
+    // previous session (persisted in localStorage) survives into a new
+    // ephemeral session whose schema no longer matches.
+    chatStore.clear();
+    queriesStore.clear();
+    sqlEditorStore.clearAll();
+    sessionStore.sessionId = crypto.randomUUID();
+
     await Promise.allSettled([loadSchema(), loadRecipes()]);
 
     // Run pending starter

--- a/frontend/src/lib/api/projects.ts
+++ b/frontend/src/lib/api/projects.ts
@@ -76,6 +76,23 @@ export async function getExploreStatus(): Promise<{
   return fetchJson("/api/explore/status");
 }
 
+export interface ScannedDataFile {
+  path: string;
+  name: string;
+  type: "csv" | "parquet";
+  size_bytes: number;
+}
+
+export interface ScanCwdResult {
+  directory: string;
+  files: ScannedDataFile[];
+  truncated: boolean;
+}
+
+export async function scanCwdForDataFiles(): Promise<ScanCwdResult> {
+  return fetchJson<ScanCwdResult>("/api/explore/scan-cwd");
+}
+
 export async function checkProjectPath(
   path: string,
 ): Promise<{ exists: boolean; files: string[] }> {

--- a/frontend/src/lib/components/DiscoveredFilesCard.svelte
+++ b/frontend/src/lib/components/DiscoveredFilesCard.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { explore } from "$lib/api/projects";
+  import {
+    scanCwdForDataFiles,
+    type ScannedDataFile,
+  } from "$lib/api/projects";
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
+
+  interface Props {
+    onExplored: () => void;
+    onError: (msg: string) => void;
+  }
+
+  let { onExplored, onError }: Props = $props();
+
+  let files = $state<ScannedDataFile[]>([]);
+  let directory = $state("");
+  let truncated = $state(false);
+  let scanned = $state(false);
+  let loading = $state(false);
+  let error = $state("");
+
+  onMount(async () => {
+    try {
+      const result = await scanCwdForDataFiles();
+      files = result.files;
+      directory = result.directory;
+      truncated = result.truncated;
+    } catch {
+      // Silent — this card just hides itself if the scan fails.
+    } finally {
+      scanned = true;
+    }
+  });
+
+  async function handleQuery() {
+    error = "";
+    if (files.length === 0) return;
+    loading = true;
+    try {
+      const result = await explore(files.map((f) => f.path));
+      if (!result.success) {
+        error = result.error || "Failed to load files";
+        onError(error);
+        return;
+      }
+      dashboardStore.currentView = "sql";
+      onExplored();
+    } catch {
+      error = "Failed to connect to server";
+      onError(error);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(n / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  }
+</script>
+
+{#if scanned && files.length > 0}
+  <div
+    class="bg-surface border border-border"
+    style="padding: 28px; border-radius: 18px; margin-bottom: 18px;
+           box-shadow: inset 0 1px 0 rgba(255,255,255,0.25), 0 14px 30px rgba(2,61,96,0.05);"
+  >
+    <div
+      class="inline-flex items-center text-orange font-bold uppercase"
+      style="padding: 4px 9px; margin-bottom: 10px; border-radius: 999px;
+             background: color-mix(in srgb, var(--orange) 14%, transparent);
+             font-size: 0.72rem; letter-spacing: 0.05em;"
+    >
+      Detected in this folder
+    </div>
+    <div
+      class="text-text-primary"
+      style="font-size: 1.1rem; font-weight: 600; margin-bottom: 6px;"
+    >
+      {files.length}
+      {files.length === 1 ? "data file" : "data files"} ready to query
+    </div>
+    <p
+      class="text-text-secondary"
+      style="font-size: 0.82rem; margin-bottom: 14px; line-height: 1.5;
+             font-family: 'JetBrains Mono', monospace; word-break: break-all;"
+    >
+      {directory}
+    </p>
+
+    <ul
+      class="border border-border"
+      style="list-style: none; padding: 6px 10px; margin: 0 0 14px 0;
+             max-height: 180px; overflow-y: auto; border-radius: 10px;
+             background: var(--bg);"
+    >
+      {#each files as file (file.path)}
+        <li
+          class="flex items-center justify-between"
+          style="padding: 4px 2px; font-family: 'JetBrains Mono', monospace; font-size: 0.78rem;"
+        >
+          <span class="text-text-primary" style="word-break: break-all;">
+            <span class="text-teal" style="font-weight: 600;">{file.type}</span>
+            &nbsp;{file.name}
+          </span>
+          <span class="text-text-secondary" style="margin-left: 12px; white-space: nowrap;">
+            {formatBytes(file.size_bytes)}
+          </span>
+        </li>
+      {/each}
+    </ul>
+
+    {#if truncated}
+      <p class="text-text-secondary" style="font-size: 0.75rem; margin-bottom: 10px;">
+        Showing first {files.length} files. Only these will be loaded.
+      </p>
+    {/if}
+
+    <button
+      onclick={handleQuery}
+      disabled={loading}
+      class="bg-teal text-white font-medium cursor-pointer
+        hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+      style="padding: 10px 20px; border: none; border-radius: 8px;
+             font-family: inherit; font-size: 0.9rem;"
+    >
+      {loading
+        ? "Loading..."
+        : `Query ${files.length === 1 ? "this file" : `these ${files.length} files`} in SQL`}
+    </button>
+
+    {#if error}
+      <p style="font-size: 0.75rem; color: #e55; margin-top: 8px;">{error}</p>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/lib/components/LandingPage.svelte
+++ b/frontend/src/lib/components/LandingPage.svelte
@@ -2,6 +2,7 @@
   import StarterGrid from "./StarterGrid.svelte";
   import ExploreCard from "./ExploreCard.svelte";
   import ProjectCard from "./ProjectCard.svelte";
+  import DiscoveredFilesCard from "./DiscoveredFilesCard.svelte";
 
   interface Props {
     onProjectLoaded: (path: string) => void;
@@ -60,6 +61,9 @@
         AI-powered database exploration with natural language
       </p>
     </div>
+
+    <!-- Auto-discovered files in CWD -->
+    <DiscoveredFilesCard {onExplored} onError={handleExploreError} />
 
     <!-- Starter Grid -->
     <StarterGrid />

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -39,7 +39,7 @@ from datasight.audit_report import (
 from datasight.distribution import build_distribution_overview
 from datasight.integrity import build_integrity_overview
 from datasight.llm import create_llm_client
-from datasight.settings import Settings
+from datasight.settings import Settings, global_env_path, load_global_env
 from datasight.validation import build_validation_report, load_validation_config
 
 
@@ -67,8 +67,13 @@ def _resolve_settings(
     -------
     Tuple of (settings, resolved_model).
     """
+    from dotenv import load_dotenv
+
     env_path = os.path.join(project_dir, ".env")
-    settings = Settings.from_env(env_path if os.path.exists(env_path) else None)
+    if os.path.exists(env_path):
+        load_dotenv(env_path, override=False)
+    load_global_env(override=False)
+    settings = Settings.from_env()
 
     # Apply model override if provided
     resolved_model = model_override if model_override else settings.llm.model
@@ -1321,6 +1326,8 @@ def _prepare_web_runtime(
     elif os.path.exists(".env"):
         load_dotenv(".env", override=False)
 
+    load_global_env(override=False)
+
     if configure_logging:
         level = "DEBUG" if verbose else "INFO"
         logger.remove()
@@ -1400,12 +1407,117 @@ def init(project_dir: str, overwrite: bool):
 
     click.echo()
     click.echo("Next steps:")
-    click.echo("  1. Edit .env with your API key and database path")
-    click.echo("  2. Edit schema_description.md to describe your data")
-    click.echo("  3. Edit queries.yaml with example questions")
-    click.echo("  4. Or let datasight draft files from data:")
+    click.echo("  1. Store API keys once in ~/.config/datasight/.env:")
+    click.echo("     datasight config init")
+    click.echo("  2. Edit .env with your database path and (optional) provider/model")
+    click.echo("  3. Edit schema_description.md to describe your data")
+    click.echo("  4. Edit queries.yaml with example questions")
+    click.echo("  5. Or let datasight draft files from data:")
     click.echo("     datasight generate <database-or-files> --overwrite")
-    click.echo("  5. Run: datasight run")
+    click.echo("  6. Run: datasight run")
+
+
+@cli.group(
+    epilog=_epilog(
+        """
+        The user-global config file (~/.config/datasight/.env) holds API
+        keys and tokens shared across every datasight project. Per-project
+        .env files override its values, so each project can still pick its
+        own LLM provider, model, and database.
+
+        Examples:
+
+            datasight config init
+            datasight config show
+        """
+    )
+)
+def config():
+    """Manage user-global datasight configuration."""
+
+
+@config.command(name="init")
+@click.option("--overwrite", is_flag=True, help="Overwrite the existing global config file.")
+def config_init(overwrite: bool):
+    """Create the user-global config file (~/.config/datasight/.env).
+
+    Stores API keys and tokens in one place so per-project .env files only
+    need to set provider, model, and database settings.
+    """
+
+    dest = global_env_path()
+    if dest.exists() and not overwrite:
+        click.echo(f"Global config already exists: {dest}")
+        click.echo("Use --overwrite to replace it.")
+        return
+
+    template_path = Path(__file__).parent / "templates" / "global_env.template"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(template_path, dest)
+
+    click.echo(f"Created: {dest}")
+    click.echo()
+    click.echo("Next steps:")
+    click.echo(f"  1. Edit {dest} and uncomment the API keys you use")
+    click.echo("  2. In each project, .env only needs DB_MODE/DB_PATH and")
+    click.echo("     (optionally) LLM_PROVIDER and the matching model variable")
+
+
+@config.command(name="show")
+def config_show():
+    """Show the resolved datasight configuration and where it loaded from."""
+    from dotenv import load_dotenv
+
+    from datasight.recent_projects import validate_project_dir
+
+    cwd = Path.cwd().resolve()
+    is_valid, _ = validate_project_dir(str(cwd))
+    project_dir = cwd if is_valid else None
+
+    project_env = (project_dir / ".env") if project_dir else None
+    global_env = global_env_path()
+
+    if project_env and project_env.exists():
+        load_dotenv(project_env, override=False)
+    load_global_env(override=False)
+    settings = Settings.from_env()
+
+    def mask(secret: str) -> str:
+        if not secret:
+            return "(not set)"
+        return f"…{secret[-4:]}" if len(secret) > 4 else "****"
+
+    click.echo("Config files:")
+    click.echo(f"  Global:  {global_env} {'(exists)' if global_env.exists() else '(missing)'}")
+    if project_env:
+        exists = "(exists)" if project_env.exists() else "(missing)"
+        click.echo(f"  Project: {project_env} {exists}")
+    else:
+        click.echo("  Project: (no datasight project detected in CWD)")
+
+    click.echo()
+    click.echo("LLM:")
+    click.echo(f"  provider: {settings.llm.provider}")
+    click.echo(f"  model:    {settings.llm.model}")
+    if settings.llm.base_url:
+        click.echo(f"  base_url: {settings.llm.base_url}")
+    click.echo(f"  api_key:  {mask(settings.llm.api_key)}")
+
+    click.echo()
+    click.echo("Database:")
+    click.echo(f"  mode: {settings.database.mode}")
+    if settings.database.mode in ("duckdb", "sqlite"):
+        click.echo(f"  path: {settings.database.path}")
+    elif settings.database.mode == "postgres":
+        if settings.database.postgres_url:
+            click.echo(f"  url:  {settings.database.postgres_url}")
+        else:
+            click.echo(
+                f"  host: {settings.database.postgres_host}:{settings.database.postgres_port}"
+            )
+            click.echo(f"  db:   {settings.database.postgres_database}")
+    elif settings.database.mode == "flightsql":
+        click.echo(f"  uri:  {settings.database.flight_uri}")
 
 
 @cli.group(

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -66,6 +66,56 @@ def detect_file_type(path: str) -> str | None:
     return None
 
 
+def scan_directory_for_data_files(
+    directory: str | Path,
+    *,
+    max_files: int = 100,
+) -> tuple[list[dict], bool]:
+    """Find CSV and Parquet files at the top level of ``directory``.
+
+    Hidden files (dot-prefixed) and unreadable entries are skipped. Only
+    single-file entries are returned; nested directories are ignored so the
+    regular ExploreCard can still be used for hive-partitioned layouts.
+
+    Returns
+    -------
+    Tuple of ``(files, truncated)`` where each file dict has ``path``, ``name``,
+    ``type`` (``"csv"`` or ``"parquet"``), and ``size_bytes``. ``truncated`` is
+    ``True`` when more than ``max_files`` matches were present.
+    """
+    root = Path(directory)
+    if not root.is_dir():
+        return [], False
+
+    matches: list[Path] = []
+    for entry in sorted(root.iterdir(), key=lambda p: p.name.lower()):
+        if entry.name.startswith("."):
+            continue
+        if not entry.is_file():
+            continue
+        suffix = entry.suffix.lower()
+        if suffix not in (".csv", ".parquet"):
+            continue
+        matches.append(entry)
+
+    truncated = len(matches) > max_files
+    files: list[dict] = []
+    for entry in matches[:max_files]:
+        try:
+            size = entry.stat().st_size
+        except OSError:
+            continue
+        files.append(
+            {
+                "path": str(entry.resolve()),
+                "name": entry.name,
+                "type": "csv" if entry.suffix.lower() == ".csv" else "parquet",
+                "size_bytes": size,
+            }
+        )
+    return files, truncated
+
+
 def sanitize_table_name(name: str) -> str:
     """Convert a filename to a valid SQL table name.
 

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -88,10 +88,19 @@ def scan_directory_for_data_files(
         return [], False
 
     matches: list[Path] = []
-    for entry in sorted(root.iterdir(), key=lambda p: p.name.lower()):
+    try:
+        entries = sorted(root.iterdir(), key=lambda p: p.name.lower())
+    except OSError as e:
+        logger.warning(f"Unable to list {root}: {e}")
+        return [], False
+
+    for entry in entries:
         if entry.name.startswith("."):
             continue
-        if not entry.is_file():
+        try:
+            if not entry.is_file():
+                continue
+        except OSError:
             continue
         suffix = entry.suffix.lower()
         if suffix not in (".csv", ".parquet"):

--- a/src/datasight/settings.py
+++ b/src/datasight/settings.py
@@ -106,12 +106,38 @@ _PROJECT_ENV_VARS = [
 _original_env: dict[str, str] = {}
 
 
+def global_env_path() -> Path:
+    """Return the path to the user-global ``.env`` file.
+
+    Honors ``XDG_CONFIG_HOME`` and falls back to ``~/.config/datasight/.env``.
+    The file is not required to exist.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "datasight" / ".env"
+
+
+def load_global_env(*, override: bool = False) -> bool:
+    """Load the user-global ``.env`` file (e.g. ``~/.config/datasight/.env``).
+
+    Intended for storing API keys/tokens that span projects. Returns True if
+    the file exists and was loaded, False otherwise.
+    """
+    path = global_env_path()
+    if not path.exists():
+        return False
+    load_dotenv(path, override=override)
+    return True
+
+
 def capture_original_env() -> None:
     """Capture the current environment as the baseline for project switching.
 
-    Call this AFTER loading the root .env file but BEFORE loading any
-    project-specific .env files. This establishes the baseline that
-    restore_original_env() will restore to.
+    Call this AFTER loading both the user-global ``.env`` and any root
+    ``.env`` file, but BEFORE loading any project-specific ``.env`` files.
+    The captured snapshot becomes the baseline that restore_original_env()
+    restores to — so global API keys persist across project switches while
+    project-specific overrides are dropped.
     """
     global _original_env
     _original_env = {var: os.environ[var] for var in _PROJECT_ENV_VARS if var in os.environ}

--- a/src/datasight/templates/env.template
+++ b/src/datasight/templates/env.template
@@ -1,11 +1,19 @@
-# datasight configuration
-# See: https://datasight.readthedocs.io/en/latest/configuration.html
+# datasight project configuration
+# See: https://datasight.readthedocs.io/en/latest/reference/configuration.html
+#
+# RECOMMENDED: store API keys/tokens in the user-global config file once,
+# then keep this file focused on the per-project provider, model, and
+# database. To create the global file, run:
+#
+#     datasight config init
+#
+# Per-project values below override anything in the global file.
 
 # LLM provider: "anthropic" (default), "openai", "ollama", or "github"
 # LLM_PROVIDER=anthropic
 
 # --- Anthropic settings (when LLM_PROVIDER=anthropic) ---
-ANTHROPIC_API_KEY=your-api-key-here
+# ANTHROPIC_API_KEY=sk-ant-...   # prefer the global config file
 # ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 
 # Optional: Azure AI Foundry endpoint
@@ -13,7 +21,7 @@ ANTHROPIC_API_KEY=your-api-key-here
 # ANTHROPIC_FOUNDRY_RESOURCE=your-resource-name
 
 # --- OpenAI settings (when LLM_PROVIDER=openai) ---
-# OPENAI_API_KEY=sk-...
+# OPENAI_API_KEY=sk-...           # prefer the global config file
 # OPENAI_MODEL=gpt-4o-mini
 # Override for Azure OpenAI or a corporate gateway:
 # OPENAI_BASE_URL=https://api.openai.com/v1
@@ -25,7 +33,7 @@ ANTHROPIC_API_KEY=your-api-key-here
 
 # --- GitHub Models settings (when LLM_PROVIDER=github) ---
 # Uses your GitHub token for authentication with GitHub Models.
-# GITHUB_TOKEN=ghp_your-token-here
+# GITHUB_TOKEN=ghp_your-token-here    # prefer the global config file
 # GITHUB_MODELS_MODEL=gpt-4o
 # GITHUB_MODELS_BASE_URL=https://models.github.ai/inference
 

--- a/src/datasight/templates/global_env.template
+++ b/src/datasight/templates/global_env.template
@@ -1,0 +1,23 @@
+# datasight user-global configuration
+#
+# This file holds API keys and tokens shared across all datasight projects.
+# Per-project .env files in each project directory take precedence over the
+# values here, so you can keep credentials in one place and let each project
+# pick its own LLM provider, model, and database.
+#
+# Edit this file to fill in the keys you actually use, then delete the lines
+# you don't need. See: https://datasight.readthedocs.io/en/latest/reference/configuration.html
+
+# --- Anthropic ---
+# ANTHROPIC_API_KEY=sk-ant-...
+# Optional: Azure AI Foundry endpoint
+# ANTHROPIC_BASE_URL=https://your-resource.services.ai.azure.com/anthropic
+
+# --- OpenAI ---
+# OPENAI_API_KEY=sk-...
+# Optional: Azure OpenAI or corporate gateway
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+# --- GitHub Models ---
+# GITHUB_TOKEN=ghp_...
+# GITHUB_MODELS_BASE_URL=https://models.github.ai/inference

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -83,7 +83,12 @@ from datasight.generate import (
 )
 from datasight.runner import CachingSqlRunner, SqlRunner
 from datasight.schema import filter_tables, format_schema_context, introspect_schema
-from datasight.settings import Settings, capture_original_env, restore_original_env
+from datasight.settings import (
+    Settings,
+    capture_original_env,
+    load_global_env,
+    restore_original_env,
+)
 from datasight.sql_validation import build_measure_rule_map, build_schema_map, validate_sql
 
 # ---------------------------------------------------------------------------
@@ -1058,8 +1063,11 @@ async def _startup() -> None:
     from dotenv import load_dotenv
 
     load_dotenv()
+    load_global_env(override=False)
 
-    # Capture env after root .env is loaded as baseline for project switching
+    # Capture env after root + global .env are loaded as baseline for project
+    # switching. Global API keys persist across switches; project values are
+    # dropped when restore_original_env() runs.
     capture_original_env()
 
     init_llm_client(_state)

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -73,6 +73,7 @@ from datasight.explore import (
     add_files_to_connection,
     create_ephemeral_session,
     save_ephemeral_as_project,
+    scan_directory_for_data_files,
 )
 from datasight.generate import (
     build_generation_context,
@@ -2459,6 +2460,25 @@ async def _write_measure_overrides_scaffold(
     measure_data = await build_measure_overview(schema_info, sql_runner.run_sql, overrides=None)
     path.write_text(format_measure_overrides_yaml(measure_data), encoding="utf-8")
     return path.name
+
+
+@app.get("/api/explore/scan-cwd")
+async def explore_scan_cwd(state: AppState = Depends(get_state)):
+    """Scan the server's working directory for CSV/Parquet files.
+
+    Returns an empty list once a project or ephemeral session is loaded so
+    the landing page only surfaces discovered files on a fresh launch.
+    """
+    if state.project_loaded:
+        return {"directory": str(Path.cwd()), "files": [], "truncated": False}
+
+    directory = Path.cwd()
+    files, truncated = scan_directory_for_data_files(directory)
+    return {
+        "directory": str(directory),
+        "files": files,
+        "truncated": truncated,
+    }
 
 
 @app.get("/api/explore/status")

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -209,6 +209,8 @@ def test_project_template_does_not_uncomment_api_key():
         stripped = line.strip()
         if stripped.startswith("#") or not stripped:
             continue
-        # Only DB_MODE is expected to be uncommented in the project template.
+        # DB_MODE and DB_PATH are the only uncommented lines in the project
+        # template — secrets must stay commented so users are nudged toward
+        # ~/.config/datasight/.env.
         assert "API_KEY" not in stripped, f"unexpected uncommented secret line: {line!r}"
         assert "TOKEN" not in stripped, f"unexpected uncommented secret line: {line!r}"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,214 @@
+"""Tests for the `datasight config` subcommands and global env loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from datasight.cli import cli
+from datasight.settings import _PROJECT_ENV_VARS, Settings, global_env_path, load_global_env
+
+
+@pytest.fixture
+def isolated_xdg(tmp_path, monkeypatch):
+    """Point XDG_CONFIG_HOME at a temp dir so global config writes are isolated."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    return tmp_path / "xdg"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Scrub project env vars so each test starts from a clean slate."""
+    for key in _PROJECT_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# global_env_path
+# ---------------------------------------------------------------------------
+
+
+def test_global_env_path_uses_xdg_config_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    assert global_env_path() == tmp_path / "xdg" / "datasight" / ".env"
+
+
+def test_global_env_path_falls_back_to_home_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert global_env_path() == tmp_path / ".config" / "datasight" / ".env"
+
+
+def test_load_global_env_returns_false_when_missing(isolated_xdg):
+    assert load_global_env() is False
+
+
+def test_load_global_env_loads_values(isolated_xdg):
+    env = isolated_xdg / "datasight" / ".env"
+    env.parent.mkdir(parents=True)
+    env.write_text("ANTHROPIC_API_KEY=from-global\n", encoding="utf-8")
+
+    assert load_global_env() is True
+    import os
+
+    assert os.environ.get("ANTHROPIC_API_KEY") == "from-global"
+
+
+# ---------------------------------------------------------------------------
+# datasight config init
+# ---------------------------------------------------------------------------
+
+
+def test_config_init_creates_global_file(isolated_xdg):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "init"])
+    assert result.exit_code == 0, result.output
+
+    dest = isolated_xdg / "datasight" / ".env"
+    assert dest.exists()
+    text = dest.read_text(encoding="utf-8")
+    assert "ANTHROPIC_API_KEY" in text
+    assert "OPENAI_API_KEY" in text
+    assert "GITHUB_TOKEN" in text
+
+
+def test_config_init_does_not_overwrite_by_default(isolated_xdg):
+    dest = isolated_xdg / "datasight" / ".env"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("ANTHROPIC_API_KEY=existing\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "init"])
+    assert result.exit_code == 0
+    assert "already exists" in result.output
+    assert dest.read_text(encoding="utf-8") == "ANTHROPIC_API_KEY=existing\n"
+
+
+def test_config_init_overwrite_flag_replaces(isolated_xdg):
+    dest = isolated_xdg / "datasight" / ".env"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("ANTHROPIC_API_KEY=existing\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "init", "--overwrite"])
+    assert result.exit_code == 0
+    text = dest.read_text(encoding="utf-8")
+    assert "existing" not in text
+    assert "ANTHROPIC_API_KEY" in text  # template placeholder restored
+
+
+# ---------------------------------------------------------------------------
+# datasight config show
+# ---------------------------------------------------------------------------
+
+
+def test_config_show_reports_missing_global(isolated_xdg, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "show"])
+    assert result.exit_code == 0, result.output
+    assert "Global:" in result.output
+    assert "(missing)" in result.output
+    assert "no datasight project detected" in result.output
+
+
+def test_config_show_reads_global_api_key(isolated_xdg, tmp_path, monkeypatch):
+    env = isolated_xdg / "datasight" / ".env"
+    env.parent.mkdir(parents=True)
+    env.write_text("ANTHROPIC_API_KEY=sk-abcdefghijkl\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "show"])
+    assert result.exit_code == 0, result.output
+    assert "(exists)" in result.output
+    # Last 4 chars should be visible; full key should not.
+    assert "…ijkl" in result.output
+    assert "sk-abcdefghijkl" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Loader precedence: shell > project > global
+# ---------------------------------------------------------------------------
+
+
+def test_project_env_overrides_global(isolated_xdg, tmp_path):
+    """A project .env value beats the user-global .env value."""
+    global_env = isolated_xdg / "datasight" / ".env"
+    global_env.parent.mkdir(parents=True)
+    global_env.write_text("ANTHROPIC_API_KEY=global-key\n", encoding="utf-8")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".env").write_text("ANTHROPIC_API_KEY=project-key\n", encoding="utf-8")
+
+    # Mirror _resolve_settings: project first, then global with override=False.
+    from dotenv import load_dotenv
+
+    load_dotenv(project / ".env", override=False)
+    load_global_env(override=False)
+    settings = Settings.from_env()
+
+    assert settings.llm.anthropic_api_key == "project-key"
+
+
+def test_global_env_fills_when_project_missing(isolated_xdg, tmp_path):
+    """Global value is used when project .env doesn't set the key."""
+    global_env = isolated_xdg / "datasight" / ".env"
+    global_env.parent.mkdir(parents=True)
+    global_env.write_text("ANTHROPIC_API_KEY=global-key\n", encoding="utf-8")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".env").write_text(
+        "LLM_PROVIDER=anthropic\nDB_MODE=duckdb\nDB_PATH=./db.duckdb\n",
+        encoding="utf-8",
+    )
+
+    from dotenv import load_dotenv
+
+    load_dotenv(project / ".env", override=False)
+    load_global_env(override=False)
+    settings = Settings.from_env()
+
+    assert settings.llm.anthropic_api_key == "global-key"
+
+
+def test_shell_env_beats_both(isolated_xdg, tmp_path, monkeypatch):
+    """Shell-exported var beats project .env beats global .env."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "shell-key")
+
+    global_env = isolated_xdg / "datasight" / ".env"
+    global_env.parent.mkdir(parents=True)
+    global_env.write_text("ANTHROPIC_API_KEY=global-key\n", encoding="utf-8")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".env").write_text("ANTHROPIC_API_KEY=project-key\n", encoding="utf-8")
+
+    from dotenv import load_dotenv
+
+    load_dotenv(project / ".env", override=False)
+    load_global_env(override=False)
+    settings = Settings.from_env()
+
+    assert settings.llm.anthropic_api_key == "shell-key"
+
+
+# ---------------------------------------------------------------------------
+# Project env.template no longer ships an uncommented placeholder API key
+# ---------------------------------------------------------------------------
+
+
+def test_project_template_does_not_uncomment_api_key():
+    template = Path(__file__).resolve().parents[1] / "src/datasight/templates/env.template"
+    text = template.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        # Only DB_MODE is expected to be uncommented in the project template.
+        assert "API_KEY" not in stripped, f"unexpected uncommented secret line: {line!r}"
+        assert "TOKEN" not in stripped, f"unexpected uncommented secret line: {line!r}"

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -8,8 +8,49 @@ from datasight.explore import (
     detect_file_type,
     sanitize_table_name,
     save_ephemeral_as_project,
+    scan_directory_for_data_files,
 )
 from datasight.exceptions import ConfigurationError
+
+
+class TestScanDirectoryForDataFiles:
+    """Tests for scan_directory_for_data_files."""
+
+    def test_finds_csv_and_parquet(self, tmp_path):
+        import duckdb
+
+        (tmp_path / "alpha.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        parquet = tmp_path / "beta.parquet"
+        conn = duckdb.connect(":memory:")
+        conn.execute("CREATE TABLE t AS SELECT 1 AS a")
+        conn.execute(f"COPY t TO '{parquet}' (FORMAT PARQUET)")
+        conn.close()
+        (tmp_path / "readme.md").write_text("ignore me", encoding="utf-8")
+        (tmp_path / ".hidden.csv").write_text("skip", encoding="utf-8")
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        (nested / "inner.csv").write_text("a\n1\n", encoding="utf-8")
+
+        files, truncated = scan_directory_for_data_files(tmp_path)
+
+        names = [f["name"] for f in files]
+        assert names == ["alpha.csv", "beta.parquet"]
+        types = {f["name"]: f["type"] for f in files}
+        assert types == {"alpha.csv": "csv", "beta.parquet": "parquet"}
+        assert all(f["size_bytes"] > 0 for f in files)
+        assert truncated is False
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        files, truncated = scan_directory_for_data_files(tmp_path / "does-not-exist")
+        assert files == []
+        assert truncated is False
+
+    def test_respects_max_files(self, tmp_path):
+        for i in range(5):
+            (tmp_path / f"f{i}.csv").write_text("a\n1\n", encoding="utf-8")
+        files, truncated = scan_directory_for_data_files(tmp_path, max_files=3)
+        assert len(files) == 3
+        assert truncated is True
 
 
 class TestDetectFileType:

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -766,14 +766,18 @@ def test_save_explore_project_seeds_measure_overrides(monkeypatch, tmp_path):
 def test_explore_scan_cwd_lists_data_files(monkeypatch, tmp_path):
     """Scan endpoint returns CSV/Parquet files discovered in CWD."""
     (tmp_path / "generation.csv").write_text("a,b\n1,2\n", encoding="utf-8")
-    (tmp_path / "plants.parquet").write_bytes(b"\x00")  # fake payload; only metadata is read
+    (tmp_path / "plants.parquet").write_bytes(b"\x00")  # existence + stat() only
     (tmp_path / "notes.txt").write_text("ignore", encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)
+    original_project_loaded = web_app._state.project_loaded
     web_app._state.project_loaded = False
 
-    with TestClient(web_app.app) as client:
-        response = client.get("/api/explore/scan-cwd")
+    try:
+        with TestClient(web_app.app) as client:
+            response = client.get("/api/explore/scan-cwd")
+    finally:
+        web_app._state.project_loaded = original_project_loaded
 
     assert response.status_code == 200
     body = response.json()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -763,6 +763,44 @@ def test_save_explore_project_seeds_measure_overrides(monkeypatch, tmp_path):
     assert captured["schema_info"][0]["name"] == "generation_hourly"
 
 
+def test_explore_scan_cwd_lists_data_files(monkeypatch, tmp_path):
+    """Scan endpoint returns CSV/Parquet files discovered in CWD."""
+    (tmp_path / "generation.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (tmp_path / "plants.parquet").write_bytes(b"\x00")  # fake payload; only metadata is read
+    (tmp_path / "notes.txt").write_text("ignore", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    web_app._state.project_loaded = False
+
+    with TestClient(web_app.app) as client:
+        response = client.get("/api/explore/scan-cwd")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["directory"] == str(tmp_path.resolve())
+    assert body["truncated"] is False
+    names = sorted(f["name"] for f in body["files"])
+    assert names == ["generation.csv", "plants.parquet"]
+
+
+def test_explore_scan_cwd_skips_when_project_loaded(monkeypatch, tmp_path):
+    """Once a project is loaded, the scan returns an empty list."""
+    (tmp_path / "generation.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    original_project_loaded = web_app._state.project_loaded
+    web_app._state.project_loaded = True
+    try:
+        with TestClient(web_app.app) as client:
+            response = client.get("/api/explore/scan-cwd")
+    finally:
+        web_app._state.project_loaded = original_project_loaded
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["files"] == []
+
+
 def test_quality_overview_returns_profile(monkeypatch):
     """Quality overview should return deterministic quality data when loaded."""
 


### PR DESCRIPTION
When `datasight run` starts without a project, scan the working directory for top-level .csv/.parquet files and surface them in a new landing-page card that registers them as an ephemeral DuckDB session and routes straight to the SQL editor. Also reset chat/queries/SQL-editor state on every new explore session so localStorage-persisted queries from a previous session don't reference tables that no longer exist.