### PR TITLE
Fix generate crash on column names with spaces

### DIFF
--- a/src/datasight/dashboard_template.py
+++ b/src/datasight/dashboard_template.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from datasight.schema import _quote_identifier
+
 try:
     import sqlglot
     from sqlglot import exp
@@ -364,10 +366,6 @@ class ApplyResult:
     error: str | None = None
 
 
-def _quote_duckdb_identifier(name: str) -> str:
-    return '"' + name.replace('"', '""') + '"'
-
-
 def _list_attached_tables(conn) -> set[str]:
     rows = conn.execute(
         "SELECT table_name FROM information_schema.tables "
@@ -462,15 +460,15 @@ async def apply_template(
                 if source_table in resolved_sources:
                     continue
                 conn.execute(
-                    f"CREATE VIEW {_quote_duckdb_identifier(source_table)} "
-                    f"AS SELECT * FROM base.main.{_quote_duckdb_identifier(source_table)}"
+                    f"CREATE VIEW {_quote_identifier(source_table)} "
+                    f"AS SELECT * FROM base.main.{_quote_identifier(source_table)}"
                 )
 
         for name, path in resolved_sources.items():
             escaped = str(path).replace("'", "''")
             try:
                 conn.execute(
-                    f"CREATE OR REPLACE VIEW {_quote_duckdb_identifier(name)} "
+                    f"CREATE OR REPLACE VIEW {_quote_identifier(name)} "
                     f"AS SELECT * FROM read_parquet('{escaped}')"
                 )
             except duckdb.Error as err:

--- a/src/datasight/data_profile.py
+++ b/src/datasight/data_profile.py
@@ -8,10 +8,7 @@ import yaml
 from loguru import logger
 
 from datasight.runner import RunSql
-
-
-def _quote_identifier(name: str) -> str:
-    return '"' + name.replace('"', '""') + '"'
+from datasight.schema import _quote_identifier
 
 
 def _is_date_dtype(dtype: str) -> bool:

--- a/src/datasight/generate.py
+++ b/src/datasight/generate.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from datasight.prompts import DESCRIBE_SYSTEM_PROMPT, DESCRIBE_USER_MESSAGE, dialect_hint
 from datasight.runner import RunSql
-from datasight.schema import TableInfo, _validate_identifier, format_schema_context
+from datasight.schema import TableInfo, _quote_identifier, format_schema_context
 
 _TEMPORAL_TYPES = {
     "TIMESTAMP",
@@ -63,12 +63,18 @@ async def sample_enum_columns(run_sql: RunSql, tables: list[TableInfo]) -> str:
     string_types = {"VARCHAR", "TEXT", "CHAR", "STRING", "NVARCHAR", "BPCHAR", "NAME"}
 
     for table in tables:
-        table_name = _validate_identifier(table.name)
+        try:
+            table_name = _quote_identifier(table.name)
+        except ValueError:
+            continue
         for col in table.columns:
             base_type = col.dtype.upper().split("(")[0].strip()
             if base_type not in string_types:
                 continue
-            col_name = _validate_identifier(col.name)
+            try:
+                col_name = _quote_identifier(col.name)
+            except ValueError:
+                continue
             try:
                 count_result = await run_sql(
                     f"SELECT COUNT(DISTINCT {col_name}) AS n FROM {table_name}"
@@ -101,7 +107,10 @@ async def sample_timestamp_columns(run_sql: RunSql, tables: list[TableInfo]) -> 
     lines: list[str] = []
 
     for table in tables:
-        table_name = _validate_identifier(table.name)
+        try:
+            table_name = _quote_identifier(table.name)
+        except ValueError:
+            continue
         for col in table.columns:
             base_type = col.dtype.upper().split("(")[0].strip()
             name_lower = col.name.lower()
@@ -111,7 +120,10 @@ async def sample_timestamp_columns(run_sql: RunSql, tables: list[TableInfo]) -> 
             )
             if not (is_temporal or is_numeric_time):
                 continue
-            col_name = _validate_identifier(col.name)
+            try:
+                col_name = _quote_identifier(col.name)
+            except ValueError:
+                continue
             try:
                 result = await run_sql(
                     f"SELECT MIN({col_name}) AS min_v, MAX({col_name}) AS max_v "

--- a/src/datasight/schema.py
+++ b/src/datasight/schema.py
@@ -292,6 +292,18 @@ def _validate_identifier(name: str) -> str:
     return name
 
 
+def _quote_identifier(name: str) -> str:
+    """Return a double-quoted SQL identifier safe to embed in a query.
+
+    Escapes embedded double quotes by doubling them per the SQL standard.
+    Rejects names containing characters that cannot be safely represented
+    inside a quoted identifier (null bytes, newlines).
+    """
+    if any(c in name for c in ("\x00", "\n", "\r")):
+        raise ValueError(f"Unsafe identifier: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
 async def _get_columns(
     run_sql: RunSql, table: str, *, prefer_sqlite: bool = False
 ) -> list[ColumnInfo]:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -153,6 +153,35 @@ class TestSampleEnumColumns:
         conn.close()
 
     @pytest.mark.asyncio
+    async def test_samples_column_names_with_spaces(self):
+        """Column names with spaces (common in CSV headers) must not crash."""
+        import duckdb
+
+        conn = duckdb.connect(":memory:")
+        conn.execute('CREATE TABLE t ("Host Name" VARCHAR, "Host Status" VARCHAR)')
+        conn.execute("INSERT INTO t VALUES ('web1', 'up'), ('web2', 'down'), ('web1', 'up')")
+
+        async def run_sql(sql):
+            return conn.execute(sql).fetchdf()
+
+        tables = [
+            TableInfo(
+                name="t",
+                columns=[
+                    ColumnInfo(name="Host Name", dtype="VARCHAR"),
+                    ColumnInfo(name="Host Status", dtype="VARCHAR"),
+                ],
+                row_count=3,
+            )
+        ]
+        result = await sample_enum_columns(run_sql, tables)
+
+        assert "t.Host Name" in result
+        assert "t.Host Status" in result
+        assert "up" in result
+        conn.close()
+
+    @pytest.mark.asyncio
     async def test_skips_high_cardinality(self):
         """Skip columns with > 50 distinct values."""
         import duckdb
@@ -262,6 +291,31 @@ class TestSampleTimestampColumns:
         result = await sample_timestamp_columns(run_sql, tables)
 
         assert result == ""
+        conn.close()
+
+    @pytest.mark.asyncio
+    async def test_samples_timestamp_column_with_space_in_name(self):
+        """Timestamp column names with spaces must not crash sampling."""
+        import duckdb
+
+        conn = duckdb.connect(":memory:")
+        conn.execute('CREATE TABLE s ("Created At" TIMESTAMP)')
+        conn.execute("INSERT INTO s VALUES ('2024-01-01 00:00:00'), ('2024-12-31 23:00:00')")
+
+        async def run_sql(sql):
+            return conn.execute(sql).fetchdf()
+
+        tables = [
+            TableInfo(
+                name="s",
+                columns=[ColumnInfo(name="Created At", dtype="TIMESTAMP")],
+                row_count=2,
+            )
+        ]
+        result = await sample_timestamp_columns(run_sql, tables)
+
+        assert "s.Created At" in result
+        assert "2024" in result
         conn.close()
 
     @pytest.mark.asyncio

--- a/tests/test_schema_extra.py
+++ b/tests/test_schema_extra.py
@@ -7,6 +7,7 @@ import pytest
 
 from datasight.schema import (
     _get_row_count,
+    _quote_identifier,
     _validate_identifier,
     introspect_schema,
 )
@@ -24,6 +25,23 @@ def test_validate_identifier_rejects_unsafe():
 
 def test_validate_identifier_allows_safe_characters():
     assert _validate_identifier("my_table.schema-1") == "my_table.schema-1"
+
+
+def test_quote_identifier_wraps_plain_name():
+    assert _quote_identifier("users") == '"users"'
+
+
+def test_quote_identifier_allows_spaces():
+    assert _quote_identifier("Host Name") == '"Host Name"'
+
+
+def test_quote_identifier_escapes_embedded_quote():
+    assert _quote_identifier('weird"name') == '"weird""name"'
+
+
+def test_quote_identifier_rejects_newline():
+    with pytest.raises(ValueError, match="Unsafe identifier"):
+        _quote_identifier("bad\nname")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_validate_identifier rejects characters outside [A-Za-z0-9_.-], so CSV headers like "Host Name" aborted datasight generate with a ValueError before any LLM call. Added _quote_identifier that double-quotes and escapes per the SQL standard, and switched the schema samplers to use it — fixing both the crash and the unquoted-identifier SQL error.