### PR TITLE
Update default Ollama model to qwen2.5:7b, add LLM guidance, and UI tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Docs use **Zensical**. Key details:
 ## Testing
 
 - **pytest + pytest-asyncio** with `asyncio_mode = "auto"`
-- **Integration marker**: tests marked `integration` require a running local Ollama instance with `qwen3:8b` available and are excluded in CI with `pytest -m "not integration"`. New tests that call a live LLM provider must be marked `integration`; prefer fake/stub LLM clients for deterministic unit tests.
+- **Integration marker**: tests marked `integration` require a running local Ollama instance with `qwen2.5:7b` available and are excluded in CI with `pytest -m "not integration"`. New tests that call a live LLM provider must be marked `integration`; prefer fake/stub LLM clients for deterministic unit tests.
 - **Vitest** for frontend unit tests (`frontend/tests/`). Run with `cd frontend && npm test`.
 - **Playwright** for frontend E2E tests (`frontend/e2e/`). Requires `datasight run` to be running. Run with `cd frontend && npm run test:e2e`.
 - **Web UI smoke tests** live in `tests/test_web_ui_smoke.py` and exercise the rendered FastAPI app without a browser build step

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ artifacts, so do not commit bundled frontend output.
 ## Testing
 
 - **pytest + pytest-asyncio** with `asyncio_mode = "auto"`
-- **Integration marker**: tests marked `integration` require a running local Ollama instance with `qwen3:8b` available and are excluded in CI with `pytest -m "not integration"`. New tests that call a live LLM provider must be marked `integration`; prefer fake/stub LLM clients for deterministic unit tests.
+- **Integration marker**: tests marked `integration` require a running local Ollama instance with `qwen2.5:7b` available and are excluded in CI with `pytest -m "not integration"`. New tests that call a live LLM provider must be marked `integration`; prefer fake/stub LLM clients for deterministic unit tests.
 - **Vitest** for frontend unit tests (`frontend/tests/`). Run with `cd frontend && npm test`.
 - **Playwright** for frontend E2E tests (`frontend/e2e/`). Requires `datasight run` to be running. Run with `cd frontend && npm run test:e2e`.
 - **Web UI smoke tests** live in `tests/test_web_ui_smoke.py` and exercise the rendered FastAPI app without a browser build step

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Generated web assets under `src/datasight/web/static/` and
 checkout when you want FastAPI to serve the production UI.
 
 Ollama-backed CLI tests are marked `integration` because they require a running
-local Ollama server with the `qwen3:8b` model available. CI runs `pytest -m "not
+local Ollama server with the `qwen2.5:7b` model available. CI runs `pytest -m "not
 integration"`; run `pytest -m integration` locally when you want to exercise the
 live LLM path.
 

--- a/docs/concepts/choosing-an-llm.md
+++ b/docs/concepts/choosing-an-llm.md
@@ -9,7 +9,7 @@ This page helps you pick one without reading every provider's pricing page.
 | Your situation | Start with |
 |---|---|
 | Trying datasight for the first time, non-sensitive data | **Anthropic Claude Haiku** or **OpenAI GPT-4o-mini** |
-| Want zero cost, don't mind rate limits | **GitHub Models** (free tier) |
+| Want zero cost, don't mind rate limits | **GitHub Models** (free tier, recommended over Ollama for most users) |
 | Already have an OpenAI key | **OpenAI** (`gpt-4o-mini` or `gpt-4.1-mini`) |
 | Data is sensitive and must not leave your network | **Local Ollama** (laptop or HPC GPU node) |
 | Data is sensitive but you have a secure hosted endpoint | **Anthropic on Bedrock** or **Azure OpenAI** (custom `base_url`) |
@@ -93,9 +93,11 @@ So a Llama 3.1 8B model fits in ~5 GB VRAM at 4-bit, a 70B model needs
 | NVIDIA laptop GPU, 8 GB VRAM | 7–8B at 4-bit |
 | NVIDIA laptop GPU, 16 GB VRAM | 13B at 4-bit |
 
-For datasight's SQL-generation workload, an 8B model (e.g. Llama 3.1 8B
-or Qwen 2.5 Coder 7B) is a reasonable floor. Smaller models often
-struggle with realistic schemas.
+For datasight's SQL-generation workload, `qwen2.5:7b` is the recommended
+starting point for CLI queries (`datasight ask`). For the web UI with
+visualizations, step up to `qwen2.5:14b` — the 7B model struggles with
+the more complex multi-step agent interactions required for chart
+generation. Smaller models often struggle with realistic schemas.
 
 ### On an HPC GPU node
 
@@ -120,7 +122,9 @@ your laptop browser).
 ### When hosted beats local
 
 A hosted cheap-tier call (Haiku or GPT-4o-mini) often produces better
-SQL than a locally-run 8B model, at a fraction of a cent. Don't reach
+SQL than a locally-run 8B model, at a fraction of a cent. GitHub Models
+offers a free tier that handles the full datasight feature set —
+including visualizations — better than most local models. Don't reach
 for local models just to avoid hosted costs — reach for them when data
 sensitivity or offline use requires it.
 
@@ -161,9 +165,9 @@ OPENAI_API_KEY=sk-...
 LLM_PROVIDER=github
 GITHUB_TOKEN=ghp-...
 
-# Ollama (local)
+# Ollama (local — use for cost/data-security reasons)
 LLM_PROVIDER=ollama
-OLLAMA_MODEL=llama3.1:8b
+OLLAMA_MODEL=qwen2.5:7b      # CLI queries; use qwen2.5:14b for web UI with viz
 ```
 
 A secure hosted endpoint (Bedrock, Azure OpenAI, corporate proxy) is

--- a/docs/end-user/how-to/install.md
+++ b/docs/end-user/how-to/install.md
@@ -60,11 +60,18 @@ shell. Pick one of:
     Install [Ollama](https://ollama.com/), pull a tool-calling model, then:
 
     ```bash
-    ollama pull qwen3:8b
+    ollama pull qwen2.5:7b
 
     LLM_PROVIDER=ollama
-    OLLAMA_MODEL=qwen3:8b
+    OLLAMA_MODEL=qwen2.5:7b
     ```
+
+    `qwen2.5:7b` is a good starting point for CLI queries (`datasight ask`).
+    For the web UI with visualizations, `qwen2.5:14b` handles the more
+    complex agent interactions better. For the best experience overall,
+    consider [GitHub Models](https://github.com/marketplace/models) (free
+    tier) — only use Ollama when cost or data-security requirements demand
+    keeping inference local.
 
 See the [Configuration reference](../../reference/configuration.md) for
 every supported variable.

--- a/docs/project-developer/set-up-project.md
+++ b/docs/project-developer/set-up-project.md
@@ -99,17 +99,22 @@ First, install and start [Ollama](https://ollama.com/), then pull a model
 with tool-calling support:
 
 ```bash
-ollama pull qwen3:8b
+ollama pull qwen2.5:7b
 ```
 
 Then configure `.env`:
 
 ```bash
 LLM_PROVIDER=ollama
-OLLAMA_MODEL=qwen3:8b
+OLLAMA_MODEL=qwen2.5:7b
 DB_MODE=duckdb
 DB_PATH=./my_database.duckdb
 ```
+
+`qwen2.5:7b` works well for CLI queries. For the web UI with visualizations,
+use `qwen2.5:14b` (`ollama pull qwen2.5:14b`). For the best experience,
+consider GitHub Models (free tier) instead — only use Ollama when cost or
+data-security requirements demand local inference.
 
 **Using SQLite or PostgreSQL?** Set `DB_MODE` accordingly:
 

--- a/docs/project-developer/verification.md
+++ b/docs/project-developer/verification.md
@@ -111,7 +111,7 @@ Run the same suite against different models to compare reliability:
 datasight verify --model claude-sonnet-4-6
 datasight verify --model claude-haiku-4-5-20251001
 LLM_PROVIDER=github datasight verify --model gpt-4o
-LLM_PROVIDER=ollama datasight verify --model qwen3:8b
+LLM_PROVIDER=ollama datasight verify --model qwen2.5:7b
 ```
 
 ## Writing deterministic queries

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -399,7 +399,7 @@ datasight ask [OPTIONS] [QUESTION]
 | `--file` | Read one question per line from a text file. |
 | `--output-dir` | Directory for per-question batch outputs (only with --file). |
 | `--print-sql` | Print the SQL queries executed by the agent to the console. |
-| `--provenance` | Print run provenance as JSON to stderr. |
+| `--provenance` | Print run provenance as JSON to stdout (suppresses human-readable answer). |
 | `--sql-script` | Write executed queries to a SQL script that materializes results into auto-named tables (CREATE OR REPLACE). |
 | `-v`, `--verbose` | Enable debug logging. |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -74,7 +74,7 @@ For help picking a provider, see [Choosing an LLM](../concepts/choosing-an-llm.m
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OLLAMA_MODEL` | `qwen3:8b` | Ollama model name (must support tool calling) |
+| `OLLAMA_MODEL` | `qwen2.5:7b` | Ollama model name (must support tool calling). `qwen2.5:7b` works well for CLI queries; for the web UI with visualizations, try `qwen2.5:14b`. |
 | `OLLAMA_BASE_URL` | `http://localhost:11434/v1` | Ollama API endpoint |
 
 ### Database settings

--- a/docs/tool-developer/contributing.md
+++ b/docs/tool-developer/contributing.md
@@ -158,10 +158,10 @@ datasight verify -v
 ```
 
 Tests marked `integration` require a running local Ollama server with the
-`qwen3:8b` model available:
+`qwen2.5:7b` model available:
 
 ```bash
-ollama pull qwen3:8b
+ollama pull qwen2.5:7b
 ollama serve
 pytest -m integration
 ```

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -338,7 +338,7 @@ form,
 
 .page-btn {
   background: transparent;
-  border: 1px solid var(--border);
+  border: 1.5px solid var(--text-secondary);
   border-radius: 4px;
   padding: 2px 10px;
   font-family: inherit;
@@ -360,7 +360,7 @@ form,
 
 .export-csv-btn {
   background: transparent;
-  border: 1px solid var(--border);
+  border: 1.5px solid var(--text-secondary);
   border-radius: 6px;
   padding: 4px 10px;
   font-family: inherit;

--- a/frontend/src/lib/components/LlmConfigForm.svelte
+++ b/frontend/src/lib/components/LlmConfigForm.svelte
@@ -11,7 +11,7 @@
 
   const MODEL_DEFAULTS: Record<string, string> = {
     anthropic: "claude-haiku-4-5-20251001",
-    ollama: "qwen3:8b",
+    ollama: "qwen2.5:7b",
     github: "gpt-4o",
     openai: "gpt-4o-mini",
   };

--- a/frontend/src/lib/components/SqlView.svelte
+++ b/frontend/src/lib/components/SqlView.svelte
@@ -150,7 +150,7 @@
           onclick={() => runSql()}
           disabled={sqlEditorStore.running || !sqlEditorStore.sql.trim()}
         >
-          {sqlEditorStore.running ? "Running..." : "Run"}
+          {sqlEditorStore.running ? "Running..." : "▶ Run"}
         </button>
       </div>
     </div>

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -1140,6 +1140,7 @@ def _build_cli_provenance(
     return {
         "turn_id": tools[0].get("turn_id") if tools else None,
         "question": question,
+        "answer": result.text or "",
         "model": model,
         "dialect": dialect,
         "project_dir": project_dir,
@@ -1171,7 +1172,7 @@ def _emit_cli_provenance(
         project_dir=project_dir,
         provider=provider,
     )
-    click.echo(json.dumps(provenance, indent=2), err=True)
+    click.echo(json.dumps(provenance, indent=2))
 
 
 def _write_batch_result_files(
@@ -2477,7 +2478,7 @@ def verify(project_dir, model, queries_path, verbose):
 @click.option(
     "--provenance",
     is_flag=True,
-    help="Print run provenance as JSON to stderr.",
+    help="Print run provenance as JSON to stdout (suppresses human-readable answer).",
 )
 @click.option(
     "--sql-script",
@@ -2577,7 +2578,8 @@ def ask(
                         sql_dialect=sql_dialect,
                     )
                 )
-                _emit_ask_result(result, batch_output_format, None, None)
+                if not provenance:
+                    _emit_ask_result(result, batch_output_format, None, None)
                 if print_sql:
                     _print_sql_queries(result)
                 if provenance:
@@ -2619,7 +2621,8 @@ def ask(
             sql_dialect=sql_dialect,
         )
     )
-    _emit_ask_result(result, output_format, chart_format, output_path)
+    if not provenance:
+        _emit_ask_result(result, output_format, chart_format, output_path)
     if print_sql:
         _print_sql_queries(result)
     if provenance:

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -2545,6 +2545,8 @@ def ask(
     settings, resolved_model = _resolve_settings(project_dir, model)
     _validate_settings_for_llm(settings)
 
+    click.echo(f"Using {settings.llm.provider} model: {resolved_model}")
+
     resolved_db_path = _resolve_db_path(settings, project_dir)
     if settings.database.mode in ("duckdb", "sqlite") and not os.path.exists(resolved_db_path):
         click.echo(f"Error: Database file not found: {resolved_db_path}", err=True)

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -2545,7 +2545,7 @@ def ask(
     settings, resolved_model = _resolve_settings(project_dir, model)
     _validate_settings_for_llm(settings)
 
-    click.echo(f"Using {settings.llm.provider} model: {resolved_model}")
+    click.echo(f"Using {settings.llm.provider} model: {resolved_model}", err=True)
 
     resolved_db_path = _resolve_db_path(settings, project_dir)
     if settings.database.mode in ("duckdb", "sqlite") and not os.path.exists(resolved_db_path):

--- a/src/datasight/settings.py
+++ b/src/datasight/settings.py
@@ -186,7 +186,7 @@ class LLMSettings:
 
     # Ollama settings
     ollama_base_url: str = "http://localhost:11434/v1"
-    ollama_model: str = "qwen3:8b"
+    ollama_model: str = "qwen2.5:7b"
 
     # GitHub Models settings
     github_token: str = ""
@@ -353,7 +353,7 @@ class Settings:
                 anthropic_model=os.environ.get("ANTHROPIC_MODEL", "claude-haiku-4-5-20251001"),
                 anthropic_base_url=os.environ.get("ANTHROPIC_BASE_URL"),
                 ollama_base_url=os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1"),
-                ollama_model=os.environ.get("OLLAMA_MODEL", "qwen3:8b"),
+                ollama_model=os.environ.get("OLLAMA_MODEL", "qwen2.5:7b"),
                 github_token=os.environ.get("GITHUB_TOKEN", ""),
                 github_models_model=os.environ.get("GITHUB_MODELS_MODEL", "gpt-4o"),
                 github_models_base_url=os.environ.get(

--- a/src/datasight/templates/env.template
+++ b/src/datasight/templates/env.template
@@ -29,7 +29,7 @@
 # --- Ollama settings (when LLM_PROVIDER=ollama) ---
 # Requires a running Ollama instance — see https://ollama.com.
 # OLLAMA_BASE_URL=http://localhost:11434/v1
-# OLLAMA_MODEL=qwen3:8b
+# OLLAMA_MODEL=qwen2.5:7b
 
 # --- GitHub Models settings (when LLM_PROVIDER=github) ---
 # Uses your GitHub token for authentication with GitHub Models.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,9 +140,7 @@ EXAMPLE_QUERIES_YAML = """\
 @pytest.fixture()
 def project_dir(tmp_path, test_duckdb_path):
     """Create a project directory with .env and config files pointing to test DB."""
-    env_content = (
-        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={test_duckdb_path}\n"
-    )
+    env_content = f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={test_duckdb_path}\n"
     (tmp_path / ".env").write_text(env_content, encoding="utf-8")
     (tmp_path / "schema_description.md").write_text(SCHEMA_DESCRIPTION, encoding="utf-8")
     (tmp_path / "queries.yaml").write_text(EXAMPLE_QUERIES_YAML, encoding="utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ EXAMPLE_QUERIES_YAML = """\
 def project_dir(tmp_path, test_duckdb_path):
     """Create a project directory with .env and config files pointing to test DB."""
     env_content = (
-        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen3:8b\nDB_MODE=duckdb\nDB_PATH={test_duckdb_path}\n"
+        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={test_duckdb_path}\n"
     )
     (tmp_path / ".env").write_text(env_content, encoding="utf-8")
     (tmp_path / "schema_description.md").write_text(SCHEMA_DESCRIPTION, encoding="utf-8")

--- a/tests/test_cli_ask.py
+++ b/tests/test_cli_ask.py
@@ -1,6 +1,6 @@
 """Integration tests for the ``datasight ask`` CLI command using Ollama.
 
-These tests require a running Ollama instance with the qwen3:8b model.
+These tests require a running Ollama instance with the qwen2.5:7b model.
 They are marked with ``@pytest.mark.integration`` and can be skipped with:
 
     pytest -m "not integration"
@@ -43,7 +43,7 @@ _SCRUBBED_ENV_VARS = (
     "POSTGRES_URL",
     "POSTGRES_SSLMODE",
 )
-_REQUIRED_OLLAMA_MODEL = "qwen3:8b"
+_REQUIRED_OLLAMA_MODEL = "qwen2.5:7b"
 
 
 def _clean_subprocess_env() -> dict[str, str]:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -80,7 +80,7 @@ def tv_project(tmp_path_factory) -> str:
     env_text = (project_dir / ".env").read_text(encoding="utf-8")
     if "LLM_PROVIDER" not in env_text:
         (project_dir / ".env").write_text(
-            env_text + "LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen3:8b\n",
+            env_text + "LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\n",
             encoding="utf-8",
         )
 
@@ -109,7 +109,7 @@ def tv_project_isolated(tv_project, tmp_path, monkeypatch):
         "DB_MODE=duckdb\n"
         f"DB_PATH={src / 'time_validation_demo.duckdb'}\n"
         "LLM_PROVIDER=ollama\n"
-        "OLLAMA_MODEL=qwen3:8b\n",
+        "OLLAMA_MODEL=qwen2.5:7b\n",
         encoding="utf-8",
     )
     return str(dst)

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1348,7 +1348,7 @@ def test_doctor_fails_when_required_files_missing(tmp_path, test_duckdb_path):
     (tmp_path / ".env").write_text(
         (
             "LLM_PROVIDER=ollama\n"
-            "OLLAMA_MODEL=qwen3:8b\n"
+            "OLLAMA_MODEL=qwen2.5:7b\n"
             "DB_MODE=duckdb\n"
             f"DB_PATH={test_duckdb_path}\n"
         ),

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1656,7 +1656,7 @@ def test_ask_print_sql_outputs_queries_to_stderr(monkeypatch, project_dir):
     assert "SELECT count(*) FROM orders" not in result.stdout
 
 
-def test_ask_provenance_outputs_json_to_stderr(monkeypatch, project_dir):
+def test_ask_provenance_outputs_json_to_stdout(monkeypatch, project_dir):
     async def fake_run_ask_pipeline(**kwargs):
         return _make_sql_result(
             text="here are the rows",
@@ -1676,9 +1676,9 @@ def test_ask_provenance_outputs_json_to_stderr(monkeypatch, project_dir):
         ["ask", "--project-dir", project_dir, "How many orders?", "--provenance"],
     )
     assert result.exit_code == 0, result.output
-    assert "here are the rows" in result.stdout
-    provenance = json.loads(result.stderr)
+    provenance = json.loads(result.stdout)
     assert provenance["question"] == "How many orders?"
+    assert provenance["answer"] == "here are the rows"
     assert provenance["dialect"] == "duckdb"
     assert provenance["tools"][0]["formatted_sql"] == "SELECT\n  count(*)\nFROM orders"
     assert provenance["tools"][0]["validation"]["status"] == "not_run"


### PR DESCRIPTION
Switch the default Ollama model from qwen3:8b to qwen2.5:7b — faster and more reliable for tool calling. Update all docs to recommend qwen2.5:7b for CLI queries and qwen2.5:14b for the web UI with visualizations, and to prefer GitHub Models (free tier) over Ollama unless cost or data-security requires local inference.

Also: print provider/model in `datasight ask`, add ▶ to SQL editor Run button, and strengthen SQL editor button borders.