### PR TITLE
Resolve [include:Title](url) directives in schema_description.md

### DIFF
--- a/docs/project-developer/schema-description.md
+++ b/docs/project-developer/schema-description.md
@@ -57,6 +57,29 @@ Don't repeat what introspection discovers:
 
 Focus on the *meaning* behind the schema, not the schema itself.
 
+## Pull in external references
+
+Use `[include:Title](https://…)` anywhere in the file to fetch a web page
+at project-load time and splice its content into the system prompt. Useful
+for pointing the LLM at fuel-code glossaries, data-source documentation,
+or anything else that lives elsewhere and changes occasionally.
+
+```markdown
+Fuel code meanings come from
+[include:EIA fuel codes](https://www.eia.gov/electricity/monthly/pdf/technotes.pdf).
+```
+
+- HTML is stripped to plain text; non-text content types are skipped.
+- Each URL is capped at 20 KB (override with the `SCHEMA_INCLUDE_MAX_BYTES`
+  env var) and fetched once per project load.
+- If a fetch fails, the original `[include:…](url)` markdown link is left
+  in place so the LLM still sees the pointer.
+- Set `SCHEMA_INCLUDE_MAX_BYTES=0` to skip resolution entirely. The
+  directives stay in the prompt as plain markdown links, which is the
+  escape hatch when a linked page pushes the system prompt past a
+  small-context model's token limit (common on the free GitHub Models
+  tier).
+
 ## File location
 
 By default, datasight looks for `schema_description.md` in the project

--- a/docs/project-developer/schema-description.md
+++ b/docs/project-developer/schema-description.md
@@ -65,11 +65,15 @@ for pointing the LLM at fuel-code glossaries, data-source documentation,
 or anything else that lives elsewhere and changes occasionally.
 
 ```markdown
-Fuel code meanings come from
-[include:EIA fuel codes](https://www.eia.gov/electricity/monthly/pdf/technotes.pdf).
+Fuel code meanings come from the EIA's
+[include:Electricity Monthly Glossary](https://www.eia.gov/tools/glossary/index.php?id=electricity).
 ```
 
-- HTML is stripped to plain text; non-text content types are skipped.
+- Only HTML, plain-text, and JSON responses are inlined. PDFs, images,
+  and other binary formats are skipped (the directive stays as a plain
+  markdown link so the LLM still sees the pointer). Link to an HTML or
+  text rendering of the reference when one exists.
+- HTML is stripped to plain text.
 - Each URL is capped at 20 KB (override with the `SCHEMA_INCLUDE_MAX_BYTES`
   env var) and fetched once per project load.
 - If a fetch fails, the original `[include:…](url)` markdown link is left
@@ -79,6 +83,12 @@ Fuel code meanings come from
   escape hatch when a linked page pushes the system prompt past a
   small-context model's token limit (common on the free GitHub Models
   tier).
+- Only public hosts are fetched. URLs pointing at `localhost`, private
+  IP ranges, or `.internal`/`.local` hostnames are blocked to mitigate
+  SSRF from a malicious project file. Set
+  `SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS=1` to opt in when a project
+  genuinely references an internal documentation server. Redirects are
+  not followed — link to the final URL directly.
 
 ## File location
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -114,6 +114,7 @@ For production, use `POSTGRES_SSLMODE=verify-full` and consider using a
 |----------|---------|-------------|
 | `SCHEMA_DESCRIPTION_PATH` | `./schema_description.md` | Schema description file |
 | `EXAMPLE_QUERIES_PATH` | `./queries.yaml` | Example queries file |
+| `SCHEMA_INCLUDE_MAX_BYTES` | `20000` | Per-URL size cap for `[include:…](url)` directives inside the schema description. Set to `0` to skip include resolution entirely — useful when fetched pages push the prompt past a small-context model's token limit. |
 | `PORT` | `8084` | Web UI port |
 | `QUERY_LOG_ENABLED` | `false` | Enable SQL query logging ([guide](../end-user/how-to/review-query-log.md)) |
 | `QUERY_LOG_PATH` | `./query_log.jsonl` | Path to query log file |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -115,6 +115,7 @@ For production, use `POSTGRES_SSLMODE=verify-full` and consider using a
 | `SCHEMA_DESCRIPTION_PATH` | `./schema_description.md` | Schema description file |
 | `EXAMPLE_QUERIES_PATH` | `./queries.yaml` | Example queries file |
 | `SCHEMA_INCLUDE_MAX_BYTES` | `20000` | Per-URL size cap for `[include:…](url)` directives inside the schema description. Set to `0` to skip include resolution entirely — useful when fetched pages push the prompt past a small-context model's token limit. |
+| `SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS` | `false` | Opt-in switch that disables the SSRF guard on `[include:…](url)` directives, allowing fetches from `localhost`, private IP ranges, and `.internal`/`.local` hostnames. Leave off unless a project intentionally references an internal documentation server. |
 | `PORT` | `8084` | Web UI port |
 | `QUERY_LOG_ENABLED` | `false` | Enable SQL query logging ([guide](../end-user/how-to/review-query-log.md)) |
 | `QUERY_LOG_PATH` | `./query_log.jsonl` | Path to query log file |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "adbc-driver-flightsql>=1.0,<2",
     "duckdb>=1.0,<2",
     "fastapi>=0.110,<1",
+    "httpx>=0.27,<1",
     "uvicorn>=0.29,<1",
     "loguru>=0.7,<1",
     "truststore>=0.10.4",

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -128,6 +128,7 @@ async def _run_ask_pipeline(
     from datasight.prompts import build_system_prompt
     from datasight.query_log import QueryLogger
     from datasight.schema import filter_tables, format_schema_context, introspect_schema
+    from datasight.schema_links import resolve_schema_description_links
     from datasight.sql_validation import build_measure_rule_map, build_schema_map
 
     llm_client = create_llm_client(
@@ -165,6 +166,7 @@ async def _run_ask_pipeline(
         ],
     )
     user_desc = load_schema_description(None, project_dir)
+    user_desc = await resolve_schema_description_links(user_desc)
     example_queries = load_example_queries(None, project_dir)
     measure_overrides = load_measure_overrides(None, project_dir)
     time_series_configs = load_time_series_config(None, project_dir)
@@ -2258,6 +2260,7 @@ def verify(project_dir, model, queries_path, verbose):
         from datasight.config import format_example_queries, load_schema_description
         from datasight.prompts import build_system_prompt
         from datasight.schema import format_schema_context, introspect_schema
+        from datasight.schema_links import resolve_schema_description_links
         from datasight.verify import run_ambiguity_analysis, run_verification
 
         llm_client = create_llm_client(
@@ -2272,6 +2275,7 @@ def verify(project_dir, model, queries_path, verbose):
         # Build system prompt
         tables = await introspect_schema(sql_runner.run_sql, runner=sql_runner)
         user_desc = load_schema_description(None, project_dir)
+        user_desc = await resolve_schema_description_links(user_desc)
         schema_text = format_schema_context(tables, user_desc)
         schema_text += format_example_queries(queries)
 

--- a/src/datasight/demo_dsgrid_tempo.py
+++ b/src/datasight/demo_dsgrid_tempo.py
@@ -33,15 +33,13 @@ DATASETS = {
 SCHEMA_DESCRIPTION = """\
 # dsgrid TEMPO — EV Charging Demand Projections
 
-This database contains projected electric vehicle (EV) charging demand from the
-[TEMPO project](https://github.com/dsgrid/dsgrid-project-StandardScenarios/blob/main/tempo_project/README.md),
-part of NLR's [dsgrid](https://www.nrel.gov/analysis/dsgrid.html) framework.
-The data covers 2024–2050 and models hourly county-level charging load for
-light-duty passenger EVs across the contiguous United States.
+Three DuckDB tables derived from the dsgrid TEMPO project's OEDI
+publications. All energy values are in **MWh** (measured at the electrical
+meter). See the "Additional project context" section at the bottom for the
+full upstream README with scenarios, vehicle types, dimensions, bounding-case
+assumptions, and timestamp details.
 
-All energy values are in **MWh** (measured at the electrical meter).
-
-## Tables
+## Tables in this database
 
 ### charging_profiles
 Hourly EV charging demand aggregated to **census division** level.
@@ -49,10 +47,10 @@ One row per scenario × model year × census division × hour.
 
 | Column | Description |
 |--------|-------------|
-| scenario | Adoption scenario (see below) |
+| scenario | Adoption scenario — column values: `reference`, `efs_high_ldv`, `ldv_sales_evs_2035` |
 | time_est | Hourly timestamp (EST, 2012 meteorological year) |
 | five_year_intervals | Model year (2025, 2030, 2035, 2040, 2045, 2050) |
-| census_division | US Census division (e.g. pacific, mountain, south_atlantic) |
+| census_division | One of: east_north_central, east_south_central, middle_atlantic, mountain, new_england, pacific, south_atlantic, west_north_central, west_south_central |
 | value | Charging demand in MWh |
 
 ### annual_state
@@ -61,11 +59,11 @@ One row per scenario × model year × state × subsector.
 
 | Column | Description |
 |--------|-------------|
-| scenario | Adoption scenario |
+| scenario | Adoption scenario (same values as above) |
 | year | Weather year (2012) |
 | tempo_project_model_years | Projection year (biennial 2024–2050) |
 | state | Two-letter state code |
-| subsector | Vehicle type (see below) |
+| subsector | Vehicle type — one of: `bev_compact`, `bev_midsize`, `bev_suv`, `bev_pickup`, `phev_compact`, `phev_midsize`, `phev_suv`, `phev_pickup` |
 | value | Annual charging demand in MWh |
 
 ### annual_county
@@ -77,43 +75,9 @@ One row per scenario × model year × county × subsector.
 | scenario | Adoption scenario |
 | year | Weather year (2012) |
 | five_year_intervals | Model year (5-year intervals, 2025–2050) |
-| county | FIPS county code (e.g. 06037 = Los Angeles County, CA) |
-| subsector | Vehicle type |
+| county | FIPS county code (e.g. `06037` = Los Angeles County, CA) |
+| subsector | Vehicle type (same values as annual_state) |
 | value | Annual charging demand in MWh |
-
-## Scenarios
-
-Three EV adoption scenarios model different market trajectories:
-
-- **reference** — AEO Reference Case: baseline EV adoption following current trends
-- **efs_high_ldv** — EFS High Electrification: aggressive electrification of light-duty vehicles
-- **ldv_sales_evs_2035** — All EV Sales by 2035: all new light-duty vehicle sales are electric by 2035
-
-## Vehicle Types (subsector)
-
-Eight categories combining drivetrain and body style:
-
-- **bev_compact**, **bev_midsize**, **bev_suv**, **bev_pickup** — Battery electric vehicles
-- **phev_compact**, **phev_midsize**, **phev_suv**, **phev_pickup** — Plug-in hybrid electric vehicles
-
-## Census Divisions
-
-Nine US Census divisions in charging_profiles:
-east_north_central, east_south_central, middle_atlantic, mountain,
-new_england, pacific, south_atlantic, west_north_central, west_south_central.
-
-## Key Assumptions
-
-The charging profiles assume **ubiquitous charger access** (drivers can charge
-whenever not driving) and **immediate charging** (vehicles plug in right after
-trips). This represents a bounding case that maximizes vehicle state of charge.
-
-## Timestamps
-
-- Timestamps use 2012 actual meteorological year weather data
-- The time_est column is in EST (Eastern Standard Time)
-- Leap day is included (8,784 hours per year)
-- Daylight savings adjustments are incorporated
 
 ## Query defaults
 
@@ -149,6 +113,14 @@ trips). This represents a bounding case that maximizes vehicle state of charge.
 - Compare scenarios to see how adoption assumptions affect projected demand
 - BEV vs PHEV split shows the drivetrain mix impact on grid load
 - This is a DuckDB database — use DuckDB SQL syntax
+
+## Additional project context
+
+Upstream project README (dsgrid dimensions, OEDI publication details,
+scenario descriptions, bounding-case charging assumptions, weather year,
+timestamp conventions):
+
+[include:dsgrid TEMPO project README](https://raw.githubusercontent.com/dsgrid/dsgrid-project-StandardScenarios/main/tempo_project/README.md)
 """
 
 EXAMPLE_QUERIES = """\

--- a/src/datasight/llm.py
+++ b/src/datasight/llm.py
@@ -46,6 +46,55 @@ DEFAULT_MAX_ATTEMPTS: int = 3
 DEFAULT_RETRY_BASE_DELAY: float = 1.0  # seconds, doubled each retry
 
 
+# Phrases and error codes each provider uses for "your prompt blew through the
+# context window." Matched case-insensitively against the raw error message.
+# Conservative on purpose: false positives would point users at
+# SCHEMA_INCLUDE_MAX_BYTES when that isn't the actual problem.
+_CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
+    "context length",
+    "context_length",
+    "context_length_exceeded",
+    "maximum context",
+    "prompt is too long",
+    "too many tokens",
+    "exceeded tokens",
+    "token limit",
+    "tokens_limit",
+    "tokens_limit_reached",
+    "request too large",
+    "request body too large",
+    "input is too long",
+)
+
+# Tail added to ``LLMResponseError`` when the provider's 4xx looks like a
+# context-window overflow. Points at the usual culprit (schema includes) and
+# the escape hatches (disable the resolver, switch to a larger-context
+# backend).
+_CONTEXT_OVERFLOW_HINT: str = (
+    "\n\nThis looks like a context-window overflow. If your schema_description.md uses "
+    "[include:Title](url) directives, the fetched pages may be pushing the prompt past "
+    "this model's token limit. Options:\n"
+    "  - Set SCHEMA_INCLUDE_MAX_BYTES=0 to skip include-link resolution entirely.\n"
+    "  - Lower SCHEMA_INCLUDE_MAX_BYTES to a smaller per-URL cap.\n"
+    "  - Switch to a larger-context backend (e.g. LLM_PROVIDER=anthropic)."
+)
+
+
+def _is_context_overflow_error(message: str) -> bool:
+    """Return True if the provider error message smells like a context overflow."""
+    if not message:
+        return False
+    lowered = message.lower()
+    return any(pattern in lowered for pattern in _CONTEXT_OVERFLOW_PATTERNS)
+
+
+def _augment_if_context_overflow(message: str) -> str:
+    """Append the context-overflow hint to ``message`` when the pattern matches."""
+    if _is_context_overflow_error(message):
+        return message + _CONTEXT_OVERFLOW_HINT
+    return message
+
+
 # ---------------------------------------------------------------------------
 # Common types
 # ---------------------------------------------------------------------------
@@ -297,7 +346,9 @@ class AnthropicLLMClient:
                 await asyncio.sleep(delay)
             except anthropic.APIStatusError as e:
                 logger.exception("Anthropic API error")
-                raise LLMResponseError(f"Anthropic API error: {e}") from e
+                raise LLMResponseError(
+                    _augment_if_context_overflow(f"Anthropic API error: {e}")
+                ) from e
 
         if response is None:
             raise LLMResponseError(
@@ -612,7 +663,7 @@ class _OpenAICompatibleClient:
                 await asyncio.sleep(delay)
             except oa.APIStatusError as e:
                 logger.exception("OpenAI-compatible API error")
-                raise LLMResponseError(f"API error: {e}") from e
+                raise LLMResponseError(_augment_if_context_overflow(f"API error: {e}")) from e
 
         if response is None:
             raise LLMResponseError(

--- a/src/datasight/schema_links.py
+++ b/src/datasight/schema_links.py
@@ -14,11 +14,14 @@ project developer can spot the bad URL.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import os
 import re
+import socket
 from dataclasses import dataclass
 from html.parser import HTMLParser
 from typing import Awaitable, Callable, overload
+from urllib.parse import urlparse
 
 from loguru import logger
 
@@ -34,6 +37,17 @@ DEFAULT_MAX_BYTES: int = 20_000
 # restores it cleanly.
 _MAX_BYTES_ENV_VAR: str = "SCHEMA_INCLUDE_MAX_BYTES"
 
+# Opt-in env var that disables the SSRF guard so internal documentation
+# servers (private IPs, ``.internal`` hostnames) become fetchable again.
+# Also registered in ``datasight.settings._PROJECT_ENV_VARS``.
+_ALLOW_PRIVATE_HOSTS_ENV_VAR: str = "SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS"
+
+# Hard ceiling on bytes pulled over the wire per URL, expressed as a
+# multiple of ``max_bytes``. HTML strips to ~1/3 of its raw size typically,
+# so 4x gives enough raw bytes to produce ``max_bytes`` of text without
+# letting a hostile server stream megabytes into memory.
+_DOWNLOAD_OVERSAMPLE: int = 4
+
 # Per-fetch timeout. Project load is not latency-critical, so we can afford
 # to wait longer than the LLM call timeout.
 DEFAULT_FETCH_TIMEOUT: float = 10.0
@@ -42,6 +56,16 @@ _ALLOWED_CONTENT_PREFIXES: tuple[str, ...] = (
     "text/",
     "application/json",
     "application/xhtml",
+)
+
+# Hostnames that must never be resolved — catches the common footgun cases
+# without requiring a DNS lookup.
+_BLOCKED_LITERAL_HOSTNAMES: frozenset[str] = frozenset({"localhost", "ip6-localhost"})
+_BLOCKED_HOSTNAME_SUFFIXES: tuple[str, ...] = (
+    ".local",
+    ".localhost",
+    ".internal",
+    ".localdomain",
 )
 
 # ``[include:Title](url)`` — title is everything after the colon up to the
@@ -115,21 +139,113 @@ def _truncate(text: str, max_bytes: int) -> str:
     return clipped + "\n\n…[content truncated]"
 
 
+def _allow_private_hosts() -> bool:
+    """Opt-out switch for the SSRF guard. Defaults to False."""
+    return os.environ.get(_ALLOW_PRIVATE_HOSTS_ENV_VAR, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _is_disallowed_ip(address: str) -> bool:
+    """Return True for loopback / private / link-local / reserved IPs."""
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+async def _validate_url_safety(url: str) -> None:
+    """Raise ``ValueError`` if ``url`` should not be fetched.
+
+    Mitigates SSRF via a malicious ``schema_description.md`` that points at
+    internal services (loopback, private IP ranges, link-local, reserved).
+    Note: we only validate the supplied URL; redirects are disabled in the
+    fetcher so we don't need to re-validate intermediate hops. DNS rebinding
+    is NOT defended against here — a full mitigation would require resolving
+    ourselves and pinning the connection to the vetted IP. Set
+    ``SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS=1`` to bypass for internal doc
+    servers you trust.
+    """
+    if _allow_private_hosts():
+        return
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"unsupported url scheme {parsed.scheme!r}")
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        raise ValueError("url has no hostname")
+    if hostname in _BLOCKED_LITERAL_HOSTNAMES:
+        raise ValueError(f"hostname {hostname!r} is blocked")
+    if any(hostname.endswith(suffix) for suffix in _BLOCKED_HOSTNAME_SUFFIXES):
+        raise ValueError(f"hostname {hostname!r} is blocked")
+    if _is_disallowed_ip(hostname):
+        raise ValueError(f"hostname {hostname!r} resolves to a disallowed address")
+
+    # Resolve and reject any A/AAAA that points into a private range.
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise ValueError(f"failed to resolve {hostname!r}: {e}") from e
+    for _family, _type, _proto, _canon, sockaddr in infos:
+        addr = sockaddr[0]
+        if _is_disallowed_ip(addr):
+            raise ValueError(f"{hostname!r} resolves to disallowed address {addr!r}")
+
+
 async def _default_fetch(url: str, *, timeout: float, max_bytes: int) -> str:
-    """Fetch ``url`` and return plain text. Raises on failure."""
+    """Fetch ``url`` and return plain text. Raises on failure.
+
+    The body is streamed in and capped at ``max_bytes * _DOWNLOAD_OVERSAMPLE``
+    raw bytes so a hostile server can't blow up project-load memory even
+    when the declared ``Content-Length`` lies. HTML pages are then stripped
+    to text before a final truncation to ``max_bytes`` of output.
+    """
     import httpx
 
+    await _validate_url_safety(url)
+
+    download_cap = max_bytes * _DOWNLOAD_OVERSAMPLE
+    # ``follow_redirects=False`` — a redirect target could bypass the SSRF
+    # validation above (e.g. a public URL that 302s into 127.0.0.1). We'd
+    # rather surface a clear error than silently chase the Location header.
     async with httpx.AsyncClient(
         timeout=timeout,
-        follow_redirects=True,
+        follow_redirects=False,
         headers={"User-Agent": "datasight schema-link resolver"},
     ) as client:
-        response = await client.get(url)
-        response.raise_for_status()
-        content_type = response.headers.get("content-type", "").lower().split(";", 1)[0].strip()
-        if not any(content_type.startswith(p) for p in _ALLOWED_CONTENT_PREFIXES):
-            raise ValueError(f"unsupported content-type {content_type!r}")
-        body = response.text
+        async with client.stream("GET", url) as response:
+            if 300 <= response.status_code < 400:
+                location = response.headers.get("location", "")
+                raise ValueError(
+                    f"redirect ({response.status_code}) to {location!r} is not followed; "
+                    "use the final URL directly"
+                )
+            response.raise_for_status()
+            content_type = (
+                response.headers.get("content-type", "").lower().split(";", 1)[0].strip()
+            )
+            if not any(content_type.startswith(p) for p in _ALLOWED_CONTENT_PREFIXES):
+                raise ValueError(f"unsupported content-type {content_type!r}")
+
+            buffer = bytearray()
+            async for chunk in response.aiter_bytes():
+                buffer.extend(chunk)
+                if len(buffer) >= download_cap:
+                    break
+
+    body = bytes(buffer).decode("utf-8", errors="replace")
     if content_type.startswith("text/html") or content_type.startswith("application/xhtml"):
         body = _html_to_text(body)
     return _truncate(body, max_bytes)
@@ -173,7 +289,8 @@ async def resolve_schema_description_links(
     fetcher: Fetcher | None = ...,
     max_bytes: int | None = ...,
     timeout: float = ...,
-) -> str: ...
+) -> str:
+    pass
 
 
 @overload
@@ -183,7 +300,8 @@ async def resolve_schema_description_links(
     fetcher: Fetcher | None = ...,
     max_bytes: int | None = ...,
     timeout: float = ...,
-) -> None: ...
+) -> None:
+    pass
 
 
 async def resolve_schema_description_links(

--- a/src/datasight/schema_links.py
+++ b/src/datasight/schema_links.py
@@ -1,0 +1,258 @@
+"""
+Resolve ``[include:Title](url)`` directives in ``schema_description.md``.
+
+Project developers can sprinkle include directives in the schema
+description to pull external documentation (API references, fuel-code
+glossaries, etc.) into the LLM system prompt without copying static text
+into the markdown file. Each URL is fetched once at project-load time,
+HTML is stripped to plain text, the body is size-capped, and the directive
+is replaced in place. On fetch failure the original ``[include:...](url)``
+markdown link is preserved so the LLM still sees the pointer and the
+project developer can spot the bad URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Awaitable, Callable, overload
+
+from loguru import logger
+
+# Default per-URL size cap. Picked so a handful of includes stays comfortable
+# for small-context local models (e.g. qwen2.5:7b at ~32K tokens) without
+# forcing hosted models to leave most of their window unused. Users on
+# long-context backends who want the whole fetched page can override via
+# the ``SCHEMA_INCLUDE_MAX_BYTES`` env var — see ``_resolve_max_bytes``.
+DEFAULT_MAX_BYTES: int = 20_000
+
+# Env var consulted when the caller doesn't pass ``max_bytes`` explicitly.
+# Registered in ``datasight.settings._PROJECT_ENV_VARS`` so project-switching
+# restores it cleanly.
+_MAX_BYTES_ENV_VAR: str = "SCHEMA_INCLUDE_MAX_BYTES"
+
+# Per-fetch timeout. Project load is not latency-critical, so we can afford
+# to wait longer than the LLM call timeout.
+DEFAULT_FETCH_TIMEOUT: float = 10.0
+
+_ALLOWED_CONTENT_PREFIXES: tuple[str, ...] = (
+    "text/",
+    "application/json",
+    "application/xhtml",
+)
+
+# ``[include:Title](url)`` — title is everything after the colon up to the
+# closing bracket (single line only), url is a plain http(s) URL.
+_INCLUDE_RE = re.compile(
+    r"\[include:([^\]\n]+)\]\((https?://[^\s)]+)\)",
+)
+
+
+Fetcher = Callable[[str], Awaitable[str]]
+
+
+@dataclass(frozen=True)
+class _Match:
+    title: str
+    url: str
+    start: int
+    end: int
+
+
+class _TextExtractor(HTMLParser):
+    """Collect text content from HTML, skipping script/style tags."""
+
+    _SKIP_TAGS = frozenset({"script", "style", "noscript", "template"})
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in self._SKIP_TAGS and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth == 0:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        raw = "".join(self._parts)
+        lines = [re.sub(r"[ \t]+", " ", line).strip() for line in raw.splitlines()]
+        out: list[str] = []
+        blank = False
+        for line in lines:
+            if not line:
+                if not blank and out:
+                    out.append("")
+                blank = True
+            else:
+                out.append(line)
+                blank = False
+        return "\n".join(out).strip()
+
+
+def _html_to_text(html: str) -> str:
+    """Strip HTML tags and collapse whitespace to a readable plain-text block."""
+    parser = _TextExtractor()
+    parser.feed(html)
+    return parser.get_text()
+
+
+def _truncate(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    clipped = encoded[:max_bytes].decode("utf-8", errors="ignore").rstrip()
+    return clipped + "\n\n…[content truncated]"
+
+
+async def _default_fetch(url: str, *, timeout: float, max_bytes: int) -> str:
+    """Fetch ``url`` and return plain text. Raises on failure."""
+    import httpx
+
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=True,
+        headers={"User-Agent": "datasight schema-link resolver"},
+    ) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        content_type = response.headers.get("content-type", "").lower().split(";", 1)[0].strip()
+        if not any(content_type.startswith(p) for p in _ALLOWED_CONTENT_PREFIXES):
+            raise ValueError(f"unsupported content-type {content_type!r}")
+        body = response.text
+    if content_type.startswith("text/html") or content_type.startswith("application/xhtml"):
+        body = _html_to_text(body)
+    return _truncate(body, max_bytes)
+
+
+def _format_included(title: str, url: str, body: str) -> str:
+    return f"### Included reference: {title.strip()}\n*Source: <{url}>*\n\n{body}\n"
+
+
+def _resolve_max_bytes() -> int:
+    """Resolve the effective per-URL size cap from the environment.
+
+    Reads ``SCHEMA_INCLUDE_MAX_BYTES`` on each call so tests and project
+    switches see the current value. ``0`` is a sentinel meaning "skip
+    include-link resolution entirely" — useful when the fetched content
+    is pushing the prompt past a small-context model's window. Invalid
+    or negative values fall back to ``DEFAULT_MAX_BYTES`` with a warning.
+    """
+    raw = os.environ.get(_MAX_BYTES_ENV_VAR, "").strip()
+    if not raw:
+        return DEFAULT_MAX_BYTES
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(
+            f"{_MAX_BYTES_ENV_VAR}={raw!r} is not an integer; falling back to {DEFAULT_MAX_BYTES}"
+        )
+        return DEFAULT_MAX_BYTES
+    if parsed < 0:
+        logger.warning(
+            f"{_MAX_BYTES_ENV_VAR}={parsed} must be >= 0; falling back to {DEFAULT_MAX_BYTES}"
+        )
+        return DEFAULT_MAX_BYTES
+    return parsed
+
+
+@overload
+async def resolve_schema_description_links(
+    markdown: str,
+    *,
+    fetcher: Fetcher | None = ...,
+    max_bytes: int | None = ...,
+    timeout: float = ...,
+) -> str: ...
+
+
+@overload
+async def resolve_schema_description_links(
+    markdown: None,
+    *,
+    fetcher: Fetcher | None = ...,
+    max_bytes: int | None = ...,
+    timeout: float = ...,
+) -> None: ...
+
+
+async def resolve_schema_description_links(
+    markdown: str | None,
+    *,
+    fetcher: Fetcher | None = None,
+    max_bytes: int | None = None,
+    timeout: float = DEFAULT_FETCH_TIMEOUT,
+) -> str | None:
+    """Expand ``[include:Title](url)`` directives.
+
+    ``None`` and link-free markdown pass through unchanged so callers can
+    thread this after ``load_schema_description`` without extra guards.
+
+    Each unique URL is fetched once. On failure, the original directive is
+    preserved in the output.
+
+    A custom ``fetcher`` is responsible for its own HTML stripping and
+    size-capping; ``max_bytes`` / ``timeout`` only affect the default
+    fetcher. When ``max_bytes`` is ``None`` (the default), the cap is read
+    from ``SCHEMA_INCLUDE_MAX_BYTES`` and falls back to
+    ``DEFAULT_MAX_BYTES``. ``max_bytes == 0`` disables resolution — the
+    markdown is returned unchanged, leaving ``[include:...](url)``
+    directives visible to the LLM as plain markdown links.
+    """
+    if max_bytes is None:
+        max_bytes = _resolve_max_bytes()
+    if markdown is None:
+        return None
+    if max_bytes == 0:
+        return markdown
+
+    matches = [
+        _Match(title=m.group(1), url=m.group(2), start=m.start(), end=m.end())
+        for m in _INCLUDE_RE.finditer(markdown)
+    ]
+    if not matches:
+        return markdown
+
+    unique_urls = list({m.url for m in matches})
+
+    async def _run_fetch(url: str) -> tuple[str, str | None, Exception | None]:
+        try:
+            if fetcher is None:
+                body = await _default_fetch(url, timeout=timeout, max_bytes=max_bytes)
+            else:
+                body = await fetcher(url)
+            return url, body, None
+        except Exception as e:  # noqa: BLE001 — summarized to warning below
+            return url, None, e
+
+    results = await asyncio.gather(*(_run_fetch(u) for u in unique_urls))
+    url_to_body: dict[str, str | None] = {}
+    for url, body, err in results:
+        if err is not None:
+            logger.warning(f"schema include fetch failed for {url}: {err}")
+            url_to_body[url] = None
+        else:
+            url_to_body[url] = body
+
+    out: list[str] = []
+    cursor = 0
+    for m in matches:
+        out.append(markdown[cursor : m.start])
+        body = url_to_body.get(m.url)
+        if body is None:
+            out.append(markdown[m.start : m.end])
+        else:
+            out.append(_format_included(m.title, m.url, body))
+        cursor = m.end
+    out.append(markdown[cursor:])
+    return "".join(out)

--- a/src/datasight/settings.py
+++ b/src/datasight/settings.py
@@ -101,6 +101,7 @@ _PROJECT_ENV_VARS = [
     "EXAMPLE_QUERIES_PATH",
     # Schema include-link resolver
     "SCHEMA_INCLUDE_MAX_BYTES",
+    "SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS",
 ]
 
 # Captured after root .env is loaded - the baseline environment that projects

--- a/src/datasight/settings.py
+++ b/src/datasight/settings.py
@@ -99,6 +99,8 @@ _PROJECT_ENV_VARS = [
     # Project-specific file paths
     "SCHEMA_DESCRIPTION_PATH",
     "EXAMPLE_QUERIES_PATH",
+    # Schema include-link resolver
+    "SCHEMA_INCLUDE_MAX_BYTES",
 ]
 
 # Captured after root .env is loaded - the baseline environment that projects

--- a/src/datasight/templates/env.template
+++ b/src/datasight/templates/env.template
@@ -78,6 +78,12 @@ DB_PATH=./my_database.duckdb
 # small-context model's token limit.
 # SCHEMA_INCLUDE_MAX_BYTES=20000
 
+# SSRF guard for [include:Title](url) directives. By default URLs pointing
+# at localhost, private IP ranges, or .internal/.local hostnames are
+# blocked. Set to 1 to fetch from internal documentation servers on
+# purpose.
+# SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS=0
+
 # Web UI port (default: 8084)
 # PORT=8084
 

--- a/src/datasight/templates/env.template
+++ b/src/datasight/templates/env.template
@@ -71,6 +71,13 @@ DB_PATH=./my_database.duckdb
 # SCHEMA_DESCRIPTION_PATH=./schema_description.md
 # EXAMPLE_QUERIES_PATH=./queries.yaml
 
+# Per-URL size cap (bytes) for [include:Title](url) directives inside
+# schema_description.md. Default is 20000 — tuned for small-context local
+# models. Bump on long-context hosted backends. Set to 0 to disable the
+# resolver entirely — useful when included pages push the prompt past a
+# small-context model's token limit.
+# SCHEMA_INCLUDE_MAX_BYTES=20000
+
 # Web UI port (default: 8084)
 # PORT=8084
 

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -83,6 +83,7 @@ from datasight.generate import (
 )
 from datasight.runner import CachingSqlRunner, SqlRunner
 from datasight.schema import filter_tables, format_schema_context, introspect_schema
+from datasight.schema_links import resolve_schema_description_links
 from datasight.settings import (
     Settings,
     capture_original_env,
@@ -981,6 +982,7 @@ async def load_project(project_dir: str, state: AppState) -> dict[str, Any]:
 
     # Load schema and introspect database
     user_desc = load_schema_description(os.environ.get("SCHEMA_DESCRIPTION_PATH"), project_dir)
+    user_desc = await resolve_schema_description_links(user_desc)
 
     schema_config = load_schema_config(None, project_dir)
     allowed_tables: set[str] | None = None

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,8 +19,10 @@ from datasight.llm import (
     TextBlock,
     ToolUseBlock,
     Usage,
+    _augment_if_context_overflow,
     _convert_messages_to_openai,
     _convert_tools_to_openai,
+    _is_context_overflow_error,
     create_llm_client,
     serialize_content,
 )
@@ -56,6 +58,61 @@ def test_serialize_content_tool_use():
 
 def test_serialize_content_empty():
     assert serialize_content([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Context-overflow detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "This model's maximum context length is 8192 tokens.",
+        "error code: context_length_exceeded",
+        "prompt is too long: 250000 tokens > 200000 maximum",
+        "Request failed: too many tokens in the request",
+        "exceeded tokens budget for this tier",
+        "Input token limit exceeded",
+        "Request too large for this model",
+        "Anthropic API error: input is too long for model",
+        "400 Bad Request: maximum context exceeded",
+        # Observed GitHub Models 413 response — error code + phrase.
+        (
+            "Error code: 413 - {'error': {'code': 'tokens_limit_reached', "
+            "'message': 'Request body too large for gpt-4o model. Max size: 8000 tokens.'}}"
+        ),
+    ],
+)
+def test_is_context_overflow_error_matches(message: str):
+    assert _is_context_overflow_error(message) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "rate limit exceeded",
+        "authentication failed",
+        "internal server error",
+        "connection timed out",
+        "model not found",
+    ],
+)
+def test_is_context_overflow_error_non_matches(message: str):
+    assert _is_context_overflow_error(message) is False
+
+
+def test_augment_if_context_overflow_appends_hint_when_match():
+    augmented = _augment_if_context_overflow("prompt is too long: 300000 tokens")
+    assert "SCHEMA_INCLUDE_MAX_BYTES=0" in augmented
+    assert "context-window overflow" in augmented
+    assert augmented.startswith("prompt is too long")
+
+
+def test_augment_if_context_overflow_passthrough_when_no_match():
+    msg = "authentication failed — check your API key"
+    assert _augment_if_context_overflow(msg) == msg
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +378,31 @@ async def test_anthropic_client_api_status_error():
             )
 
 
+@pytest.mark.asyncio
+async def test_anthropic_context_overflow_error_adds_hint():
+    with patch("datasight.llm.anthropic.AsyncAnthropic") as mock_cls:
+        instance = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.headers = {}
+        instance.messages.create = AsyncMock(
+            side_effect=anthropic.APIStatusError(
+                "prompt is too long: 250000 tokens > 200000 maximum",
+                response=mock_resp,
+                body=None,
+            )
+        )
+        mock_cls.return_value = instance
+
+        client = AnthropicLLMClient(api_key="sk-test")
+        with pytest.raises(LLMResponseError) as excinfo:
+            await client.create_message(
+                model="claude", system="sys", messages=[], tools=[], max_tokens=100
+            )
+        assert "SCHEMA_INCLUDE_MAX_BYTES=0" in str(excinfo.value)
+        assert "context-window overflow" in str(excinfo.value)
+
+
 def test_create_llm_client_missing_api_key_raises_configuration_error():
     """Factory short-circuits with a clear error when a required key is missing."""
     from datasight.exceptions import ConfigurationError
@@ -507,6 +589,30 @@ async def test_openai_compat_non_transient_error_fails_immediately():
             await client.create_message(
                 model="m", system="sys", messages=[], tools=[], max_tokens=50
             )
+        assert instance.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_context_overflow_error_adds_hint():
+    fake_module = _fake_openai_module()
+    instance = MagicMock()
+    instance.chat.completions.create = AsyncMock(
+        side_effect=_openai_status_error(
+            "This model's maximum context length is 8192 tokens. However, your "
+            "messages resulted in 12345 tokens."
+        )
+    )
+    fake_module.AsyncOpenAI = MagicMock(return_value=instance)
+
+    with patch.dict("sys.modules", {"openai": fake_module}):
+        client = GitHubModelsLLMClient(api_key="ghp_test")
+        with pytest.raises(LLMResponseError) as excinfo:
+            await client.create_message(
+                model="gpt-4o", system="sys", messages=[], tools=[], max_tokens=50
+            )
+        assert "SCHEMA_INCLUDE_MAX_BYTES=0" in str(excinfo.value)
+        assert "context-window overflow" in str(excinfo.value)
+        # Should still fail immediately; overflow is a 4xx, not transient.
         assert instance.chat.completions.create.await_count == 1
 
 

--- a/tests/test_schema_links.py
+++ b/tests/test_schema_links.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import socket
 from collections.abc import Awaitable, Callable
+
+import pytest
 
 from datasight.schema_links import (
     DEFAULT_MAX_BYTES,
+    _default_fetch,
     _html_to_text,
+    _is_disallowed_ip,
     _resolve_max_bytes,
     _truncate,
+    _validate_url_safety,
     resolve_schema_description_links,
 )
 
@@ -153,3 +159,188 @@ async def test_max_bytes_zero_skips_resolution():
 
     result = await resolve_schema_description_links(md, fetcher=_fetch, max_bytes=0)
     assert result == md
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "192.168.1.1",
+        "172.16.0.5",
+        "169.254.169.254",  # AWS/GCP metadata service
+        "::1",
+        "fe80::1",
+        "0.0.0.0",
+    ],
+)
+def test_is_disallowed_ip_blocks_internal_ranges(address: str):
+    assert _is_disallowed_ip(address) is True
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["1.1.1.1", "8.8.8.8", "2001:4860:4860::8888"],
+)
+def test_is_disallowed_ip_allows_public_addresses(address: str):
+    assert _is_disallowed_ip(address) is False
+
+
+async def test_validate_url_safety_rejects_localhost(monkeypatch):
+    monkeypatch.delenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", raising=False)
+    with pytest.raises(ValueError, match="blocked"):
+        await _validate_url_safety("http://localhost:8080/internal")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://foo.local/docs",
+        "http://bar.internal/schema",
+        "http://service.localdomain/x",
+    ],
+)
+async def test_validate_url_safety_rejects_blocked_suffixes(monkeypatch, url):
+    monkeypatch.delenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", raising=False)
+    with pytest.raises(ValueError, match="blocked"):
+        await _validate_url_safety(url)
+
+
+async def test_validate_url_safety_rejects_ip_literal_in_private_range(monkeypatch):
+    monkeypatch.delenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", raising=False)
+    with pytest.raises(ValueError, match="disallowed"):
+        await _validate_url_safety("http://10.0.0.1/secret")
+
+
+async def test_validate_url_safety_rejects_non_http_scheme(monkeypatch):
+    monkeypatch.delenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", raising=False)
+    with pytest.raises(ValueError, match="scheme"):
+        await _validate_url_safety("file:///etc/passwd")
+
+
+async def test_validate_url_safety_rejects_private_dns_resolution(monkeypatch):
+    """Hostname that resolves into a private range is blocked."""
+    monkeypatch.delenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", raising=False)
+
+    async def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 0))]
+
+    import asyncio
+
+    monkeypatch.setattr(
+        asyncio.get_event_loop_policy().get_event_loop().__class__,
+        "getaddrinfo",
+        _fake_getaddrinfo,
+    )
+    with pytest.raises(ValueError, match="disallowed address"):
+        await _validate_url_safety("http://rebind.example.com/x")
+
+
+async def test_validate_url_safety_allows_public_host_with_mocked_dns(monkeypatch):
+    monkeypatch.delenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", raising=False)
+
+    async def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.1.1.1", 0))]
+
+    import asyncio
+
+    monkeypatch.setattr(
+        asyncio.get_event_loop_policy().get_event_loop().__class__,
+        "getaddrinfo",
+        _fake_getaddrinfo,
+    )
+    # Should return without raising.
+    await _validate_url_safety("https://example.com/docs")
+
+
+async def test_validate_url_safety_opt_out_skips_all_checks(monkeypatch):
+    monkeypatch.setenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", "1")
+    # localhost would normally be rejected; opt-out bypasses the guard.
+    await _validate_url_safety("http://localhost:8080/docs")
+
+
+# ---------------------------------------------------------------------------
+# Streaming fetch cap
+# ---------------------------------------------------------------------------
+
+
+async def test_default_fetch_caps_oversized_stream(monkeypatch):
+    """A body larger than max_bytes * oversample is truncated during streaming."""
+    import httpx
+
+    monkeypatch.setenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", "1")  # skip DNS
+
+    # Serve 1 MB of text — much larger than 1 KB max_bytes * 4 oversample = 4 KB.
+    big_body = b"A" * 1_000_000
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/plain"},
+            content=big_body,
+        )
+
+    transport = httpx.MockTransport(_handler)
+    real_client_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client_cls(*args, **kwargs)
+
+    monkeypatch.setattr("httpx.AsyncClient", _factory)
+
+    result = await _default_fetch("https://example.com/big.txt", timeout=5.0, max_bytes=1_000)
+    # Result should be truncated to max_bytes of text plus the truncation marker.
+    assert "truncated" in result
+    assert len(result.encode("utf-8")) < 2_000  # well under the raw body size
+
+
+async def test_default_fetch_rejects_redirect(monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", "1")
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "https://example.com/final"})
+
+    transport = httpx.MockTransport(_handler)
+    real_client_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client_cls(*args, **kwargs)
+
+    monkeypatch.setattr("httpx.AsyncClient", _factory)
+
+    with pytest.raises(ValueError, match="redirect"):
+        await _default_fetch("https://example.com/start", timeout=5.0, max_bytes=1_000)
+
+
+async def test_default_fetch_rejects_unsupported_content_type(monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("SCHEMA_INCLUDE_ALLOW_PRIVATE_HOSTS", "1")
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/pdf"},
+            content=b"%PDF-1.4 fake",
+        )
+
+    transport = httpx.MockTransport(_handler)
+    real_client_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client_cls(*args, **kwargs)
+
+    monkeypatch.setattr("httpx.AsyncClient", _factory)
+
+    with pytest.raises(ValueError, match="content-type"):
+        await _default_fetch("https://example.com/doc.pdf", timeout=5.0, max_bytes=1_000)

--- a/tests/test_schema_links.py
+++ b/tests/test_schema_links.py
@@ -1,0 +1,155 @@
+"""Tests for the schema_description.md include-directive resolver."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from datasight.schema_links import (
+    DEFAULT_MAX_BYTES,
+    _html_to_text,
+    _resolve_max_bytes,
+    _truncate,
+    resolve_schema_description_links,
+)
+
+
+def _stub_fetcher(mapping: dict[str, str]) -> Callable[[str], Awaitable[str]]:
+    async def _fetch(url: str) -> str:
+        if url not in mapping:
+            raise RuntimeError(f"no stub for {url}")
+        return mapping[url]
+
+    return _fetch
+
+
+async def test_none_passthrough():
+    assert await resolve_schema_description_links(None, fetcher=_stub_fetcher({})) is None
+
+
+async def test_no_directives_noop():
+    md = "# Schema\n\nA plain description with no include directives.\n"
+    result = await resolve_schema_description_links(md, fetcher=_stub_fetcher({}))
+    assert result == md
+
+
+async def test_single_directive_is_replaced():
+    md = "See [include:Fuel codes](https://example.com/fuel) for details."
+    fetch = _stub_fetcher({"https://example.com/fuel": "NG = natural gas\nSUN = solar"})
+    result = await resolve_schema_description_links(md, fetcher=fetch)
+    assert "[include:Fuel codes]" not in result
+    assert "Included reference: Fuel codes" in result
+    assert "NG = natural gas" in result
+    assert "https://example.com/fuel" in result
+
+
+async def test_multiple_directives_both_expand():
+    md = "A [include:One](https://a.example) and [include:Two](https://b.example)."
+    fetch = _stub_fetcher({"https://a.example": "content A", "https://b.example": "content B"})
+    result = await resolve_schema_description_links(md, fetcher=fetch)
+    assert "content A" in result
+    assert "content B" in result
+    assert result.count("Included reference") == 2
+
+
+async def test_duplicate_url_fetched_once():
+    md = "[include:X](https://same.example) then [include:Y](https://same.example)"
+    calls = {"count": 0}
+
+    async def _fetch(url: str) -> str:
+        calls["count"] += 1
+        return "shared body"
+
+    result = await resolve_schema_description_links(md, fetcher=_fetch)
+    assert calls["count"] == 1
+    assert result.count("Included reference") == 2
+
+
+async def test_fetch_failure_preserves_original_directive():
+    md = "Ref: [include:Broken](https://bad.example) end."
+
+    async def _fetch(url: str) -> str:
+        raise RuntimeError("boom")
+
+    result = await resolve_schema_description_links(md, fetcher=_fetch)
+    assert "[include:Broken](https://bad.example)" in result
+    assert "Included reference" not in result
+
+
+async def test_partial_failure_mixes_expanded_and_preserved():
+    md = "Good [include:Good](https://ok.example) and bad [include:Bad](https://fail.example)."
+
+    async def _fetch(url: str) -> str:
+        if "fail" in url:
+            raise RuntimeError("network down")
+        return "good body"
+
+    result = await resolve_schema_description_links(md, fetcher=_fetch)
+    assert "good body" in result
+    assert "[include:Bad](https://fail.example)" in result
+
+
+def test_html_to_text_strips_tags_and_scripts():
+    html = (
+        "<html><body><h1>Title</h1><p>hello <b>world</b></p>"
+        "<script>alert('x')</script><style>.a{color:red}</style></body></html>"
+    )
+    text = _html_to_text(html)
+    assert "Title" in text
+    assert "hello" in text
+    assert "world" in text
+    assert "alert" not in text
+    assert "color:red" not in text
+
+
+def test_html_to_text_collapses_whitespace():
+    html = "<p>  multiple    spaces  </p>\n\n\n<p>second</p>"
+    text = _html_to_text(html)
+    assert "multiple spaces" in text
+    # At most one blank line between blocks.
+    assert "\n\n\n" not in text
+
+
+def test_truncate_preserves_small_text():
+    assert _truncate("short text", 1000) == "short text"
+
+
+def test_truncate_cuts_oversized_text():
+    big = "a" * 5000
+    out = _truncate(big, 1000)
+    assert "truncated" in out
+    assert len(out) < len(big)
+
+
+def test_resolve_max_bytes_unset_uses_default(monkeypatch):
+    monkeypatch.delenv("SCHEMA_INCLUDE_MAX_BYTES", raising=False)
+    assert _resolve_max_bytes() == DEFAULT_MAX_BYTES
+
+
+def test_resolve_max_bytes_reads_env(monkeypatch):
+    monkeypatch.setenv("SCHEMA_INCLUDE_MAX_BYTES", "12345")
+    assert _resolve_max_bytes() == 12345
+
+
+def test_resolve_max_bytes_rejects_invalid(monkeypatch):
+    monkeypatch.setenv("SCHEMA_INCLUDE_MAX_BYTES", "not-a-number")
+    assert _resolve_max_bytes() == DEFAULT_MAX_BYTES
+
+
+def test_resolve_max_bytes_zero_is_disabled_sentinel(monkeypatch):
+    monkeypatch.setenv("SCHEMA_INCLUDE_MAX_BYTES", "0")
+    assert _resolve_max_bytes() == 0
+
+
+def test_resolve_max_bytes_rejects_negative(monkeypatch):
+    monkeypatch.setenv("SCHEMA_INCLUDE_MAX_BYTES", "-5")
+    assert _resolve_max_bytes() == DEFAULT_MAX_BYTES
+
+
+async def test_max_bytes_zero_skips_resolution():
+    md = "See [include:Foo](https://example.com/foo) for details."
+
+    async def _fetch(url: str) -> str:
+        raise AssertionError("fetcher should not run when max_bytes=0")
+
+    result = await resolve_schema_description_links(md, fetcher=_fetch, max_bytes=0)
+    assert result == md

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ toml = [
 
 [[package]]
 name = "datasight"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-flightsql" },
@@ -271,6 +271,7 @@ dependencies = [
     { name = "click" },
     { name = "duckdb" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "loguru" },
     { name = "openai" },
     { name = "pandas" },
@@ -308,6 +309,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0,<9" },
     { name = "duckdb", specifier = ">=1.0,<2" },
     { name = "fastapi", specifier = ">=0.110,<1" },
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "kaleido", marker = "extra == 'export'", specifier = ">=0.2,<1" },
     { name = "loguru", specifier = ">=0.7,<1" },
     { name = "openai", specifier = ">=2,<3" },


### PR DESCRIPTION
## Summary

- Project developers can now reference external documentation from `schema_description.md` with `[include:Title](url)` directives. At project load, each URL is fetched once (HTML → text, size-capped via `SCHEMA_INCLUDE_MAX_BYTES`, default 20 KB) and spliced into the system prompt. Failed fetches leave the original markdown link in place so the pointer still reaches the LLM.
- Setting `SCHEMA_INCLUDE_MAX_BYTES=0` skips resolution entirely — the escape hatch for small-context models where fetched pages push past the token limit.
- LLM errors that look like context-window overflows (matched across Anthropic 400s and OpenAI-compatible 4xx/413 error shapes, including GitHub Models' `tokens_limit_reached` / "Request body too large") carry an actionable hint pointing at `SCHEMA_INCLUDE_MAX_BYTES=0` and suggesting a larger-context backend.
- The dsgrid-tempo demo now references the project README on GitHub via an include directive rather than duplicating that content inline.

## Test plan

- [x] `pytest -m "not integration"` — 1131 passed
- [x] `ruff check`, `ruff format --check`, `ty check` — clean
- [x] New unit coverage in `tests/test_schema_links.py` (17 tests) and `tests/test_llm.py` (context-overflow detection + per-backend augmentation, 20 cases)
- [ ] Manually load the dsgrid-tempo demo against Anthropic and confirm the README content reaches the prompt
- [ ] Manually trigger a GitHub Models 413 and confirm the hint surfaces to the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)