### PR TITLE
Add Apache Spark backend via Spark Connect

### DIFF
--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -1,0 +1,186 @@
+# Connect to an Apache Spark backend
+
+This guide covers configuring datasight to talk to an Apache Spark cluster
+over [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html).
+Use this when your data is too large to fit on a single machine — typically
+multi-terabyte Parquet, Delta, or Iceberg tables managed by Spark.
+
+## When to use this
+
+Reach for the Spark backend when:
+
+- **Your data is on a Spark cluster.** Generation data partitioned across
+  years of `report_date`, plant-level fuel consumption at sub-hourly
+  resolution, or any other multi-TB table set that a single laptop cannot
+  scan.
+- **Someone else runs the cluster.** A data platform team at your
+  organization already operates Spark with Spark Connect enabled — you just
+  need a URI and credentials.
+- **You want aggregations, not row dumps.** datasight's agent is steered
+  (via the system prompt) to always aggregate, always filter on partition
+  columns, and never `SELECT *` on Spark tables. The results come back as
+  small summaries suitable for a chart, not multi-gigabyte exports.
+
+If your data fits on one machine, prefer DuckDB — it will be much faster
+for interactive exploration.
+
+## Overview
+
+Spark Connect decouples the client from the cluster. datasight (the web UI
+and LLM agent) runs on your laptop; the Spark driver and executors run on
+your cluster. Your laptop never materializes more than a bounded slice of
+any result.
+
+```mermaid
+flowchart LR
+    subgraph laptop ["Your laptop"]
+        DS[datasight web UI<br>+ LLM agent]
+    end
+    subgraph cluster ["Spark cluster"]
+        SC[Spark Connect server]
+        DR[Spark driver<br>+ executors]
+        DATA["Parquet / Delta / Iceberg<br>multi-TB tables"]
+        SC --> DR --> DATA
+    end
+    DS <-->|"SQL over<br>gRPC + Arrow"| SC
+
+    style DS fill:#15a8a8,stroke:#023d60,color:#fff
+    style SC fill:#fe5d26,stroke:#c44a1e,color:#fff
+    style DR fill:#2e7ebb,stroke:#1a5c8a,color:#fff
+    style DATA fill:#8a7d55,stroke:#6b6040,color:#fff
+    style laptop fill:#1a8a8a,stroke:#15a8a8,color:#fff
+    style cluster fill:#c44a1e,stroke:#fe5d26,color:#fff
+```
+
+Queries travel as Spark logical plans over gRPC. Results stream back as
+Arrow record batches. datasight stops reading the stream once the
+accumulated result exceeds `SPARK_MAX_RESULT_BYTES` (default 100 MiB) and
+surfaces a truncation warning in the UI and to the LLM.
+
+## Prerequisites
+
+- A Spark cluster running **Spark 3.5 or newer** with the Spark Connect
+  server enabled.
+- The **Spark Connect URI** for that cluster — typically `sc://host:15002`.
+  Ask your data platform team if you don't know it.
+- A **bearer token** if the cluster requires authentication.
+
+!!! tip
+    If you're not sure whether Spark Connect is enabled, ask for the URI.
+    Clusters running Databricks, EMR, or self-managed Spark with the
+    `spark.api.mode=connect` config have a Connect endpoint.
+
+## Step 1: Install the Spark extra
+
+The Spark Connect client isn't bundled by default because it pulls in
+pyspark. Install the extra on your laptop:
+
+```bash
+pip install 'datasight[spark]'
+```
+
+This adds `pyspark[connect]>=3.5` to your environment. No Java is
+required — the Connect client is pure Python and talks to the cluster
+over gRPC.
+
+## Step 2: Configure the connection
+
+In your project's `.env`:
+
+```bash
+# Use any LLM provider (see Getting Started for options)
+ANTHROPIC_API_KEY=sk-ant-...
+
+DB_MODE=spark
+SPARK_REMOTE=sc://spark-connect.example.com:15002
+SPARK_TOKEN=your_bearer_token            # optional, only if the cluster requires auth
+```
+
+### Tuning the byte cap
+
+datasight caps client-side result size to protect your laptop (and, if you
+host the web UI for others, the web server) from OOMing when the agent
+writes a query that returns too much data. The default is 100 MiB on the
+wire, which inflates to roughly 250–500 MiB as a pandas DataFrame.
+
+Raise or lower the cap to match your environment:
+
+```bash
+# Default — safe for most laptops and small web deployments
+SPARK_MAX_RESULT_BYTES=104857600         # 100 MiB
+
+# Lower for memory-constrained environments
+SPARK_MAX_RESULT_BYTES=26214400          # 25 MiB
+
+# Higher if you trust the queries and have the RAM
+SPARK_MAX_RESULT_BYTES=524288000         # 500 MiB
+```
+
+When a result is truncated, the UI shows a banner and the LLM sees a
+partial-result warning in its tool output — so the agent can say "showing
+the first 2M rows; add aggregation for the full answer" instead of
+silently misreporting truncated data.
+
+## Step 3: Describe the schema for multi-TB scale
+
+datasight introspects tables automatically, but for Spark it deliberately
+**skips row counts** — a naive `SELECT COUNT(*)` on a partitioned
+multi-TB table kicks off a full-cluster job every time the project loads.
+
+To help the agent write cheap queries, document your partition columns
+explicitly in `schema_description.md`:
+
+```markdown
+## generation_fuel
+
+Daily net generation and fuel consumption by plant, aggregated from the
+EIA-923 hourly feed. Approximately 4 billion rows.
+
+**Partition columns:** `report_date` (daily), `energy_source_code`.
+Always include a `report_date` filter — e.g. `WHERE report_date >=
+'2024-01-01'` — otherwise the query scans the full history.
+
+**Columns:**
+- `plant_id` (int) — EIA plant identifier
+- `report_date` (date) — partition key
+- `energy_source_code` (varchar) — partition key; 'NG', 'COL', 'NUC', 'WND', etc.
+- `net_generation_mwh` (double) — MWh produced in the period
+- `fuel_consumed_units` (double) — physical units of fuel consumed
+- `fuel_consumed_mmbtu` (double) — heat content consumed
+```
+
+Partition hints in the schema description flow into the system prompt, so
+the agent learns to write `WHERE report_date >= '2024-01-01' AND
+energy_source_code = 'NG'` instead of full-table scans.
+
+## Step 4: Run datasight
+
+```bash
+datasight run
+```
+
+datasight connects to the Spark Connect server via `spark.catalog.listTables()`,
+pulls column metadata for each table, and starts the web UI at
+<http://localhost:8084>. Ask a question and the agent writes Spark SQL
+against your tables.
+
+## Tips
+
+- **Let the agent aggregate.** Questions like "total wind generation by
+  month in 2024" return a tiny result (12 rows) even though the underlying
+  table is terabytes. Questions like "show me every generation record in
+  2024" will hit the byte cap — the agent will be told, and should
+  re-plan as an aggregation.
+- **Document partition columns** explicitly in `schema_description.md`.
+  This is the single highest-leverage thing you can do to make Spark
+  queries fast.
+- **Watch for truncation banners** in the UI. If they appear on
+  aggregated queries, your aggregation isn't grouping enough — the result
+  is still too wide. Either narrow the time range or bucket more
+  aggressively.
+- **Server-side cancellation works.** If a query hits the `LLM_TIMEOUT`
+  or you kill the session, datasight calls Spark Connect's `interruptTag`
+  API so the cluster stops executing the job — cluster resources are
+  freed, not left running in the background.
+- **Keep credentials out of git.** `.env` should be in `.gitignore`
+  (datasight adds it by default).

--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -217,10 +217,28 @@ Also useful to check:
 ## Running Spark on an HPC compute node
 
 If your organization doesn't have a shared Spark cluster but you do have
-HPC, you can start your own short-lived Spark Connect server on a
-Slurm-allocated compute node and tunnel to it from your laptop. This
-mirrors the [Flight SQL on HPC](connect-flight-sql.md) setup, just with
-a Spark driver instead of GizmoSQL.
+HPC, you can start your own short-lived Spark cluster on Slurm-allocated
+compute nodes and tunnel to it from your laptop. This mirrors the
+[Flight SQL on HPC](connect-flight-sql.md) setup, just with a Spark
+cluster instead of a GizmoSQL server.
+
+Pick a variant based on your scale:
+
+- **[Variant A: single-node driver](#variant-a-single-node-driver-local-mode)**
+  — fastest to get running, no networking between nodes. Everything
+  runs in one JVM. Good for up to a few hundred GB that fits in a
+  single compute node's memory.
+- **[Variant B: multi-node standalone cluster](#variant-b-multi-node-standalone-cluster)**
+  — launch a Spark standalone master + workers across 2+ compute nodes
+  so queries actually distribute. Use this when you want real parallel
+  execution across multiple machines.
+
+!!! important
+    **Do not run Spark on the login node.** Spark drivers and executors
+    can consume significant memory and CPU. Always allocate compute
+    nodes with Slurm first, then start the services on those nodes.
+
+### Variant A: single-node driver (local mode)
 
 ```mermaid
 flowchart LR
@@ -248,19 +266,14 @@ flowchart LR
     style compute fill:#c44a1e,stroke:#fe5d26,color:#fff
 ```
 
-!!! important
-    **Do not run Spark on the login node.** Spark drivers can consume
-    significant memory and CPU. Always allocate a compute node with Slurm
-    first, then start the Connect server on that node.
-
-### Step A: Allocate a compute node
+**Step A1: Allocate one compute node**
 
 ```bash
 salloc --time=4:00:00 --mem=240G --cpus-per-task=104 --account <your-account>
 hostname     # note the compute node hostname (e.g. compute-node-42)
 ```
 
-### Step B: Start Spark Connect on the compute node
+**Step A2: Start Spark Connect on the compute node**
 
 Spark 3.5+ ships a helper script that launches a local driver with the
 Connect server enabled:
@@ -285,19 +298,158 @@ The script binds the Connect gRPC server to `0.0.0.0:15002` by default.
 Override with `--conf spark.connect.grpc.binding.port=<port>` if 15002
 is taken. Check the driver log — it prints the exact bound address.
 
-### Step C: SSH tunnel from your laptop
+**Step A3: SSH tunnel and configure datasight** — see
+[common steps](#common-steps-ssh-tunnel-and-datasight-config) below.
 
-Replace `compute-node-42` with your actual allocated hostname:
+### Variant B: multi-node standalone cluster
+
+Use this when your dataset is too big for one compute node, or when you
+saw `spark.master = local[*]` in the session info log and only one node
+was actually doing work.
+
+```mermaid
+flowchart LR
+    subgraph laptop ["Your laptop"]
+        DS[datasight web UI<br>+ LLM agent]
+    end
+    subgraph login ["Login node"]
+        SSH[SSH tunnel<br>passthrough only]
+    end
+    subgraph nodeA ["Compute node A · head"]
+        MASTER[Spark master<br>:7077]
+        SC[Spark Connect server<br>:15002]
+        WA[Worker A]
+        SC --> MASTER
+        WA --> MASTER
+    end
+    subgraph nodeB ["Compute node B · worker"]
+        WB[Worker B]
+        WB --> MASTER
+    end
+    PQ["/scratch parquet files<br>shared filesystem"]
+    WA --> PQ
+    WB --> PQ
+    DS <-->|"SQL over<br>gRPC + Arrow"| SSH <-->|port 15002| SC
+
+    style DS fill:#15a8a8,stroke:#023d60,color:#fff
+    style SSH fill:#bf1363,stroke:#8a0d42,color:#fff
+    style SC fill:#fe5d26,stroke:#c44a1e,color:#fff
+    style MASTER fill:#2e7ebb,stroke:#1a5c8a,color:#fff
+    style WA fill:#2e7ebb,stroke:#1a5c8a,color:#fff
+    style WB fill:#2e7ebb,stroke:#1a5c8a,color:#fff
+    style PQ fill:#8a7d55,stroke:#6b6040,color:#fff
+    style laptop fill:#1a8a8a,stroke:#15a8a8,color:#fff
+    style login fill:#9e1050,stroke:#bf1363,color:#fff
+    style nodeA fill:#c44a1e,stroke:#fe5d26,color:#fff
+    style nodeB fill:#c44a1e,stroke:#fe5d26,color:#fff
+```
+
+!!! tip
+    Spark's standalone mode needs the **parquet / delta files on a
+    shared filesystem** that every node can read at the same path.
+    On HPC that usually means `/scratch` or `/projects`. NFS-mounted
+    home directories work but are slow under parallel IO.
+
+**Step B1: Allocate 2 compute nodes**
+
+Ask Slurm for two whole nodes with one task per node — you'll manually
+start different services on each:
+
+```bash
+salloc --nodes=2 --ntasks-per-node=1 --time=4:00:00 \
+    --mem=240G --cpus-per-task=104 --account <your-account>
+
+# List the allocated node names — first is "head", second is "worker"
+scontrol show hostnames "$SLURM_JOB_NODELIST"
+# → compute-node-42
+# → compute-node-43
+```
+
+Capture them into shell variables. From the head node (the one `salloc`
+puts you on):
+
+```bash
+HEAD_NODE=$(hostname)
+WORKER_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | tail -n1)
+echo "Head:   $HEAD_NODE"
+echo "Worker: $WORKER_NODE"
+```
+
+**Step B2: Start the standalone master on the head node**
+
+```bash
+# On the head node
+$SPARK_HOME/sbin/start-master.sh \
+    --host "$HEAD_NODE" \
+    --port 7077 \
+    --webui-port 8080
+```
+
+The master now accepts worker registrations at `spark://$HEAD_NODE:7077`.
+The web UI on `http://$HEAD_NODE:8080` lists every worker that registers.
+
+**Step B3: Launch a worker on each compute node**
+
+Start one worker locally on the head node, and use `srun` to launch
+another worker on the second node — `srun` inherits the Slurm allocation
+so it lands on `$WORKER_NODE` without a separate job:
+
+```bash
+# Worker on the head node (same box as the master)
+$SPARK_HOME/sbin/start-worker.sh "spark://$HEAD_NODE:7077" \
+    --cores 100 --memory 200g
+
+# Worker on the second node — srun runs it there inside this allocation
+srun --nodes=1 --ntasks=1 -w "$WORKER_NODE" \
+    $SPARK_HOME/sbin/start-worker.sh "spark://$HEAD_NODE:7077" \
+    --cores 100 --memory 200g &
+```
+
+Leave `--cores` a few below `--cpus-per-task` so the worker JVM and OS
+have breathing room. Check `http://$HEAD_NODE:8080` — you should see
+two `ALIVE` workers.
+
+**Step B4: Start the Connect server pointing at the standalone master**
+
+This is the critical change from Variant A — `--master` goes to
+`spark://...` instead of `local[...]`:
+
+```bash
+# On the head node
+$SPARK_HOME/sbin/start-connect-server.sh \
+    --master "spark://$HEAD_NODE:7077" \
+    --packages org.apache.spark:spark-connect_2.13:3.5.1 \
+    --conf spark.driver.memory=16g \
+    --conf spark.executor.memory=200g \
+    --conf spark.executor.cores=100 \
+    --conf spark.sql.execution.arrow.pyspark.enabled=true
+```
+
+When datasight connects, the session info log should now show something
+like `spark.master = spark://compute-node-42:7077` and the local-mode
+warning will not fire.
+
+**Step B5: SSH tunnel and configure datasight** — see
+[common steps](#common-steps-ssh-tunnel-and-datasight-config) below.
+Note that `$HEAD_NODE` is where the Connect server lives — that's what
+goes in the `-L` forward, not `$WORKER_NODE`.
+
+### Common steps: SSH tunnel and datasight config
+
+**SSH tunnel from your laptop**
+
+Replace `compute-node-42` with the compute node running the Connect
+server (the head node in Variant B):
 
 ```bash
 ssh -N -L 15002:compute-node-42:15002 user@hpc-login-node
 ```
 
-Leave this running in a separate terminal. The `-L` forwards your laptop's
-`localhost:15002` through the login node to port 15002 on the compute
-node — which is where the Spark Connect server is actually listening.
+Leave this running in a separate terminal. The `-L` forwards your
+laptop's `localhost:15002` through the login node to port 15002 on the
+head compute node.
 
-### Step D: Configure datasight
+**Configure datasight**
 
 Because the tunnel exposes the server at `localhost:15002` on your
 laptop, `SPARK_REMOTE` points at `localhost`, not the compute node:
@@ -313,10 +465,20 @@ SPARK_REMOTE=sc://localhost:15002
 - **Use the compute node hostname in the `-L` target, not the login
   node.** Spark is on the compute node; the login node is a passthrough.
   If you tunnel only to the login node, you'll hit `connection refused`.
+- **Standalone workers need to reach the master over the internal HPC
+  network.** On most HPC systems, compute nodes can freely reach each
+  other via the management or IB fabric — but some clusters firewall
+  internal traffic. If `start-worker.sh` on the second node hangs or
+  errors with "unable to connect to master", ask your HPC support
+  whether port 7077 is blocked between nodes.
 - **Watch for port collisions.** 15002 is the Spark Connect default, but
   if a previous job of yours on the same compute node is still bound to
   it, startup will fail. Either pick a different port via
   `spark.connect.grpc.binding.port` or kill the old job.
+- **Shared filesystem path must match on every node.** A worker at
+  `/scratch/alice/data.parquet` on node A and `/home/alice/data.parquet`
+  on node B will fail with "file not found" on whichever node didn't
+  match the query's path.
 - **The tunnel dies when the allocation ends.** Same as Flight SQL on
   HPC: request a generous `--time` or use `salloc` so you can extend
   interactively.

--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -164,6 +164,117 @@ pulls column metadata for each table, and starts the web UI at
 <http://localhost:8084>. Ask a question and the agent writes Spark SQL
 against your tables.
 
+## Running Spark on an HPC compute node
+
+If your organization doesn't have a shared Spark cluster but you do have
+HPC, you can start your own short-lived Spark Connect server on a
+Slurm-allocated compute node and tunnel to it from your laptop. This
+mirrors the [Flight SQL on HPC](connect-flight-sql.md) setup, just with
+a Spark driver instead of GizmoSQL.
+
+```mermaid
+flowchart LR
+    subgraph laptop ["Your laptop"]
+        DS[datasight web UI<br>+ LLM agent]
+    end
+    subgraph login ["Login node"]
+        SSH[SSH tunnel<br>passthrough only]
+    end
+    subgraph compute ["Compute node · Slurm-allocated"]
+        SC[Spark Connect server]
+        DR[Spark driver<br>+ local executors]
+        PQ["/scratch parquet files"]
+        SC --> DR --> PQ
+    end
+    DS <-->|"SQL over<br>gRPC + Arrow"| SSH <-->|port 15002| SC
+
+    style DS fill:#15a8a8,stroke:#023d60,color:#fff
+    style SSH fill:#bf1363,stroke:#8a0d42,color:#fff
+    style SC fill:#fe5d26,stroke:#c44a1e,color:#fff
+    style DR fill:#2e7ebb,stroke:#1a5c8a,color:#fff
+    style PQ fill:#8a7d55,stroke:#6b6040,color:#fff
+    style laptop fill:#1a8a8a,stroke:#15a8a8,color:#fff
+    style login fill:#9e1050,stroke:#bf1363,color:#fff
+    style compute fill:#c44a1e,stroke:#fe5d26,color:#fff
+```
+
+!!! important
+    **Do not run Spark on the login node.** Spark drivers can consume
+    significant memory and CPU. Always allocate a compute node with Slurm
+    first, then start the Connect server on that node.
+
+### Step A: Allocate a compute node
+
+```bash
+salloc --time=4:00:00 --mem=240G --cpus-per-task=104 --account <your-account>
+hostname     # note the compute node hostname (e.g. compute-node-42)
+```
+
+### Step B: Start Spark Connect on the compute node
+
+Spark 3.5+ ships a helper script that launches a local driver with the
+Connect server enabled:
+
+```bash
+# On the compute node, inside your allocation
+$SPARK_HOME/sbin/start-connect-server.sh \
+    --master "local[104]" \
+    --packages org.apache.spark:spark-connect_2.13:3.5.1 \
+    --conf spark.driver.memory=200g \
+    --conf spark.sql.execution.arrow.pyspark.enabled=true
+```
+
+- `--master local[104]` runs driver and executors in one JVM using all
+  allocated cores (tune to `--cpus-per-task`).
+- `--packages` pulls the Connect server jar matching your Spark version.
+  Some Spark distributions bundle it already — if so, omit this flag.
+- `--conf spark.driver.memory=...` must fit inside your Slurm `--mem`
+  allocation with headroom for the Python gRPC process and OS cache.
+
+The script binds the Connect gRPC server to `0.0.0.0:15002` by default.
+Override with `--conf spark.connect.grpc.binding.port=<port>` if 15002
+is taken. Check the driver log — it prints the exact bound address.
+
+### Step C: SSH tunnel from your laptop
+
+Replace `compute-node-42` with your actual allocated hostname:
+
+```bash
+ssh -N -L 15002:compute-node-42:15002 user@hpc-login-node
+```
+
+Leave this running in a separate terminal. The `-L` forwards your laptop's
+`localhost:15002` through the login node to port 15002 on the compute
+node — which is where the Spark Connect server is actually listening.
+
+### Step D: Configure datasight
+
+Because the tunnel exposes the server at `localhost:15002` on your
+laptop, `SPARK_REMOTE` points at `localhost`, not the compute node:
+
+```bash
+DB_MODE=spark
+SPARK_REMOTE=sc://localhost:15002
+# No SPARK_TOKEN needed — the SSH tunnel already authenticates you
+```
+
+### Gotchas
+
+- **Use the compute node hostname in the `-L` target, not the login
+  node.** Spark is on the compute node; the login node is a passthrough.
+  If you tunnel only to the login node, you'll hit `connection refused`.
+- **Watch for port collisions.** 15002 is the Spark Connect default, but
+  if a previous job of yours on the same compute node is still bound to
+  it, startup will fail. Either pick a different port via
+  `spark.connect.grpc.binding.port` or kill the old job.
+- **The tunnel dies when the allocation ends.** Same as Flight SQL on
+  HPC: request a generous `--time` or use `salloc` so you can extend
+  interactively.
+- **Package resolution requires login-node internet.** The first
+  `--packages` invocation downloads jars to `~/.ivy2`. If your compute
+  nodes lack outbound network, pre-resolve on the login node first, or
+  install the Connect jar into `$SPARK_HOME/jars`.
+
 ## Tips
 
 - **Let the agent aggregate.** Questions like "total wind generation by

--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -164,6 +164,56 @@ pulls column metadata for each table, and starts the web UI at
 <http://localhost:8084>. Ask a question and the agent writes Spark SQL
 against your tables.
 
+### Verifying you're actually distributed
+
+On startup, datasight logs the Spark session details it sees from the
+Connect server. Look for a block like this in the terminal output:
+
+```text
+INFO  Spark session info:
+  version                                   = 3.5.1
+  spark.master                              = spark://master-node:7077
+  spark.app.name                            = datasight
+  spark.app.id                              = app-20260422-0001
+  spark.default.parallelism                 = 208
+  spark.sql.shuffle.partitions              = 200
+  spark.executor.instances                  = 2
+  spark.executor.cores                      = 104
+  spark.executor.memory                     = 200g
+  spark.dynamicAllocation.enabled           = false
+```
+
+The field to check first is **`spark.master`**:
+
+- `spark://host:7077` — connected to a standalone cluster. ✓ distributed
+- `yarn` / `k8s://...` — connected to a YARN / Kubernetes cluster. ✓
+- `local` or `local[*]` — **the Connect server is running all work in
+  one JVM on the driver node.** No executors on other nodes are used.
+  This is almost always the reason only one node shows CPU activity.
+
+If you see `local[*]` and you expected distribution, datasight also emits
+a warning pointing at the fix:
+
+```text
+WARNING Spark master is 'local[*]' — the Connect server is running all
+work in one JVM on the driver node. If you expected distributed
+execution, set spark.master on the Connect server (e.g.
+spark://master:7077, yarn, or k8s://...) and restart it.
+```
+
+`spark.master` is set on the **Connect server** side when it starts, not
+on the datasight client. If you launched Spark with
+`start-connect-server.sh --master local[104]`, that's where the setting
+lives — restart the server with the correct master URL.
+
+Also useful to check:
+
+- `spark.executor.instances` — should be ≥ 1 for a real cluster. `None`
+  or missing means dynamic allocation, in which case look at
+  `spark.dynamicAllocation.minExecutors` / `maxExecutors`.
+- `spark.default.parallelism` — roughly `executor_count × cores_per_executor`.
+  If this number looks like a single machine's core count, you're local.
+
 ## Running Spark on an HPC compute node
 
 If your organization doesn't have a shared Spark cluster but you do have

--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -79,7 +79,7 @@ pyspark. Install the extra on your laptop:
 pip install 'datasight[spark]'
 ```
 
-This adds `pyspark[connect]>=3.5` to your environment. No Java is
+This adds `pyspark[connect]>=4.0,<5` to your environment. No Java is
 required — the Connect client is pure Python and talks to the cluster
 over gRPC.
 

--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -236,31 +236,132 @@ Also useful to check:
 - `spark.default.parallelism` — roughly `executor_count × cores_per_executor`.
   If this number looks like a single machine's core count, you're local.
 
+## Running Spark in the cloud
+
+Most managed Spark services expose a Spark Connect endpoint — all
+datasight needs is the `sc://…` URI and (if auth is enabled) a bearer
+token.
+
+**Databricks** — connection strings embed the PAT and target cluster
+right in the URI. Datasight forwards this as-is:
+
+```bash
+DB_MODE=spark
+SPARK_REMOTE=sc://<workspace>.cloud.databricks.com:443/;token=<personal-access-token>;x-databricks-cluster-id=<cluster-id>
+```
+
+**Self-managed on K8s / EKS / GKE / AKS / Dataproc / EMR** — you or
+your team started a Spark Connect server on the cluster. The URI is
+the service hostname and port, TLS if configured, plus optional token:
+
+```bash
+DB_MODE=spark
+SPARK_REMOTE=sc://spark-connect.example.com:15002
+# Or with TLS + bearer auth:
+# SPARK_REMOTE=sc://spark-connect.example.com:443/;use_ssl=true
+SPARK_TOKEN=<bearer-token>
+```
+
+No tunnel needed in either case — datasight connects directly to the
+public endpoint. If your cluster is VPC-private, the usual options
+apply: VPN, bastion tunnel, Cloud IAP, etc. — all of which terminate
+at a local port that `SPARK_REMOTE=sc://localhost:<port>` points at.
+
 ## Running Spark on an HPC compute node
 
-If your organization doesn't have a shared Spark cluster but you do have
-HPC, you can start your own short-lived Spark cluster on Slurm-allocated
-compute nodes and tunnel to it from your laptop. This mirrors the
-[Flight SQL on HPC](connect-flight-sql.md) setup, just with a Spark
-cluster instead of a GizmoSQL server.
+If your organization doesn't have a shared Spark cluster but does have
+HPC, you can start a short-lived Spark cluster on Slurm-allocated
+compute nodes and tunnel to it from your laptop.
 
-Pick a variant based on your scale:
-
-- **[Variant A: single-node driver](#variant-a-single-node-driver-local-mode)**
-  — fastest to get running, no networking between nodes. Everything
-  runs in one JVM. Good for up to a few hundred GB that fits in a
-  single compute node's memory.
-- **[Variant B: multi-node standalone cluster](#variant-b-multi-node-standalone-cluster)**
-  — launch a Spark standalone master + workers across 2+ compute nodes
-  so queries actually distribute. Use this when you want real parallel
-  execution across multiple machines.
+The cleanest path is **[sparkctl](https://github.com/NatLabRockies/sparkctl)**
+— an NLR-developed tool that orchestrates a Spark standalone cluster
+across Slurm-allocated compute nodes for you. It handles the master,
+workers, and Connect server in a handful of commands. Fall back to the
+hand-rolled single-node variant below only if sparkctl isn't available
+on your cluster.
 
 !!! important
     **Do not run Spark on the login node.** Spark drivers and executors
     can consume significant memory and CPU. Always allocate compute
     nodes with Slurm first, then start the services on those nodes.
 
-### Variant A: single-node driver (local mode)
+### Recommended: sparkctl (multi-node standalone)
+
+sparkctl stands up a Spark standalone cluster across the compute nodes
+in your Slurm allocation — one head (master + driver) and N workers —
+and starts the Connect server on the head node.
+
+**Step 1: Install sparkctl** (one-time, on a login node)
+
+```bash
+module load python
+python -m venv ~/python-envs/sparkctl
+source ~/python-envs/sparkctl/bin/activate
+pip install sparkctl
+```
+
+See the [sparkctl install guide](https://natlabrockies.github.io/sparkctl/)
+for supported Spark versions and OS notes.
+
+**Step 2: Allocate compute nodes**
+
+sparkctl uses the Slurm env vars to discover the allocation. This
+example reserves 1 node for the master + driver + your interactive
+session, and 2 full nodes for workers:
+
+```bash
+salloc -t 04:00:00 -n4 --partition=shared --mem=30G : \
+       -N2 --account=<your-account> --mem=240G
+```
+
+**Step 3: Configure and start the cluster**
+
+```bash
+source ~/python-envs/sparkctl/bin/activate
+sparkctl configure           # inspects the allocation, writes ./conf
+sparkctl start               # starts master, workers, and Connect server
+
+# Set the env vars sparkctl prints so subsequent commands use this cluster.
+export SPARK_CONF_DIR=$(pwd)/conf
+export JAVA_HOME=<path printed by sparkctl>
+```
+
+The Connect server binds to port 15002 on the head node (the box your
+interactive session is on). Verify with `hostname` and pick that up as
+`$HEAD_NODE` for the next step.
+
+**Step 4: SSH tunnel from your laptop**
+
+```bash
+ssh -N -L 15002:<head-node-hostname>:15002 user@hpc-login-node
+```
+
+**Step 5: Configure datasight**
+
+```bash
+DB_MODE=spark
+SPARK_REMOTE=sc://localhost:15002
+```
+
+**Step 6: When you're done**
+
+```bash
+sparkctl stop
+```
+
+Shutting down cleanly returns cluster resources to the scheduler and
+avoids leaked JVMs.
+
+See the [sparkctl Spark Connect tutorial](https://github.com/NatLabRockies/sparkctl/blob/main/docs/tutorials/run_python_spark_jobs_spark_connect.md)
+for the full reference, including how to tune worker memory and
+customize the Spark config before `sparkctl start`.
+
+### Fallback: hand-rolled single-node driver (local mode)
+
+Use this only if sparkctl isn't installed on your cluster and you need
+a quick smoke test. Everything runs in one JVM on one node, so there's
+no cross-node parallelism — good for datasets that fit in a single
+compute node's memory, bad for real multi-TB workloads.
 
 ```mermaid
 flowchart LR
@@ -320,161 +421,15 @@ The script binds the Connect gRPC server to `0.0.0.0:15002` by default.
 Override with `--conf spark.connect.grpc.binding.port=<port>` if 15002
 is taken. Check the driver log — it prints the exact bound address.
 
-**Step A3: SSH tunnel and configure datasight** — see
-[common steps](#common-steps-ssh-tunnel-and-datasight-config) below.
-
-### Variant B: multi-node standalone cluster
-
-Use this when your dataset is too big for one compute node, or when you
-saw `spark.master = local[*]` in the session info log and only one node
-was actually doing work.
-
-```mermaid
-flowchart LR
-    subgraph laptop ["Your laptop"]
-        DS[datasight web UI<br>+ LLM agent]
-    end
-    subgraph login ["Login node"]
-        SSH[SSH tunnel<br>passthrough only]
-    end
-    subgraph nodeA ["Compute node A · head"]
-        MASTER[Spark master<br>:7077]
-        SC[Spark Connect server<br>:15002]
-        WA[Worker A]
-        SC --> MASTER
-        WA --> MASTER
-    end
-    subgraph nodeB ["Compute node B · worker"]
-        WB[Worker B]
-        WB --> MASTER
-    end
-    PQ["/scratch parquet files<br>shared filesystem"]
-    WA --> PQ
-    WB --> PQ
-    DS <-->|"SQL over<br>gRPC + Arrow"| SSH <-->|port 15002| SC
-
-    style DS fill:#15a8a8,stroke:#023d60,color:#fff
-    style SSH fill:#bf1363,stroke:#8a0d42,color:#fff
-    style SC fill:#fe5d26,stroke:#c44a1e,color:#fff
-    style MASTER fill:#2e7ebb,stroke:#1a5c8a,color:#fff
-    style WA fill:#2e7ebb,stroke:#1a5c8a,color:#fff
-    style WB fill:#2e7ebb,stroke:#1a5c8a,color:#fff
-    style PQ fill:#8a7d55,stroke:#6b6040,color:#fff
-    style laptop fill:#1a8a8a,stroke:#15a8a8,color:#fff
-    style login fill:#9e1050,stroke:#bf1363,color:#fff
-    style nodeA fill:#c44a1e,stroke:#fe5d26,color:#fff
-    style nodeB fill:#c44a1e,stroke:#fe5d26,color:#fff
-```
-
-!!! tip
-    Spark's standalone mode needs the **parquet / delta files on a
-    shared filesystem** that every node can read at the same path.
-    On HPC that usually means `/scratch` or `/projects`. NFS-mounted
-    home directories work but are slow under parallel IO.
-
-**Step B1: Allocate 2 compute nodes**
-
-Ask Slurm for two whole nodes with one task per node — you'll manually
-start different services on each:
+**Step A3: SSH tunnel from your laptop**
 
 ```bash
-salloc --nodes=2 --ntasks-per-node=1 --time=4:00:00 \
-    --mem=240G --cpus-per-task=104 --account <your-account>
-
-# List the allocated node names — first is "head", second is "worker"
-scontrol show hostnames "$SLURM_JOB_NODELIST"
-# → compute-node-42
-# → compute-node-43
+ssh -N -L 15002:<compute-node-hostname>:15002 user@hpc-login-node
 ```
 
-Capture them into shell variables. From the head node (the one `salloc`
-puts you on):
+Leave this running in a separate terminal.
 
-```bash
-HEAD_NODE=$(hostname)
-WORKER_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | tail -n1)
-echo "Head:   $HEAD_NODE"
-echo "Worker: $WORKER_NODE"
-```
-
-**Step B2: Start the standalone master on the head node**
-
-```bash
-# On the head node
-$SPARK_HOME/sbin/start-master.sh \
-    --host "$HEAD_NODE" \
-    --port 7077 \
-    --webui-port 8080
-```
-
-The master now accepts worker registrations at `spark://$HEAD_NODE:7077`.
-The web UI on `http://$HEAD_NODE:8080` lists every worker that registers.
-
-**Step B3: Launch a worker on each compute node**
-
-Start one worker locally on the head node, and use `srun` to launch
-another worker on the second node — `srun` inherits the Slurm allocation
-so it lands on `$WORKER_NODE` without a separate job:
-
-```bash
-# Worker on the head node (same box as the master)
-$SPARK_HOME/sbin/start-worker.sh "spark://$HEAD_NODE:7077" \
-    --cores 100 --memory 200g
-
-# Worker on the second node — srun runs it there inside this allocation
-srun --nodes=1 --ntasks=1 -w "$WORKER_NODE" \
-    $SPARK_HOME/sbin/start-worker.sh "spark://$HEAD_NODE:7077" \
-    --cores 100 --memory 200g &
-```
-
-Leave `--cores` a few below `--cpus-per-task` so the worker JVM and OS
-have breathing room. Check `http://$HEAD_NODE:8080` — you should see
-two `ALIVE` workers.
-
-**Step B4: Start the Connect server pointing at the standalone master**
-
-This is the critical change from Variant A — `--master` goes to
-`spark://...` instead of `local[...]`:
-
-```bash
-# On the head node
-$SPARK_HOME/sbin/start-connect-server.sh \
-    --master "spark://$HEAD_NODE:7077" \
-    --packages org.apache.spark:spark-connect_2.13:3.5.1 \
-    --conf spark.driver.memory=16g \
-    --conf spark.executor.memory=200g \
-    --conf spark.executor.cores=100 \
-    --conf spark.sql.execution.arrow.pyspark.enabled=true
-```
-
-When datasight connects, the session info log should now show something
-like `spark.master = spark://compute-node-42:7077` and the local-mode
-warning will not fire.
-
-**Step B5: SSH tunnel and configure datasight** — see
-[common steps](#common-steps-ssh-tunnel-and-datasight-config) below.
-Note that `$HEAD_NODE` is where the Connect server lives — that's what
-goes in the `-L` forward, not `$WORKER_NODE`.
-
-### Common steps: SSH tunnel and datasight config
-
-**SSH tunnel from your laptop**
-
-Replace `compute-node-42` with the compute node running the Connect
-server (the head node in Variant B):
-
-```bash
-ssh -N -L 15002:compute-node-42:15002 user@hpc-login-node
-```
-
-Leave this running in a separate terminal. The `-L` forwards your
-laptop's `localhost:15002` through the login node to port 15002 on the
-head compute node.
-
-**Configure datasight**
-
-Because the tunnel exposes the server at `localhost:15002` on your
-laptop, `SPARK_REMOTE` points at `localhost`, not the compute node:
+**Step A4: Configure datasight**
 
 ```bash
 DB_MODE=spark
@@ -482,32 +437,26 @@ SPARK_REMOTE=sc://localhost:15002
 # No SPARK_TOKEN needed — the SSH tunnel already authenticates you
 ```
 
-### Gotchas
+### HPC gotchas
 
 - **Use the compute node hostname in the `-L` target, not the login
   node.** Spark is on the compute node; the login node is a passthrough.
   If you tunnel only to the login node, you'll hit `connection refused`.
-- **Standalone workers need to reach the master over the internal HPC
-  network.** On most HPC systems, compute nodes can freely reach each
-  other via the management or IB fabric — but some clusters firewall
-  internal traffic. If `start-worker.sh` on the second node hangs or
-  errors with "unable to connect to master", ask your HPC support
-  whether port 7077 is blocked between nodes.
-- **Watch for port collisions.** 15002 is the Spark Connect default, but
-  if a previous job of yours on the same compute node is still bound to
-  it, startup will fail. Either pick a different port via
-  `spark.connect.grpc.binding.port` or kill the old job.
-- **Shared filesystem path must match on every node.** A worker at
-  `/scratch/alice/data.parquet` on node A and `/home/alice/data.parquet`
-  on node B will fail with "file not found" on whichever node didn't
-  match the query's path.
-- **The tunnel dies when the allocation ends.** Same as Flight SQL on
-  HPC: request a generous `--time` or use `salloc` so you can extend
-  interactively.
+- **Watch for port collisions.** 15002 is the Spark Connect default;
+  if a previous job on the same node is still bound to it, startup
+  will fail. Either pick a different port (`spark.connect.grpc.binding.port`)
+  or kill the old job.
+- **The tunnel dies when the allocation ends.** Request generous
+  `--time`, or use `salloc` so you can extend interactively.
 - **Package resolution requires login-node internet.** The first
   `--packages` invocation downloads jars to `~/.ivy2`. If your compute
   nodes lack outbound network, pre-resolve on the login node first, or
   install the Connect jar into `$SPARK_HOME/jars`.
+- **Shared filesystem paths must match on every node** — workers
+  executing the query need the parquet data at the exact same path the
+  query references. sparkctl handles this for you; if you're hand-rolling,
+  prefer `/scratch` or `/projects` (identically mounted on every node)
+  over per-user paths.
 
 ## Tips
 

--- a/docs/end-user/how-to/connect-spark.md
+++ b/docs/end-user/how-to/connect-spark.md
@@ -164,6 +164,28 @@ pulls column metadata for each table, and starts the web UI at
 <http://localhost:8084>. Ask a question and the agent writes Spark SQL
 against your tables.
 
+### File-based commands also route through Spark
+
+When `DB_MODE=spark` is set in your `.env`, commands that accept explicit
+file arguments — `datasight inspect foo.parquet`, `datasight generate
+--files`, `datasight trends --files`, and the web UI's "explore files"
+flow — register the given Parquet/CSV paths as Spark temp views and run
+introspection on the cluster instead of opening a local in-memory
+DuckDB. Your `SPARK_REMOTE` appears in the startup log so you can
+confirm Spark was used:
+
+```text
+INFO  File inspection routed through Spark Connect: sc://localhost:15002
+INFO  Connected to Spark Connect: sc://localhost:15002
+INFO  Spark session info: ...
+```
+
+The file paths you pass must be reachable from the Spark workers at the
+same absolute path — Spark does not upload local files to the cluster.
+On HPC this is usually fine because `/scratch` / `/projects` are shared;
+on a laptop-only Spark-Connect setup it won't work, so use DuckDB mode
+in that case.
+
 ### Verifying you're actually distributed
 
 On startup, datasight logs the Spark session details it sees from the

--- a/docs/project-developer/database-connections.md
+++ b/docs/project-developer/database-connections.md
@@ -1,18 +1,18 @@
 # Database connections
 
-datasight supports four database backends. This guide explains when to use
+datasight supports five database backends. This guide explains when to use
 each one and how to configure the connection.
 
 ## Choosing a database
 
-| | DuckDB | SQLite | PostgreSQL | Flight SQL |
-|---|---|---|---|---|
-| **Best for** | Local analytics on Parquet/CSV files | Existing SQLite databases from other apps | Production databases, multi-user access | Remote HPC or distributed query engines |
-| **Install** | Built in | Built in | Built in | Built in |
-| **DB_MODE** | `duckdb` | `sqlite` | `postgres` | `flightsql` |
-| **Connection** | Local file path | Local file path | Host/port or connection string | gRPC URI |
-| **Concurrent users** | Single process | Single process | Multi-user | Multi-user |
-| **SQL dialect** | DuckDB SQL (Postgres-like) | SQLite SQL | PostgreSQL | Depends on server |
+| | DuckDB | SQLite | PostgreSQL | Flight SQL | Spark |
+|---|---|---|---|---|---|
+| **Best for** | Local analytics on Parquet/CSV files | Existing SQLite databases from other apps | Production databases, multi-user access | Remote HPC or distributed query engines | Multi-TB datasets on a Spark cluster |
+| **Install** | Built in | Built in | Built in | Built in | `pip install 'datasight[spark]'` |
+| **DB_MODE** | `duckdb` | `sqlite` | `postgres` | `flightsql` | `spark` |
+| **Connection** | Local file path | Local file path | Host/port or connection string | gRPC URI | Spark Connect URI |
+| **Concurrent users** | Single process | Single process | Multi-user | Multi-user | Multi-user |
+| **SQL dialect** | DuckDB SQL (Postgres-like) | SQLite SQL | PostgreSQL | Depends on server | Spark SQL |
 
 **DuckDB** is the default and recommended for most use cases. It is an
 embedded OLAP (Online Analytical Processing) database designed for
@@ -32,6 +32,14 @@ databases, data warehouses, or managed services like RDS or Cloud SQL.
 protocol, such as [GizmoSQL](https://github.com/gizmodata/gizmosql) on an
 HPC cluster. See [Connect to a remote Flight SQL backend](../end-user/how-to/connect-flight-sql.md)
 for a full walkthrough.
+
+**Spark** connects to an Apache Spark cluster via
+[Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html).
+Use this when your data is too large to fit on a single machine — typically
+multi-terabyte Parquet/Delta/Iceberg tables managed by Spark. The client
+streams Arrow batches and truncates the result once it exceeds a byte cap
+(default 100 MiB), so the web server stays responsive even when the agent
+forgets to aggregate.
 
 ## DuckDB
 
@@ -179,6 +187,54 @@ For TLS-enabled servers, use `grpc+tls://` as the URI scheme:
 FLIGHT_SQL_URI=grpc+tls://flight.example.com:31337
 FLIGHT_SQL_TOKEN=your_bearer_token
 ```
+
+## Spark (via Spark Connect)
+
+Spark is for multi-terabyte datasets that live on a Spark cluster. The
+cluster must have the Spark Connect server enabled (Spark 3.4+; we require
+pyspark 3.5+ on the client). Install the extra dependency:
+
+```bash
+pip install 'datasight[spark]'
+```
+
+Then configure the connection:
+
+```bash
+DB_MODE=spark
+SPARK_REMOTE=sc://spark-connect.example.com:15002
+SPARK_TOKEN=your_bearer_token        # optional
+SPARK_MAX_RESULT_BYTES=104857600     # optional, default 100 MiB
+```
+
+### Why the byte cap
+
+At multi-TB scale, a careless `SELECT * FROM fact_table` could try to pull
+terabytes of Arrow data back to the client. The client streams Arrow
+batches and stops once the accumulated bytes exceed `SPARK_MAX_RESULT_BYTES`.
+Truncated results are flagged in the UI and in the LLM's tool output so
+the agent can tell the user "partial result — add aggregation" rather than
+misreporting them as the full answer.
+
+- Default cap: **100 MiB** on the wire (≈250–500 MiB after pandas inflation).
+- Truncation is safe: cancelling the query server-side via Spark Connect's
+  interrupt API so it stops consuming cluster resources.
+
+### Schema introspection at TB scale
+
+- Table discovery uses `spark.catalog.listTables()` — fast, metadata-only.
+- Row counts are **skipped** for Spark tables. A naive `SELECT COUNT(*)` on
+  a partitioned multi-TB table can kick off a full-cluster job at project
+  load, before the user even asks a question. Row counts simply won't
+  appear in the schema prompt for Spark backends.
+
+### Write queries that the cluster can serve cheaply
+
+datasight's system prompt for Spark already tells the LLM to aggregate,
+avoid `SELECT *`, include partition predicates, and always add `LIMIT`
+for non-aggregated queries. When you write `schema_description.md`,
+document your partition columns explicitly — e.g. "this table is
+partitioned by `report_date` (daily)" — so the agent uses them as filters.
 
 ## All environment variables
 

--- a/docs/project-developer/database-connections.md
+++ b/docs/project-developer/database-connections.md
@@ -188,17 +188,16 @@ FLIGHT_SQL_URI=grpc+tls://flight.example.com:31337
 FLIGHT_SQL_TOKEN=your_bearer_token
 ```
 
-## Spark (via Spark Connect)
+## Spark
 
-Spark is for multi-terabyte datasets that live on a Spark cluster. The
-cluster must have the Spark Connect server enabled (Spark 3.4+; we require
-pyspark 3.5+ on the client). Install the extra dependency:
+Spark connects to an Apache Spark cluster over Spark Connect. Use this
+for multi-terabyte datasets that won't fit on a single machine. See
+[Connect to an Apache Spark backend](../end-user/how-to/connect-spark.md)
+for the full walkthrough.
 
 ```bash
 pip install 'datasight[spark]'
 ```
-
-Then configure the connection:
 
 ```bash
 DB_MODE=spark
@@ -207,34 +206,12 @@ SPARK_TOKEN=your_bearer_token        # optional
 SPARK_MAX_RESULT_BYTES=104857600     # optional, default 100 MiB
 ```
 
-### Why the byte cap
-
-At multi-TB scale, a careless `SELECT * FROM fact_table` could try to pull
-terabytes of Arrow data back to the client. The client streams Arrow
-batches and stops once the accumulated bytes exceed `SPARK_MAX_RESULT_BYTES`.
-Truncated results are flagged in the UI and in the LLM's tool output so
-the agent can tell the user "partial result — add aggregation" rather than
-misreporting them as the full answer.
-
-- Default cap: **100 MiB** on the wire (≈250–500 MiB after pandas inflation).
-- Truncation is safe: cancelling the query server-side via Spark Connect's
-  interrupt API so it stops consuming cluster resources.
-
-### Schema introspection at TB scale
-
-- Table discovery uses `spark.catalog.listTables()` — fast, metadata-only.
-- Row counts are **skipped** for Spark tables. A naive `SELECT COUNT(*)` on
-  a partitioned multi-TB table can kick off a full-cluster job at project
-  load, before the user even asks a question. Row counts simply won't
-  appear in the schema prompt for Spark backends.
-
-### Write queries that the cluster can serve cheaply
-
-datasight's system prompt for Spark already tells the LLM to aggregate,
-avoid `SELECT *`, include partition predicates, and always add `LIMIT`
-for non-aggregated queries. When you write `schema_description.md`,
-document your partition columns explicitly — e.g. "this table is
-partitioned by `report_date` (daily)" — so the agent uses them as filters.
+The client streams Arrow batches and truncates results above
+`SPARK_MAX_RESULT_BYTES` to protect the web server from OOMing. Row
+counts are skipped at introspection time (a naive `SELECT COUNT(*)` on
+a multi-TB partitioned table would kick off a full-cluster job); document
+your partition columns in `schema_description.md` so the agent uses them
+as predicates.
 
 ## All environment variables
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -656,9 +656,12 @@ datasight trends [OPTIONS] [FILES]...
 
 Run all analyses on Parquet, CSV, or DuckDB files and print results.
 
-Creates an ephemeral in-memory database from the given files and runs
-profile, quality, measures, dimensions, trends, and recipes — printing
-everything to the console without creating a project.
+Creates a file-backed session and runs profile, quality, measures,
+dimensions, trends, and recipes — printing everything to the console
+without creating a project. When the current directory contains a
+``.env`` with ``DB_MODE=spark``, the files are registered as Spark
+temp views and all queries run on the cluster; otherwise an ephemeral
+in-memory DuckDB session is used.
 
 Examples:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -81,7 +81,7 @@ For help picking a provider, see [Choosing an LLM](../concepts/choosing-an-llm.m
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DB_MODE` | `duckdb` | Database type: `duckdb`, `sqlite`, `postgres`, or `flightsql` |
+| `DB_MODE` | `duckdb` | Database type: `duckdb`, `sqlite`, `postgres`, `flightsql`, or `spark` |
 | `DB_PATH` | `./database.duckdb` | Path to DuckDB or SQLite file (used when `DB_MODE=duckdb` or `sqlite`) |
 
 #### PostgreSQL settings (when `DB_MODE=postgres`)
@@ -107,6 +107,16 @@ For production, use `POSTGRES_SSLMODE=verify-full` and consider using a
 | `FLIGHT_SQL_TOKEN` | — | Bearer token for Flight SQL auth |
 | `FLIGHT_SQL_USERNAME` | — | Username for Flight SQL basic auth |
 | `FLIGHT_SQL_PASSWORD` | — | Password for Flight SQL basic auth |
+
+#### Spark Connect settings (when `DB_MODE=spark`)
+
+Requires the `spark` extra: `pip install 'datasight[spark]'`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPARK_REMOTE` | `sc://localhost:15002` | Spark Connect URI (e.g. `sc://spark.example.com:15002`) |
+| `SPARK_TOKEN` | — | Optional bearer token for Spark Connect auth |
+| `SPARK_MAX_RESULT_BYTES` | `104857600` | Client-side cap on Arrow result size (100 MiB default). Results above this are truncated to protect the web server on multi-TB backends. |
 
 ### Other settings
 

--- a/frontend/src/lib/components/ProjectHealth.svelte
+++ b/frontend/src/lib/components/ProjectHealth.svelte
@@ -19,15 +19,23 @@
   let summary = $derived(
     (data?.summary as { ok_count?: number; fail_count?: number }) || {},
   );
-  let projectDir = $derived(
+  let totalCount = $derived(checks.length);
+  let healthy = $derived((summary.fail_count || 0) === 0);
+  let failing = $derived(checks.filter((c) => !c.ok));
+  let passing = $derived(checks.filter((c) => c.ok));
+  let projectName = $derived(
     data?.project_loaded
-      ? (data?.project_dir as string) || "Project loaded"
+      ? ((data?.project_dir as string) || "Project loaded").split("/").pop() ||
+        "Project"
       : "No project loaded",
   );
-  let hints = $derived(
-    checks.filter((c) => !c.ok && c.remediation),
-  );
-  let healthy = $derived((summary.fail_count || 0) === 0);
+  let dbMode = $derived((data?.db_mode as string) || null);
+  let dbTarget = $derived((data?.db_target as string) || null);
+  let llmProvider = $derived((data?.llm_provider as string) || null);
+
+  // Show the OK rows only when the user opens the disclosure. Default
+  // closed because in the healthy case they're just noise.
+  let showAll = $state(false);
 </script>
 
 {#if !data}
@@ -36,37 +44,80 @@
   <p class="health-empty">No health data available.</p>
 {:else}
   <div class="health-grid">
-    <!-- Summary -->
-    <div class="health-summary {healthy ? 'healthy' : 'has-failures'}">
-      <strong>{projectDir}</strong>
-      <span>{summary.ok_count || 0} OK &bull; {summary.fail_count || 0} failing</span>
-    </div>
+    <!-- Identity rows: who/what is configured. Always visible. -->
+    <dl class="identity">
+      <div class="identity-row" title={data?.project_dir as string ?? ""}>
+        <dt>Project</dt>
+        <dd>{projectName}</dd>
+      </div>
+      {#if dbMode}
+        <div class="identity-row" title={dbTarget ?? ""}>
+          <dt>Database</dt>
+          <dd>
+            <span class="mode">{dbMode}</span>
+            {#if dbTarget && dbTarget !== dbMode}
+              <span class="target">{dbTarget}</span>
+            {/if}
+          </dd>
+        </div>
+      {/if}
+      {#if llmProvider}
+        <div class="identity-row">
+          <dt>LLM</dt>
+          <dd>{llmProvider}</dd>
+        </div>
+      {/if}
+    </dl>
 
-    <!-- Remediation hints -->
-    {#if hints.length > 0}
-      <div class="health-hints">
-        {#each hints as hint}
-          <div class="health-hint">
-            <strong>{hint.name}:</strong> {hint.remediation}
+    <!-- Status pill: one line in the healthy case, click to expand. -->
+    <button
+      type="button"
+      class="status-pill {healthy ? 'healthy' : 'has-failures'}"
+      aria-expanded={showAll}
+      onclick={() => (showAll = !showAll)}
+    >
+      <span class="status-text">
+        {#if healthy}
+          All {totalCount} checks passed
+        {:else}
+          {summary.fail_count} of {totalCount} checks failing
+        {/if}
+      </span>
+      <span class="chev" aria-hidden="true">{showAll ? "▾" : "▸"}</span>
+    </button>
+
+    <!-- Failing checks + remediation hints — always visible when present. -->
+    {#if failing.length > 0}
+      <div class="failing-list">
+        {#each failing as check}
+          <div class="health-row fail">
+            <span class="health-name">{check.name}</span>
+            <span class="health-status fail">FAIL</span>
+            {#if check.detail}
+              <span class="health-detail">{check.detail}</span>
+            {/if}
+            {#if check.remediation}
+              <span class="health-remediation">{check.remediation}</span>
+            {/if}
           </div>
         {/each}
       </div>
     {/if}
 
-    <!-- Check rows -->
-    {#each checks as check}
-      <div class="health-row {check.ok ? '' : 'fail'}">
-        <span class="health-name">{check.name}</span>
-        <span class="health-status {check.ok ? 'ok' : 'fail'}">
-          {check.ok ? "OK" : "FAIL"}
-        </span>
-        {#if check.detail}
-          <span class="health-detail">{check.detail}</span>
-        {:else}
-          <span class="health-detail">{check.category}</span>
-        {/if}
+    <!-- All passing checks behind the disclosure. -->
+    {#if showAll && passing.length > 0}
+      <div class="passing-list">
+        {#each passing as check}
+          <div class="health-row">
+            <span class="health-name">{check.name}</span>
+            <span class="health-status ok">OK</span>
+            {#if check.detail}
+              <span class="health-detail">{check.detail}</span>
+            {/if}
+          </div>
+        {/each}
       </div>
-    {/each}
+    {/if}
   </div>
 {/if}
 
@@ -81,40 +132,83 @@
     color: var(--text-secondary);
   }
 
-  .health-summary {
-    padding: 10px 12px;
-    border-radius: 10px;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    color: var(--text);
-    font-size: 0.78rem;
-    word-break: break-word;
+  .identity {
     display: grid;
     gap: 4px;
+    margin: 0;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg) 84%, var(--surface));
+    font-size: 0.78rem;
   }
 
-  .health-summary.healthy {
+  .identity-row {
+    display: grid;
+    grid-template-columns: 70px minmax(0, 1fr);
+    gap: 8px;
+    align-items: baseline;
+  }
+
+  .identity-row dt {
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .identity-row dd {
+    margin: 0;
+    color: var(--text);
+    word-break: break-word;
+  }
+
+  .identity-row .mode {
+    font-weight: 600;
+    margin-right: 6px;
+  }
+
+  .identity-row .target {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+  }
+
+  .status-pill {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 8px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .status-pill.healthy {
     border-color: color-mix(in srgb, var(--teal) 32%, var(--border));
     background: color-mix(in srgb, var(--teal) 6%, var(--bg));
   }
 
-  .health-summary.has-failures {
+  .status-pill.has-failures {
     border-color: color-mix(in srgb, var(--orange) 34%, var(--border));
     background: color-mix(in srgb, var(--orange) 6%, var(--bg));
   }
 
-  .health-hints {
-    display: grid;
-    gap: 8px;
+  .status-pill .chev {
+    color: var(--text-secondary);
+    font-size: 0.78rem;
   }
 
-  .health-hint {
-    padding: 10px 12px;
-    border-radius: 10px;
-    border: 1px solid color-mix(in srgb, var(--orange) 28%, var(--border));
-    background: color-mix(in srgb, var(--orange) 6%, var(--bg));
-    color: var(--text);
-    font-size: 0.74rem;
+  .failing-list,
+  .passing-list {
+    display: grid;
+    gap: 8px;
   }
 
   .health-row {
@@ -129,6 +223,7 @@
 
   .health-row.fail {
     border-color: color-mix(in srgb, var(--orange) 24%, var(--border));
+    background: color-mix(in srgb, var(--orange) 5%, var(--bg));
   }
 
   .health-name {
@@ -156,5 +251,15 @@
     color: var(--text-secondary);
     font-size: 0.74rem;
     word-break: break-word;
+  }
+
+  .health-remediation {
+    grid-column: 1 / -1;
+    color: var(--text);
+    font-size: 0.74rem;
+    word-break: break-word;
+    padding-top: 2px;
+    border-top: 1px solid color-mix(in srgb, var(--orange) 18%, transparent);
+    margin-top: 4px;
   }
 </style>

--- a/frontend/src/lib/components/ProjectHealth.svelte
+++ b/frontend/src/lib/components/ProjectHealth.svelte
@@ -25,8 +25,10 @@
   let passing = $derived(checks.filter((c) => c.ok));
   let projectName = $derived(
     data?.project_loaded
-      ? ((data?.project_dir as string) || "Project loaded").split("/").pop() ||
-        "Project"
+      ? ((data?.project_dir as string) || "Project loaded")
+          .replace(/[\\/]+$/, "")
+          .split(/[\\/]/)
+          .pop() || "Project"
       : "No project loaded",
   );
   let dbMode = $derived((data?.db_mode as string) || null);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - Review the SQL query log: end-user/how-to/review-query-log.md
           - Run on an HPC compute node: end-user/how-to/run-on-hpc.md
           - Connect to a remote Flight SQL backend: end-user/how-to/connect-flight-sql.md
+          - Connect to an Apache Spark backend: end-user/how-to/connect-spark.md
       - Tutorials:
           - Explore US electricity generation (EIA): end-user/tutorials/getting-started.md
           - Explore EV charging demand (TEMPO): end-user/tutorials/tempo.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 export = [
     "kaleido>=0.2,<1",
 ]
+spark = [
+    "pyspark[connect]>=3.5,<5",
+]
 dev = [
     "pytest>=8.0,<9",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ export = [
     "kaleido>=0.2,<1",
 ]
 spark = [
-    "pyspark[connect]>=3.5,<5",
+    "pyspark[connect]>=4.0,<5",
 ]
 dev = [
     "pytest>=8.0,<9",

--- a/src/datasight/agent.py
+++ b/src/datasight/agent.py
@@ -344,6 +344,8 @@ class SqlExecutionResult:
     validation_error: str | None = None
     validation_status: str = "not_run"
     validation_errors: list[str] = field(default_factory=list)
+    truncated: bool = False
+    truncation_reason: str | None = None
 
 
 async def execute_sql_with_validation(
@@ -405,11 +407,20 @@ async def execute_sql_with_validation(
     try:
         df = await run_sql(sql)
         elapsed_ms = (time.perf_counter() - t0) * 1000
+        # Runners signal client-side truncation (e.g. Spark's byte cap) via
+        # df.attrs. Lift it out now: df.attrs is ephemeral and doesn't
+        # survive downstream pandas operations.
+        truncated = bool(df.attrs.get("truncated")) if df is not None else False
+        truncation_reason = (
+            str(df.attrs.get("truncation_reason") or "") if df is not None else ""
+        ) or None
         return SqlExecutionResult(
             df=df,
             elapsed_ms=elapsed_ms,
             validation_status=validation_status,
             validation_errors=validation_errors,
+            truncated=truncated,
+            truncation_reason=truncation_reason,
         )
     except QueryTimeoutError as e:
         elapsed_ms = (time.perf_counter() - t0) * 1000
@@ -496,6 +507,9 @@ def _build_tool_meta(
         meta["row_count"] = len(execution_result.df)
         meta["column_count"] = len(execution_result.df.columns)
         meta["columns"] = list(execution_result.df.columns)
+    if execution_result.truncated:
+        meta["truncated"] = True
+        meta["truncation_reason"] = execution_result.truncation_reason
     return meta
 
 
@@ -568,6 +582,20 @@ async def _execute_run_sql(
     # Handle empty result
     df = result.df
     if df is None or df.empty:
+        if result.truncated:
+            reason = result.truncation_reason or "Result truncated before any rows returned."
+            return ToolResult(
+                result_text=(
+                    "Query was truncated before any rows could be returned. "
+                    f"{reason} The database likely holds matching data — "
+                    "add aggregation or a tighter LIMIT to get a usable answer."
+                ),
+                result_html=(
+                    f"<p class='sql-warning'>Result truncated: {escape_html(reason)}</p>"
+                ),
+                meta=meta,
+                df=df,
+            )
         return ToolResult(
             result_text="Query executed successfully. No rows returned.",
             meta=meta,
@@ -578,7 +606,15 @@ async def _execute_run_sql(
     csv = df.to_csv(index=False)
     preview = csv if len(csv) <= 500 else csv[:500] + "\n..."
     result_text = f"{preview}\n\nReturned {len(df)} rows, {len(df.columns)} columns."
+    if result.truncated:
+        reason = result.truncation_reason or "Result truncated by client-side cap."
+        result_text += f"\n\n⚠ Partial result — {reason}"
     result_html = df_to_html_table(df)
+    if result.truncated:
+        reason = result.truncation_reason or "Result truncated by client-side cap."
+        result_html = (
+            f"<p class='sql-warning'>Partial result — {escape_html(reason)}</p>" + result_html
+        )
 
     return ToolResult(
         result_text=result_text,

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -50,6 +50,23 @@ def _epilog(text: str) -> str:
     return "\n\n".join(line.rstrip() for line in dedent(text).strip().splitlines())
 
 
+# One-line log format that shows the module name but not the function or
+# line number — ``function:line`` noise rarely helps users diagnose their
+# own CLI runs, and leaving it out makes each line fit comfortably.
+_LOG_FORMAT = "{time:HH:mm:ss} | {level: <7} | {name} - {message}"
+
+
+def _configure_logging(level: str = "INFO") -> None:
+    """Replace any existing Loguru sinks with a single stderr sink.
+
+    Call from commands that log progress so every command uses the same
+    format regardless of which module emitted the log. Safe to call
+    multiple times.
+    """
+    logger.remove()
+    logger.add(sys.stderr, level=level, format=_LOG_FORMAT)
+
+
 def _resolve_settings(
     project_dir: str,
     model_override: str | None = None,
@@ -1363,9 +1380,7 @@ def _prepare_web_runtime(
     load_global_env(override=False)
 
     if configure_logging:
-        level = "DEBUG" if verbose else "INFO"
-        logger.remove()
-        logger.add(sys.stderr, level=level, format="{time:HH:mm:ss} {name} {level} {message}")
+        _configure_logging("DEBUG" if verbose else "INFO")
 
     settings = Settings.from_env()
     resolved_model = model if model else settings.llm.model
@@ -1595,8 +1610,7 @@ def demo_eia_generation(project_dir: str, min_year: int):
 
     PROJECT_DIR defaults to the current directory.
     """
-    logger.remove()
-    logger.add(sys.stderr, level="INFO", format="{time:HH:mm:ss} {level} {message}")
+    _configure_logging("INFO")
 
     dest = Path(project_dir).resolve()
     dest.mkdir(parents=True, exist_ok=True)
@@ -1647,8 +1661,7 @@ def demo_dsgrid_tempo(project_dir: str):
 
     PROJECT_DIR defaults to the current directory.
     """
-    logger.remove()
-    logger.add(sys.stderr, level="INFO", format="{time:HH:mm:ss} {level} {message}")
+    _configure_logging("INFO")
 
     dest = Path(project_dir).resolve()
     dest.mkdir(parents=True, exist_ok=True)
@@ -1702,8 +1715,7 @@ def demo_time_validation(project_dir: str):
 
     PROJECT_DIR defaults to the current directory.
     """
-    logger.remove()
-    logger.add(sys.stderr, level="INFO", format="{time:HH:mm:ss} {level} {message}")
+    _configure_logging("INFO")
 
     dest = Path(project_dir).resolve()
     dest.mkdir(parents=True, exist_ok=True)
@@ -1893,8 +1905,7 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
 
     # Logging
     level = "DEBUG" if verbose else "WARNING"
-    logger.remove()
-    logger.add(sys.stderr, level=level, format="{time:HH:mm:ss} {level} {message}")
+    _configure_logging(level)
 
     # Load settings and validate
     settings, resolved_model = _resolve_settings(project_dir, model)
@@ -2264,8 +2275,7 @@ def verify(project_dir, model, queries_path, verbose):
 
     # Logging
     level = "DEBUG" if verbose else "WARNING"
-    logger.remove()
-    logger.add(sys.stderr, level=level, format="{time:HH:mm:ss} {level} {message}")
+    _configure_logging(level)
 
     # Load queries
     from datasight.config import load_example_queries
@@ -2579,8 +2589,7 @@ def ask(
 
     # Logging
     level = "DEBUG" if verbose else "WARNING"
-    logger.remove()
-    logger.add(sys.stderr, level=level, format="{time:HH:mm:ss} {level} {message}")
+    _configure_logging(level)
 
     # Load settings and validate
     settings, resolved_model = _resolve_settings(project_dir, model)
@@ -4264,6 +4273,7 @@ def inspect(files, output_format, output_path):
     from datasight.explore import create_files_session_for_settings
     from datasight.schema import introspect_schema
 
+    _configure_logging("INFO")
     db_settings = _current_db_settings_or_none()
 
     async def _run_phase(name: str, coro):
@@ -4717,8 +4727,7 @@ def recipes_run(
     _validate_settings_for_llm(settings)
 
     if verbose:
-        logger.remove()
-        logger.add(sys.stderr, level="DEBUG")
+        _configure_logging("DEBUG")
 
     recipe_data = _load_recipe_entries(project_dir, settings, table)
     recipe = next((item for item in recipe_data if item["id"] == recipe_id), None)

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -3898,6 +3898,7 @@ def audit_report(project_dir, table, output_path, output_format):
     Combines profile, measures, quality, integrity, distribution, and
     validation results into one HTML, Markdown, or JSON artifact.
     """
+    _configure_logging("INFO")
     project_dir = str(Path(project_dir).resolve())
     settings, _ = _resolve_settings(project_dir)
     resolved_db_path = _resolve_db_path(settings, project_dir)

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -81,6 +81,29 @@ def _resolve_settings(
     return settings, resolved_model
 
 
+def _current_db_settings_or_none():
+    """Load database settings from the current directory's .env, or None.
+
+    Used by the file-based commands (``inspect``, ``generate --files``,
+    ``trends --files``) so that when the user is inside a project with
+    ``DB_MODE=spark``, file operations route through Spark Connect
+    instead of silently dropping the configured backend.
+
+    Returns
+    -------
+    ``DatabaseSettings`` if a ``.env`` is found in the current directory,
+    otherwise ``None`` (caller should fall back to plain DuckDB).
+    """
+    from dotenv import load_dotenv
+
+    env_path = os.path.join(os.getcwd(), ".env")
+    if not os.path.exists(env_path):
+        return None
+    load_dotenv(env_path, override=False)
+    load_global_env(override=False)
+    return Settings.from_env().database
+
+
 def _validate_settings_for_llm(settings: Settings) -> None:
     """Validate that required LLM settings are present. Exits on error."""
     errors = settings.validate()
@@ -1922,9 +1945,11 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
             sql_runner = DuckDBRunner(str(duckdb_source_path))
             tables_info = []
         elif use_files:
-            from datasight.explore import create_ephemeral_session
+            from datasight.explore import create_files_session_for_settings
 
-            sql_runner, tables_info = create_ephemeral_session(list(files))
+            sql_runner, tables_info = create_files_session_for_settings(
+                list(files), settings.database
+            )
         else:
             sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
             tables_info = []
@@ -4071,10 +4096,11 @@ def trends(files, project_dir, table, output_format, output_path):
 
     async def _run_trends():
         if files:
-            from datasight.explore import create_ephemeral_session
+            from datasight.explore import create_files_session_for_settings
             from datasight.schema import introspect_schema
 
-            runner, _ = create_ephemeral_session(list(files))
+            db_settings = _current_db_settings_or_none()
+            runner, _ = create_files_session_for_settings(list(files), db_settings)
             tables = await introspect_schema(runner.run_sql, runner=runner)
             schema_info = [
                 {
@@ -4215,17 +4241,22 @@ def trends(files, project_dir, table, output_format, output_path):
 def inspect(files, output_format, output_path):
     """Run all analyses on Parquet, CSV, or DuckDB files and print results.
 
-    Creates an ephemeral in-memory database from the given files and runs
-    profile, quality, measures, dimensions, trends, and recipes — printing
-    everything to the console without creating a project.
+    Creates a file-backed session and runs profile, quality, measures,
+    dimensions, trends, and recipes — printing everything to the console
+    without creating a project. When the current directory contains a
+    ``.env`` with ``DB_MODE=spark``, the files are registered as Spark
+    temp views and all queries run on the cluster; otherwise an ephemeral
+    in-memory DuckDB session is used.
     """
     from rich.console import Console
 
-    from datasight.explore import create_ephemeral_session
+    from datasight.explore import create_files_session_for_settings
     from datasight.schema import introspect_schema
 
+    db_settings = _current_db_settings_or_none()
+
     async def _run_all():
-        runner, tables_info = create_ephemeral_session(list(files))
+        runner, tables_info = create_files_session_for_settings(list(files), db_settings)
         tables = await introspect_schema(runner.run_sql, runner=runner)
         schema_info = [
             {

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -1824,10 +1824,20 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
 
     project_dir = str(Path(project_dir).resolve())
 
+    # Configure logging and resolve settings early so the db_target
+    # preflight can respect a pre-existing DB_MODE (e.g. spark) and
+    # avoid clobbering the user's backend config.
+    level = "DEBUG" if verbose else "WARNING"
+    _configure_logging(level)
+    settings, resolved_model = _resolve_settings(project_dir, model)
+    _validate_settings_for_llm(settings)
+
     # Resolve the would-be DB path up front so we can include it in the
     # preflight check — otherwise a stale database.duckdb would abort the
     # run only after the LLM call and the doc writes, leaving behind a
-    # partial, mutated project.
+    # partial, mutated project. Skip it entirely when the project is
+    # configured for a non-DuckDB backend; we're not going to touch the
+    # local DuckDB in that case.
     use_files = bool(files)
     db_target: Path | None = None
     sqlite_source_path: Path | None = None
@@ -1869,11 +1879,13 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
                 )
                 sys.exit(1)
             duckdb_source_path = duckdb_files[0]
-        else:
+        elif settings.database.mode == "duckdb":
             _db_target = Path(db_path or "database.duckdb")
             if not _db_target.is_absolute():
                 _db_target = Path(project_dir) / _db_target
             db_target = _db_target.resolve()
+        # Any other mode (spark, postgres, flightsql, sqlite) → no
+        # local DuckDB target; we'll preserve the existing backend.
 
     # Check for existing files early
     schema_path = Path(project_dir) / "schema_description.md"
@@ -1902,14 +1914,6 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
                 err=True,
             )
             sys.exit(1)
-
-    # Logging
-    level = "DEBUG" if verbose else "WARNING"
-    _configure_logging(level)
-
-    # Load settings and validate
-    settings, resolved_model = _resolve_settings(project_dir, model)
-    _validate_settings_for_llm(settings)
 
     if not use_files:
         resolved_db_path = _resolve_db_path(settings, project_dir)
@@ -2121,33 +2125,47 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
         set_env_vars(env_path, {"DB_MODE": db_mode, "DB_PATH": db_env_value})
         written.append(".env (updated)" if existed else ".env")
     elif use_files:
-        from datasight.config import set_env_vars
-        from datasight.explore import build_persistent_duckdb
-
-        assert db_target is not None  # set above when use_files is True
-        try:
-            build_persistent_duckdb(db_target, tables_info, overwrite=overwrite)
-        except FileExistsError:
-            # Preflight above rejects pre-existing DBs without --overwrite,
-            # so reaching here means the file appeared mid-run.
+        # The "new project from parquet files" flow creates a local DuckDB
+        # mirror and writes DB_MODE=duckdb to .env. When the user is already
+        # inside a project configured for a different backend (Spark,
+        # Postgres, Flight SQL, SQLite), doing that silently clobbers
+        # their real config. Preserve whatever they already have.
+        if settings.database.mode != "duckdb":
             click.echo(
-                f"Error: Database file already exists: {db_target}.",
-                err=True,
+                f"Existing .env has DB_MODE={settings.database.mode} — "
+                "keeping it. The schema_description.md / queries.yaml "
+                "files describe the same tables your configured backend "
+                "serves; no local DuckDB mirror was created and .env was "
+                "not modified."
             )
-            sys.exit(1)
-        db_size_mb = db_target.stat().st_size / (1024 * 1024)
-        written.append(f"{db_target.name} ({db_size_mb:.2f} MB)")
+        else:
+            from datasight.config import set_env_vars
+            from datasight.explore import build_persistent_duckdb
 
-        try:
-            rel_db = db_target.relative_to(Path(project_dir).resolve())
-            db_env_value = f"./{rel_db.as_posix()}"
-        except ValueError:
-            db_env_value = str(db_target)
+            assert db_target is not None  # set above when use_files is True
+            try:
+                build_persistent_duckdb(db_target, tables_info, overwrite=overwrite)
+            except FileExistsError:
+                # Preflight above rejects pre-existing DBs without --overwrite,
+                # so reaching here means the file appeared mid-run.
+                click.echo(
+                    f"Error: Database file already exists: {db_target}.",
+                    err=True,
+                )
+                sys.exit(1)
+            db_size_mb = db_target.stat().st_size / (1024 * 1024)
+            written.append(f"{db_target.name} ({db_size_mb:.2f} MB)")
 
-        env_path = Path(project_dir) / ".env"
-        existed = env_path.exists()
-        set_env_vars(env_path, {"DB_MODE": "duckdb", "DB_PATH": db_env_value})
-        written.append(".env (updated)" if existed else ".env")
+            try:
+                rel_db = db_target.relative_to(Path(project_dir).resolve())
+                db_env_value = f"./{rel_db.as_posix()}"
+            except ValueError:
+                db_env_value = str(db_target)
+
+            env_path = Path(project_dir) / ".env"
+            existed = env_path.exists()
+            set_env_vars(env_path, {"DB_MODE": "duckdb", "DB_PATH": db_env_value})
+            written.append(".env (updated)" if existed else ".env")
 
     click.echo()
     if written:

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -1521,6 +1521,9 @@ def config_show():
             click.echo(f"  db:   {settings.database.postgres_database}")
     elif settings.database.mode == "flightsql":
         click.echo(f"  uri:  {settings.database.flight_uri}")
+    elif settings.database.mode == "spark":
+        click.echo(f"  remote: {settings.database.spark_remote}")
+        click.echo(f"  max result bytes: {settings.database.spark_max_result_bytes:,}")
 
 
 @cli.group(
@@ -4753,6 +4756,9 @@ def doctor(project_dir, output_format, output_path):
     elif settings.database.mode == "flightsql":
         db_ok = bool(settings.database.flight_uri)
         db_detail = settings.database.flight_uri
+    elif settings.database.mode == "spark":
+        db_ok = bool(settings.database.spark_remote)
+        db_detail = settings.database.spark_remote
     add_check("Database config", db_ok, db_detail or settings.database.mode)
 
     for name in ("schema_description.md", "queries.yaml"):

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -4256,6 +4256,9 @@ def inspect(files, output_format, output_path):
     temp views and all queries run on the cluster; otherwise an ephemeral
     in-memory DuckDB session is used.
     """
+    import time as _time
+
+    from loguru import logger as _logger
     from rich.console import Console
 
     from datasight.explore import create_files_session_for_settings
@@ -4263,9 +4266,19 @@ def inspect(files, output_format, output_path):
 
     db_settings = _current_db_settings_or_none()
 
+    async def _run_phase(name: str, coro):
+        _logger.info(f"[inspect] {name}…")
+        t0 = _time.perf_counter()
+        result = await coro
+        _logger.info(f"[inspect] {name} done in {_time.perf_counter() - t0:.1f}s")
+        return result
+
     async def _run_all():
         runner, tables_info = create_files_session_for_settings(list(files), db_settings)
-        tables = await introspect_schema(runner.run_sql, runner=runner)
+        tables = await _run_phase(
+            f"introspecting schema for {len(tables_info)} table(s)",
+            introspect_schema(runner.run_sql, runner=runner),
+        )
         schema_info = [
             {
                 "name": t.name,
@@ -4277,12 +4290,27 @@ def inspect(files, output_format, output_path):
             for t in tables
         ]
 
-        profile_data = await build_dataset_overview(schema_info, runner.run_sql)
-        quality_data = await build_quality_overview(schema_info, runner.run_sql)
-        measure_data = await build_measure_overview(schema_info, runner.run_sql, overrides=None)
-        dimension_data = await build_dimension_overview(schema_info, runner.run_sql)
-        trend_data = await build_trend_overview(schema_info, runner.run_sql, overrides=None)
-        recipe_list = await build_prompt_recipes(schema_info, runner.run_sql, overrides=None)
+        profile_data = await _run_phase(
+            "profiling tables", build_dataset_overview(schema_info, runner.run_sql)
+        )
+        quality_data = await _run_phase(
+            "running quality checks", build_quality_overview(schema_info, runner.run_sql)
+        )
+        measure_data = await _run_phase(
+            "discovering measures",
+            build_measure_overview(schema_info, runner.run_sql, overrides=None),
+        )
+        dimension_data = await _run_phase(
+            "discovering dimensions", build_dimension_overview(schema_info, runner.run_sql)
+        )
+        trend_data = await _run_phase(
+            "scanning for trends",
+            build_trend_overview(schema_info, runner.run_sql, overrides=None),
+        )
+        recipe_list = await _run_phase(
+            "building prompt recipes",
+            build_prompt_recipes(schema_info, runner.run_sql, overrides=None),
+        )
         recipes_data = [{"id": idx, **r} for idx, r in enumerate(recipe_list, start=1)]
 
         return {

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -95,13 +95,21 @@ def _current_db_settings_or_none():
     otherwise ``None`` (caller should fall back to plain DuckDB).
     """
     from dotenv import load_dotenv
+    from loguru import logger
 
     env_path = os.path.join(os.getcwd(), ".env")
     if not os.path.exists(env_path):
+        logger.info(
+            f"No .env found in {os.getcwd()} — file commands will use an "
+            "in-memory DuckDB session. Set DB_MODE in a .env to route "
+            "through a configured backend (e.g. Spark)."
+        )
         return None
     load_dotenv(env_path, override=False)
     load_global_env(override=False)
-    return Settings.from_env().database
+    db = Settings.from_env().database
+    logger.info(f"Loaded .env from {env_path} — DB_MODE={db.mode}")
+    return db
 
 
 def _validate_settings_for_llm(settings: Settings) -> None:

--- a/src/datasight/config.py
+++ b/src/datasight/config.py
@@ -181,6 +181,8 @@ def create_sql_runner_from_settings(
         if project_dir:
             db_path = str(Path(project_dir) / db_path)
 
+    logger.info(f"Database mode: {settings.mode} (dialect: {settings.sql_dialect})")
+
     runner = create_sql_runner(
         db_mode=settings.mode,
         db_path=db_path,

--- a/src/datasight/config.py
+++ b/src/datasight/config.py
@@ -16,10 +16,12 @@ from loguru import logger
 
 from datasight.exceptions import ConfigurationError
 from datasight.runner import (
+    DEFAULT_SPARK_MAX_RESULT_BYTES,
     CachingSqlRunner,
     DuckDBRunner,
     FlightSqlRunner,
     PostgresRunner,
+    SparkConnectRunner,
     SQLiteRunner,
     SqlRunner,
 )
@@ -83,19 +85,25 @@ def create_sql_runner(
     postgres_password: str = "",
     postgres_url: str = "",
     postgres_sslmode: str = "prefer",
+    spark_remote: str = "sc://localhost:15002",
+    spark_token: str | None = None,
+    spark_max_result_bytes: int = DEFAULT_SPARK_MAX_RESULT_BYTES,
 ) -> SqlRunner:
     """Create the appropriate SqlRunner based on db_mode.
 
     Parameters
     ----------
     db_mode:
-        Database mode: "duckdb", "sqlite", "postgres", or "flightsql".
+        Database mode: "duckdb", "sqlite", "postgres", "flightsql", or "spark".
     db_path:
         Path to database file (for duckdb and sqlite modes).
     flight_*:
         Flight SQL connection parameters.
     postgres_*:
         PostgreSQL connection parameters.
+    spark_*:
+        Spark Connect parameters. ``spark_max_result_bytes`` caps how much
+        Arrow data is materialized client-side before truncation.
 
     Returns
     -------
@@ -138,6 +146,13 @@ def create_sql_runner(
                 raise ConfigurationError("DB_PATH is required for DuckDB mode")
             logger.info(f"Opening local DuckDB: {db_path}")
             return DuckDBRunner(database_path=db_path)
+        case "spark":
+            logger.info(f"Connecting to Spark Connect: {spark_remote}")
+            return SparkConnectRunner(
+                remote=spark_remote,
+                token=spark_token,
+                max_result_bytes=spark_max_result_bytes,
+            )
         case _:
             raise ConfigurationError(f"Invalid database mode: {db_mode}")
 
@@ -180,6 +195,9 @@ def create_sql_runner_from_settings(
         postgres_password=settings.postgres_password,
         postgres_url=settings.postgres_url,
         postgres_sslmode=settings.postgres_sslmode,
+        spark_remote=settings.spark_remote,
+        spark_token=settings.spark_token,
+        spark_max_result_bytes=settings.spark_max_result_bytes,
     )
     if sql_cache_max_bytes > 0:
         runner = CachingSqlRunner(runner, max_bytes=sql_cache_max_bytes)

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -3,19 +3,28 @@ Explore functionality for datasight.
 
 Provides utilities for quickly exploring CSV and Parquet files without
 setting up a full project. Creates ephemeral DuckDB sessions with views
-pointing to user files.
+pointing to user files, or routes through Spark Connect when the
+current project is configured with ``DB_MODE=spark``.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import duckdb
 from loguru import logger
 
 from datasight.exceptions import ConfigurationError
-from datasight.runner import EphemeralDuckDBRunner
+from datasight.runner import (
+    DEFAULT_SPARK_MAX_RESULT_BYTES,
+    EphemeralDuckDBRunner,
+    SparkConnectRunner,
+)
+
+if TYPE_CHECKING:
+    from datasight.settings import DatabaseSettings
 
 
 def detect_file_type(path: str) -> str | None:
@@ -359,6 +368,142 @@ def create_ephemeral_session(file_paths: list[str]) -> tuple[EphemeralDuckDBRunn
 
     runner = EphemeralDuckDBRunner(conn)
     return runner, tables_info
+
+
+_SPARK_SUPPORTED_TYPES = {"parquet", "hive_parquet", "csv", "csv_dir"}
+
+
+def create_spark_files_session(
+    file_paths: list[str],
+    *,
+    spark_remote: str,
+    spark_token: str | None = None,
+    spark_max_result_bytes: int = DEFAULT_SPARK_MAX_RESULT_BYTES,
+    spark: Any = None,
+) -> tuple[SparkConnectRunner, list[dict]]:
+    """Register parquet/CSV files as Spark temp views on a Spark Connect session.
+
+    Each file or directory becomes a temp view that the rest of datasight
+    (schema introspection, the agent, the web UI) can query by name. The
+    paths must be reachable by the Spark workers at the *same* absolute
+    path — Spark does not upload local files to the cluster.
+
+    Parameters
+    ----------
+    file_paths:
+        Paths to Parquet/CSV files or directories. SQLite and DuckDB files
+        are not supported on this path.
+    spark_remote, spark_token, spark_max_result_bytes:
+        Forwarded to ``SparkConnectRunner``.
+    spark:
+        Optional pre-built Spark session (used by tests to inject a fake).
+
+    Raises
+    ------
+    ConfigurationError
+        If a path doesn't exist, isn't absolute-resolvable, or is a file
+        type Spark can't read (duckdb/sqlite).
+    """
+    if not file_paths:
+        raise ConfigurationError("No file paths provided")
+
+    resolved: list[tuple[str, str]] = []
+    for p in file_paths:
+        abs_path = str(Path(p).resolve())
+        ftype = detect_file_type(abs_path)
+        if ftype is None:
+            raise ConfigurationError(f"Unrecognized or missing file: {p}")
+        if ftype not in _SPARK_SUPPORTED_TYPES:
+            raise ConfigurationError(
+                f"Spark backend cannot read {ftype!r} files ({p}). "
+                "Use DuckDB mode, or re-export to Parquet."
+            )
+        resolved.append((abs_path, ftype))
+
+    runner = SparkConnectRunner(
+        remote=spark_remote,
+        token=spark_token,
+        max_result_bytes=spark_max_result_bytes,
+        spark=spark,
+    )
+
+    tables_info: list[dict] = []
+    existing_names: set[str] = set()
+    errors: list[str] = []
+    for path, file_type in resolved:
+        p = Path(path)
+        base_name = p.stem if p.is_file() else p.name
+        view_name = sanitize_table_name(base_name)
+        if view_name in existing_names:
+            counter = 2
+            while f"{view_name}_{counter}" in existing_names:
+                counter += 1
+            view_name = f"{view_name}_{counter}"
+        try:
+            _register_spark_view(runner._spark, view_name, path, file_type)
+            existing_names.add(view_name)
+            tables_info.append({"name": view_name, "path": path, "type": file_type})
+            logger.info(f"Registered Spark temp view '{view_name}' from {file_type}: {path}")
+        except Exception as e:
+            errors.append(f"Failed to register {path}: {e}")
+            logger.warning(f"Failed to register Spark view for {path}: {e}")
+
+    if not tables_info:
+        runner.close()
+        msg = "No valid data files registered with Spark."
+        if errors:
+            msg += " " + " ".join(errors)
+        raise ConfigurationError(msg)
+
+    return runner, tables_info
+
+
+def _register_spark_view(spark: Any, view_name: str, path: str, file_type: str) -> None:
+    """Read ``path`` with Spark and expose it as a temp view.
+
+    ``hive_parquet`` and ``csv_dir`` point at directories; Spark autodetects
+    the partitioning. Plain parquet / csv are single files.
+    """
+    reader = spark.read
+    if file_type in ("parquet", "hive_parquet"):
+        df = reader.parquet(path)
+    elif file_type in ("csv", "csv_dir"):
+        df = reader.option("header", "true").option("inferSchema", "true").csv(path)
+    else:
+        raise ConfigurationError(f"Unsupported Spark file type: {file_type}")
+    df.createOrReplaceTempView(view_name)
+
+
+def create_files_session_for_settings(
+    file_paths: list[str],
+    settings: DatabaseSettings | None = None,
+) -> tuple[Any, list[dict]]:
+    """Pick a file-session backend based on the project's configured DB_MODE.
+
+    - ``spark``: register files as temp views on a SparkConnectRunner so
+      the cluster does the reading — cheap to set up on HPC where the
+      files already live on a shared filesystem.
+    - ``duckdb`` / ``sqlite`` / no settings: local ephemeral DuckDB session
+      (the long-standing default).
+    - ``postgres`` / ``flightsql``: fall back to DuckDB with a warning —
+      those backends can't read arbitrary local files.
+    """
+    if settings is None or settings.mode in ("duckdb", "sqlite"):
+        return create_ephemeral_session(file_paths)
+    if settings.mode == "spark":
+        logger.info(f"File inspection routed through Spark Connect: {settings.spark_remote}")
+        return create_spark_files_session(
+            file_paths,
+            spark_remote=settings.spark_remote,
+            spark_token=settings.spark_token,
+            spark_max_result_bytes=settings.spark_max_result_bytes,
+        )
+    logger.warning(
+        f"DB_MODE={settings.mode!r} cannot read local files directly — "
+        "file inspection will use a local DuckDB session, independent of "
+        "the configured database."
+    )
+    return create_ephemeral_session(file_paths)
 
 
 def add_files_to_connection(

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -488,10 +488,17 @@ def create_files_session_for_settings(
     - ``postgres`` / ``flightsql``: fall back to DuckDB with a warning —
       those backends can't read arbitrary local files.
     """
-    if settings is None or settings.mode in ("duckdb", "sqlite"):
+    if settings is None:
+        logger.info("File session: in-memory DuckDB (no settings / no .env)")
+        return create_ephemeral_session(file_paths)
+    if settings.mode in ("duckdb", "sqlite"):
+        logger.info(f"File session: in-memory DuckDB (DB_MODE={settings.mode})")
         return create_ephemeral_session(file_paths)
     if settings.mode == "spark":
-        logger.info(f"File inspection routed through Spark Connect: {settings.spark_remote}")
+        logger.info(
+            f"File session: Spark Connect at {settings.spark_remote} "
+            f"(DB_MODE=spark, byte cap {settings.spark_max_result_bytes:,})"
+        )
         return create_spark_files_session(
             file_paths,
             spark_remote=settings.spark_remote,

--- a/src/datasight/generate.py
+++ b/src/datasight/generate.py
@@ -82,9 +82,13 @@ async def sample_enum_columns(run_sql: RunSql, tables: list[TableInfo]) -> str:
                 n_distinct = _extract_scalar(count_result, "n")
                 if n_distinct < 1 or n_distinct > 50:
                     continue
+                # ORDER BY the output alias (not the pre-DISTINCT column) so
+                # this parses under Spark's ANSI analyzer, which requires an
+                # ORDER BY after DISTINCT to reference output-list columns.
+                # DuckDB and Postgres accept either form.
                 sample_result = await run_sql(
                     f"SELECT DISTINCT {col_name} AS val FROM {table_name} "
-                    f"WHERE {col_name} IS NOT NULL ORDER BY {col_name} LIMIT 20"
+                    f"WHERE {col_name} IS NOT NULL ORDER BY val LIMIT 20"
                 )
                 values = _extract_values(sample_result, "val")
                 if values:

--- a/src/datasight/prompts.py
+++ b/src/datasight/prompts.py
@@ -107,6 +107,27 @@ _DIALECT_HINTS: dict[str, str] = {
         "SQLite has no built-in regression aggregates — compute slope/intercept "
         "manually from AVG/SUM over (x - xbar)*(y - ybar) and (x - xbar)^2.\n"
     ),
+    "spark": (
+        "Use Spark SQL (HiveQL-compatible) syntax.\n"
+        "Spark dates: date_trunc('month', col), year(col), month(col), "
+        "to_date(col), date_format(col, 'yyyy-MM').\n"
+        "Spark regression: regr_slope(y, x), regr_intercept(y, x), "
+        "regr_r2(y, x), corr(y, x). Available as window functions.\n"
+        "## Multi-TB scale — read carefully\n"
+        "This database holds multi-terabyte tables. Every query must be "
+        "designed to return a small result, not scan the world:\n"
+        "- ALWAYS aggregate (GROUP BY, SUM, AVG, COUNT) rather than returning "
+        "raw rows. A bare SELECT on a fact table will scan TBs.\n"
+        "- NEVER write SELECT *. Project only the columns you need.\n"
+        "- ALWAYS include a tight WHERE on a partition column when one exists "
+        "(commonly a date / report_date / year column) so Spark can prune "
+        "partitions instead of scanning the full table.\n"
+        "- ALWAYS include LIMIT on any non-aggregated query (LIMIT 1000 or less "
+        "for previews).\n"
+        "- Results above ~100 MB will be truncated by the client and the user "
+        "will see a 'truncated' warning — the cure is more aggregation, not "
+        "a larger LIMIT.\n"
+    ),
 }
 
 

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -108,7 +108,10 @@ class DuckDBRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("DuckDBRunner is closed")
-        logger.info(f"DuckDB query: {_sql_preview(sql)}")
+        # Per-query logs at DEBUG: a single inspect / generate run can fire
+        # hundreds of these and they drown out genuinely interesting INFO
+        # output. Run with -v (or LOG_LEVEL=DEBUG) to surface them.
+        logger.debug(f"DuckDB query: {_sql_preview(sql)}")
         t0 = time.perf_counter()
         try:
             df = self._conn.execute(sql).fetchdf()
@@ -116,7 +119,7 @@ class DuckDBRunner:
             logger.debug(f"DuckDB query error: {e}\nSQL: {sql[:500]}")
             raise QueryError(str(e)) from e
         elapsed_ms = (time.perf_counter() - t0) * 1000
-        logger.info(
+        logger.debug(
             f"DuckDB returned {len(df)} rows, {len(df.columns)} cols in {elapsed_ms:.0f}ms"
         )
         return df
@@ -182,7 +185,10 @@ class EphemeralDuckDBRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("EphemeralDuckDBRunner is closed")
-        logger.info(f"DuckDB query: {_sql_preview(sql)}")
+        # Per-query logs at DEBUG: a single inspect / generate run can fire
+        # hundreds of these and they drown out genuinely interesting INFO
+        # output. Run with -v (or LOG_LEVEL=DEBUG) to surface them.
+        logger.debug(f"DuckDB query: {_sql_preview(sql)}")
         t0 = time.perf_counter()
         try:
             df = self._conn.execute(sql).fetchdf()
@@ -190,7 +196,7 @@ class EphemeralDuckDBRunner:
             logger.debug(f"DuckDB query error: {e}\nSQL: {sql[:500]}")
             raise QueryError(str(e)) from e
         elapsed_ms = (time.perf_counter() - t0) * 1000
-        logger.info(
+        logger.debug(
             f"DuckDB returned {len(df)} rows, {len(df.columns)} cols in {elapsed_ms:.0f}ms"
         )
         return df
@@ -459,13 +465,13 @@ class FlightSqlRunner:
         if self._conn is None:
             raise ConnectionError("FlightSqlRunner is closed")
         sql = sql.strip().rstrip(";")
-        logger.info(f"Flight SQL query: {sql[:200]}")
+        logger.debug(f"Flight SQL query: {sql[:200]}")
         try:
             cursor = self._conn.cursor()
             cursor.execute(sql)
             table = cursor.fetch_arrow_table()
             df = table.to_pandas()
-            logger.info(f"Flight SQL returned {len(df)} rows, {len(df.columns)} columns")
+            logger.debug(f"Flight SQL returned {len(df)} rows, {len(df.columns)} columns")
             return df
         except Exception as e:
             logger.debug(f"Flight SQL query error: {e}\nSQL: {sql[:500]}")
@@ -808,7 +814,7 @@ class SparkConnectRunner:
         import pyarrow as pa
 
         sql = sql.strip().rstrip(";")
-        logger.info(f"Spark SQL: {sql[:200]}")
+        logger.debug(f"Spark SQL: {sql[:200]}")
         try:
             sdf = self._spark.sql(sql)
             columns = list(getattr(sdf, "columns", []) or [])
@@ -867,7 +873,7 @@ class SparkConnectRunner:
                 f"Spark result truncated at {total_bytes:,} bytes ({len(df):,} rows returned)"
             )
         else:
-            logger.info(f"Spark returned {len(df)} rows, {len(df.columns)} columns")
+            logger.debug(f"Spark returned {len(df)} rows, {len(df.columns)} columns")
         return df
 
     async def run_sql(self, sql: str) -> pd.DataFrame:

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -515,6 +515,8 @@ class SparkConnectRunner:
             try:
                 self._spark.stop()
             except Exception:
+                # Best-effort cleanup: session may already be dead, and a
+                # failure here would mask the real error from the caller.
                 pass
             self._spark = None
 
@@ -534,26 +536,23 @@ class SparkConnectRunner:
     def _iter_arrow_batches(spark: Any, sdf: Any):
         """Yield ``pyarrow.RecordBatch`` from a Spark DataFrame.
 
-        Prefers the Spark Connect client's streaming iterator so we can stop
-        before materializing the full result. Falls back to ``toArrow()`` /
-        ``toPandas()`` if the streaming API isn't exposed.
+        Uses the Spark Connect client's streaming iterator so we can stop
+        before materializing the full result. Falling back to ``toArrow()`` /
+        ``toPandas()`` would defeat the byte cap (they fully materialize the
+        result client-side), so we require the streaming API and fail fast
+        otherwise. The API is public on pyspark 3.5+, which is our minimum.
         """
-        import pyarrow as pa
-
         client = getattr(spark, "client", None)
         plan = getattr(sdf, "_plan", None)
-        if client is not None and plan is not None and hasattr(client, "to_table_as_iterator"):
-            for table, _ in client.to_table_as_iterator(plan, observations={}):
-                for batch in table.to_batches():
-                    yield batch
-            return
-        if hasattr(sdf, "toArrow"):
-            table = sdf.toArrow()
+        if client is None or plan is None or not hasattr(client, "to_table_as_iterator"):
+            raise QueryError(
+                "Spark Connect streaming API (client.to_table_as_iterator) is "
+                "unavailable — pyspark>=3.5 is required. Upgrade pyspark so "
+                "the client-side byte cap remains effective."
+            )
+        for table, _ in client.to_table_as_iterator(plan, observations={}):
             for batch in table.to_batches():
                 yield batch
-            return
-        df = sdf.toPandas()
-        yield pa.RecordBatch.from_pandas(df)
 
     def _execute(self, sql: str) -> pd.DataFrame:
         if self._spark is None:
@@ -564,6 +563,7 @@ class SparkConnectRunner:
         logger.info(f"Spark SQL: {sql[:200]}")
         try:
             sdf = self._spark.sql(sql)
+            columns = list(getattr(sdf, "columns", []) or [])
             iterator = self._iter_arrow_batches(self._spark, sdf)
             batches: list[pa.RecordBatch] = []
             schema: pa.Schema | None = None
@@ -571,26 +571,41 @@ class SparkConnectRunner:
             truncated = False
             try:
                 for batch in iterator:
+                    # Check the cap *before* appending so the returned result
+                    # is a true upper bound (cap=0 → zero-row truncated result).
+                    if total_bytes + batch.nbytes > self._max_result_bytes:
+                        truncated = True
+                        break
                     if schema is None:
                         schema = batch.schema
                     batches.append(batch)
                     total_bytes += batch.nbytes
-                    if total_bytes > self._max_result_bytes:
-                        truncated = True
-                        break
             finally:
                 close = getattr(iterator, "close", None)
                 if close is not None:
                     try:
                         close()
                     except Exception:
+                        # Iterator cleanup is best-effort; don't mask any
+                        # primary exception raised during iteration.
                         pass
+        except QueryError:
+            raise
         except Exception as e:
             logger.debug(f"Spark SQL error: {e}\nSQL: {sql[:500]}")
             raise QueryError(str(e)) from e
 
         if not batches:
-            return pd.DataFrame()
+            # No data, but preserve the column list so downstream UI and
+            # schema logic still sees the shape of the result.
+            df = pd.DataFrame(columns=columns)
+            if truncated:
+                df.attrs["truncated"] = True
+                df.attrs["truncation_reason"] = (
+                    f"Result exceeded {self._max_result_bytes:,} bytes before any "
+                    "batch could be returned. Add aggregation or a tighter LIMIT."
+                )
+            return df
         table = pa.Table.from_batches(batches, schema=schema)
         df = table.to_pandas()
         if truncated:
@@ -625,6 +640,8 @@ class SparkConnectRunner:
                 try:
                     add_tag(tag)
                 except Exception:
+                    # Tag API is best-effort: without it we lose server-side
+                    # cancellation on timeout, but the query still runs.
                     pass
             try:
                 return self._execute(sql)
@@ -633,6 +650,7 @@ class SparkConnectRunner:
                     try:
                         remove_tag(tag)
                     except Exception:
+                        # Ancillary cleanup; never mask the primary result.
                         pass
 
         try:

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -506,9 +506,58 @@ class SparkConnectRunner:
                 builder = builder.config("spark.connect.client.token", self._token)
             self._spark = builder.getOrCreate()
             logger.info(f"Connected to Spark Connect: {self._remote}")
+            self._log_session_info(self._spark)
         except Exception as e:
             logger.exception("Spark Connect connection error")
             raise ConnectionError(f"Failed to connect to Spark Connect: {e}") from e
+
+    @staticmethod
+    def _log_session_info(spark: Any) -> None:
+        """Log Spark session details so users can verify they're distributed.
+
+        Surfaces version, master URL, app id, parallelism, and executor
+        configuration. When ``spark.master`` starts with ``local`` the Connect
+        server is running all work in one JVM — a common "why is only one
+        node busy" cause — so we log a loud warning pointing at the fix.
+        """
+        info: dict[str, Any] = {"version": getattr(spark, "version", None)}
+        keys = [
+            "spark.master",
+            "spark.app.name",
+            "spark.app.id",
+            "spark.default.parallelism",
+            "spark.sql.shuffle.partitions",
+            "spark.executor.instances",
+            "spark.executor.cores",
+            "spark.executor.memory",
+            "spark.dynamicAllocation.enabled",
+            "spark.dynamicAllocation.minExecutors",
+            "spark.dynamicAllocation.maxExecutors",
+        ]
+        conf = getattr(spark, "conf", None)
+        for key in keys:
+            if conf is None:
+                info[key] = None
+                continue
+            try:
+                info[key] = conf.get(key)
+            except Exception:
+                # conf.get raises on unset keys in some Spark versions;
+                # treat that as "not configured" rather than failing connect.
+                info[key] = None
+
+        lines = [f"  {k:<42} = {v}" for k, v in info.items()]
+        logger.info("Spark session info:\n" + "\n".join(lines))
+
+        master = str(info.get("spark.master") or "")
+        if master.startswith("local"):
+            logger.warning(
+                f"Spark master is '{master}' — the Connect server is running "
+                "all work in one JVM on the driver node. If you expected "
+                "distributed execution, set spark.master on the Connect "
+                "server (e.g. spark://master:7077, yarn, or k8s://...) "
+                "and restart it."
+            )
 
     def close(self) -> None:
         if self._spark is not None:

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -530,6 +530,7 @@ class SparkConnectRunner:
             self._spark = builder.getOrCreate()
             self._probe_connection(self._spark, self._remote)
             logger.info(f"Connected to Spark Connect: {self._remote}")
+            self._enable_ansi_quoted_identifiers(self._spark)
             self._log_session_info(self._spark)
         except ConnectionError:
             raise
@@ -575,6 +576,29 @@ class SparkConnectRunner:
         if status == "error":
             raise ConnectionError(
                 f"Spark Connect server at {remote} rejected the handshake: {payload}"
+            )
+
+    @staticmethod
+    def _enable_ansi_quoted_identifiers(spark: Any) -> None:
+        """Make Spark accept ``"name"`` as an identifier, not a string literal.
+
+        Spark's default SQL parser treats double-quoted text as a string
+        literal (it expects backticks for quoted identifiers). The rest
+        of datasight — and the SQL the LLM agent writes — uses the SQL
+        standard ``"identifier"`` form, which Spark rejects with
+        PARSE_SYNTAX_ERROR. Setting this session-level config flips
+        Spark's behavior to the standard interpretation. Available
+        on Spark 3.4+; ANSI mode (default in Spark 4.0) must be on.
+        """
+        key = "spark.sql.ansi.double_quoted_identifiers"
+        try:
+            spark.conf.set(key, "true")
+            logger.info(f"Set {key}=true so Spark accepts SQL-standard quoted identifiers")
+        except Exception as e:
+            logger.warning(
+                f"Could not set {key}: {e}. Queries that use double-quoted "
+                "identifiers may fail. Workaround: enable ANSI mode on the "
+                "Connect server, or upgrade Spark to 3.4+."
             )
 
     @staticmethod

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
@@ -35,6 +36,14 @@ DEFAULT_SPARK_MAX_RESULT_BYTES: int = 100 * 1024 * 1024
 
 # Type alias for async SQL execution function
 RunSql = Callable[[str], Awaitable[pd.DataFrame]]
+
+
+def _sql_preview(sql: str, max_len: int = 200) -> str:
+    """Collapse whitespace and truncate so a SQL log line fits one row."""
+    one_line = " ".join(sql.split())
+    if len(one_line) <= max_len:
+        return one_line
+    return one_line[:max_len] + "…"
 
 
 class SqlRunner(Protocol):
@@ -99,11 +108,18 @@ class DuckDBRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("DuckDBRunner is closed")
+        logger.info(f"DuckDB query: {_sql_preview(sql)}")
+        t0 = time.perf_counter()
         try:
-            return self._conn.execute(sql).fetchdf()
+            df = self._conn.execute(sql).fetchdf()
         except duckdb.Error as e:
             logger.debug(f"DuckDB query error: {e}\nSQL: {sql[:500]}")
             raise QueryError(str(e)) from e
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        logger.info(
+            f"DuckDB returned {len(df)} rows, {len(df.columns)} cols in {elapsed_ms:.0f}ms"
+        )
+        return df
 
     async def run_sql(self, sql: str) -> pd.DataFrame:
         """Execute SQL asynchronously with timeout."""
@@ -166,11 +182,18 @@ class EphemeralDuckDBRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("EphemeralDuckDBRunner is closed")
+        logger.info(f"DuckDB query: {_sql_preview(sql)}")
+        t0 = time.perf_counter()
         try:
-            return self._conn.execute(sql).fetchdf()
+            df = self._conn.execute(sql).fetchdf()
         except duckdb.Error as e:
             logger.debug(f"DuckDB query error: {e}\nSQL: {sql[:500]}")
             raise QueryError(str(e)) from e
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        logger.info(
+            f"DuckDB returned {len(df)} rows, {len(df.columns)} cols in {elapsed_ms:.0f}ms"
+        )
+        return df
 
     async def run_sql(self, sql: str) -> pd.DataFrame:
         """Execute SQL asynchronously with timeout."""

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -532,6 +532,40 @@ class SparkConnectRunner:
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
 
+    def get_table_names(self) -> list[str]:
+        """List tables via ``spark.catalog.listTables()``.
+
+        Spark's ``SHOW TABLES`` returns ``namespace | tableName | isTemporary``,
+        so the generic first-column strategy in ``schema._get_table_names``
+        would pick up database names instead of table names. The catalog
+        API returns structured ``Table`` objects with a stable ``.name``.
+        """
+        if self._spark is None:
+            raise ConnectionError("SparkConnectRunner is closed")
+        try:
+            tables = self._spark.catalog.listTables()
+        except Exception as e:
+            logger.debug(f"Spark catalog.listTables error: {e}")
+            raise QueryError(f"Failed to list Spark tables: {e}") from e
+        names: list[str] = []
+        for t in tables:
+            name = getattr(t, "name", None)
+            if name:
+                names.append(str(name))
+        return names
+
+    async def get_row_count(self, table: str) -> int | None:  # noqa: ARG002
+        """Skip row counts for Spark.
+
+        A naive ``SELECT COUNT(*)`` on a multi-TB partitioned table kicks
+        off a full cluster job at introspection time, which is exactly
+        the foot-gun the byte-cap design exists to prevent. Return None
+        so the schema prompt simply omits row counts for Spark tables.
+        Statistics from ``DESCRIBE TABLE EXTENDED`` could be wired in
+        here later if we need approximate counts.
+        """
+        return None
+
     @staticmethod
     def _iter_arrow_batches(spark: Any, sdf: Any):
         """Yield ``pyarrow.RecordBatch`` from a Spark DataFrame.

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -21,6 +21,7 @@ import pandas as pd
 from loguru import logger
 
 from datasight.exceptions import ConnectionError, QueryError, QueryTimeoutError
+from datasight.schema_types import ColumnInfo
 
 # Default timeout for SQL queries (seconds). Can be overridden per-runner.
 DEFAULT_QUERY_TIMEOUT: float = 120.0
@@ -755,7 +756,7 @@ class SparkConnectRunner:
         """
         return None
 
-    def get_columns(self, table: str) -> list[Any]:
+    def get_columns(self, table: str) -> list[ColumnInfo]:
         """Return ``ColumnInfo`` for ``table`` via ``spark.catalog.listColumns()``.
 
         The generic SQL probes in ``schema._get_columns`` (DESCRIBE
@@ -764,8 +765,6 @@ class SparkConnectRunner:
         PARSE_SYNTAX_ERROR or TABLE_OR_VIEW_NOT_FOUND. Spark's catalog
         API returns the same information without any SQL.
         """
-        from datasight.schema import ColumnInfo
-
         if self._spark is None:
             raise ConnectionError("SparkConnectRunner is closed")
         try:
@@ -797,16 +796,32 @@ class SparkConnectRunner:
         per Arrow batch; we skip the schema and flatten each table to its
         underlying batches. pyspark 4.0 also requires a ``Plan`` protobuf, so
         we convert the DataFrame's ``LogicalPlan`` with ``to_proto(client)``.
+
+        Wraps the underlying gRPC iterator in a try/finally so early-exit on
+        truncation/timeout releases the server stream instead of leaving it
+        open until GC.
         """
         import pyarrow as pa
 
         client = spark.client
         plan_proto = sdf._plan.to_proto(client)
-        for item in client.to_table_as_iterator(plan_proto, observations={}):
-            if not isinstance(item, pa.Table):
-                continue
-            for batch in item.to_batches():
-                yield batch
+        table_iter = client.to_table_as_iterator(plan_proto, observations={})
+        try:
+            for item in table_iter:
+                if not isinstance(item, pa.Table):
+                    continue
+                for batch in item.to_batches():
+                    yield batch
+        finally:
+            for name in ("close", "cancel"):
+                method = getattr(table_iter, name, None)
+                if callable(method):
+                    try:
+                        method()
+                    except Exception:
+                        # Best-effort cleanup; do not mask iteration errors.
+                        pass
+                    break
 
     def _execute(self, sql: str) -> pd.DataFrame:
         if self._spark is None:
@@ -907,21 +922,40 @@ class SparkConnectRunner:
                         # Ancillary cleanup; never mask the primary result.
                         pass
 
+        # Run on a dedicated single-worker executor rather than the shared
+        # asyncio thread pool. pyspark Connect stores tag state per-thread
+        # (ThreadLocal), so reusing a worker thread that was mid-query when
+        # we timed out could leak tags or other session state into the next
+        # query. A dedicated executor isolates this query's thread entirely
+        # — on timeout we call shutdown(wait=False) so the stuck thread is
+        # not recycled, and it exits naturally once the gRPC call returns
+        # (typically via the interruptTag below).
+        import concurrent.futures
+
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="spark-query"
+        )
+        loop = asyncio.get_running_loop()
         try:
-            return await asyncio.wait_for(
-                asyncio.to_thread(_exec),
-                timeout=self._query_timeout,
-            )
-        except TimeoutError:
-            if interrupt_tag is not None:
-                try:
-                    interrupt_tag(tag)
-                except Exception:
-                    logger.warning("Failed to interrupt Spark query on timeout")
-            raise QueryTimeoutError(
-                f"Query timed out after {self._query_timeout:.0f}s. "
-                "Try a simpler query or add filters to reduce the result set."
-            )
+            future = loop.run_in_executor(executor, _exec)
+            try:
+                return await asyncio.wait_for(future, timeout=self._query_timeout)
+            except TimeoutError:
+                if interrupt_tag is not None:
+                    try:
+                        interrupt_tag(tag)
+                    except Exception:
+                        logger.warning("Failed to interrupt Spark query on timeout")
+                raise QueryTimeoutError(
+                    f"Query timed out after {self._query_timeout:.0f}s. "
+                    "Try a simpler query or add filters to reduce the result set."
+                )
+        finally:
+            # wait=False: if the worker thread is still blocked on a gRPC
+            # call, do not block shutdown. The thread will exit after the
+            # call returns (and _exec's finally clears the tag). The key
+            # guarantee is that this thread never serves another query.
+            executor.shutdown(wait=False)
 
 
 class CachingSqlRunner:

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -590,7 +590,7 @@ class SparkConnectRunner:
         Spark's behavior to the standard interpretation. Available
         on Spark 3.4+; ANSI mode (default in Spark 4.0) must be on.
         """
-        key = "spark.sql.ansi.double_quoted_identifiers"
+        key = "spark.sql.ansi.doubleQuotedIdentifiers"
         try:
             spark.conf.set(key, "true")
             logger.info(f"Set {key}=true so Spark accepts SQL-standard quoted identifiers")
@@ -785,19 +785,21 @@ class SparkConnectRunner:
         Uses the Spark Connect client's streaming iterator so we can stop
         before materializing the full result. Falling back to ``toArrow()`` /
         ``toPandas()`` would defeat the byte cap (they fully materialize the
-        result client-side), so we require the streaming API and fail fast
-        otherwise. The API is public on pyspark 3.5+, which is our minimum.
+        result client-side).
+
+        The iterator yields a ``StructType`` schema first, then one ``pa.Table``
+        per Arrow batch; we skip the schema and flatten each table to its
+        underlying batches. pyspark 4.0 also requires a ``Plan`` protobuf, so
+        we convert the DataFrame's ``LogicalPlan`` with ``to_proto(client)``.
         """
-        client = getattr(spark, "client", None)
-        plan = getattr(sdf, "_plan", None)
-        if client is None or plan is None or not hasattr(client, "to_table_as_iterator"):
-            raise QueryError(
-                "Spark Connect streaming API (client.to_table_as_iterator) is "
-                "unavailable — pyspark>=3.5 is required. Upgrade pyspark so "
-                "the client-side byte cap remains effective."
-            )
-        for table, _ in client.to_table_as_iterator(plan, observations={}):
-            for batch in table.to_batches():
+        import pyarrow as pa
+
+        client = spark.client
+        plan_proto = sdf._plan.to_proto(client)
+        for item in client.to_table_as_iterator(plan_proto, observations={}):
+            if not isinstance(item, pa.Table):
+                continue
+            for batch in item.to_batches():
                 yield batch
 
     def _execute(self, sql: str) -> pd.DataFrame:

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -542,35 +542,79 @@ class SparkConnectRunner:
         configuration. When ``spark.master`` starts with ``local`` the Connect
         server is running all work in one JVM — a common "why is only one
         node busy" cause — so we log a loud warning pointing at the fix.
-        """
-        info: dict[str, Any] = {"version": getattr(spark, "version", None)}
-        keys = [
-            "spark.master",
-            "spark.app.name",
-            "spark.app.id",
-            "spark.default.parallelism",
-            "spark.sql.shuffle.partitions",
-            "spark.executor.instances",
-            "spark.executor.cores",
-            "spark.executor.memory",
-            "spark.dynamicAllocation.enabled",
-            "spark.dynamicAllocation.minExecutors",
-            "spark.dynamicAllocation.maxExecutors",
-        ]
-        conf = getattr(spark, "conf", None)
-        for key in keys:
-            if conf is None:
-                info[key] = None
-                continue
-            try:
-                info[key] = conf.get(key)
-            except Exception:
-                # conf.get raises on unset keys in some Spark versions;
-                # treat that as "not configured" rather than failing connect.
-                info[key] = None
 
-        lines = [f"  {k:<42} = {v}" for k, v in info.items()]
-        logger.info("Spark session info:\n" + "\n".join(lines))
+        Each property and config is fetched via a synchronous gRPC call
+        to the Connect server, so we log per-key progress (in case one
+        hangs) and time-bound the whole probe so a slow cluster cannot
+        freeze the CLI. If the probe times out, the connection is still
+        usable; only the diagnostics are skipped. Runs on a daemon thread
+        so a hung gRPC call doesn't keep the process alive.
+        """
+        import queue
+        import threading
+
+        logger.info("Fetching Spark session info (one gRPC call per property)…")
+
+        def _gather() -> dict[str, Any]:
+            info: dict[str, Any] = {}
+            try:
+                info["version"] = getattr(spark, "version", None)
+                logger.info(f"  spark.version = {info['version']}")
+            except Exception as e:
+                info["version"] = None
+                logger.info(f"  spark.version unavailable: {e}")
+
+            keys = [
+                "spark.master",
+                "spark.app.name",
+                "spark.app.id",
+                "spark.default.parallelism",
+                "spark.sql.shuffle.partitions",
+                "spark.executor.instances",
+                "spark.executor.cores",
+                "spark.executor.memory",
+                "spark.dynamicAllocation.enabled",
+                "spark.dynamicAllocation.minExecutors",
+                "spark.dynamicAllocation.maxExecutors",
+            ]
+            conf = getattr(spark, "conf", None)
+            for key in keys:
+                if conf is None:
+                    info[key] = None
+                    continue
+                try:
+                    info[key] = conf.get(key)
+                except Exception:
+                    # conf.get raises on unset keys in some Spark versions;
+                    # treat that as "not configured" rather than failing.
+                    info[key] = None
+                logger.info(f"  {key} = {info[key]}")
+            return info
+
+        result_q: queue.Queue = queue.Queue(maxsize=1)
+
+        def _runner() -> None:
+            try:
+                result_q.put(("ok", _gather()))
+            except Exception as e:
+                result_q.put(("error", e))
+
+        # Daemon thread: if the gRPC calls hang forever the process can
+        # still exit cleanly when the rest of datasight finishes.
+        threading.Thread(target=_runner, daemon=True).start()
+        try:
+            status, payload = result_q.get(timeout=30.0)
+        except queue.Empty:
+            logger.warning(
+                "Spark session-info probe timed out after 30s — the Connect "
+                "server is responding slowly. Skipping the diagnostic block; "
+                "the connection itself should still be usable."
+            )
+            return
+        if status == "error":
+            logger.warning(f"Spark session-info probe failed: {payload}")
+            return
+        info: dict[str, Any] = payload
 
         master = str(info.get("spark.master") or "")
         if master.startswith("local"):

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -2,16 +2,18 @@
 SQL runners for datasight.
 
 Provides a common async interface for executing SQL queries against local
-DuckDB files, remote Flight SQL servers, PostgreSQL, or SQLite databases.
+DuckDB files, remote Flight SQL servers, PostgreSQL, SQLite databases, or
+Apache Spark via Spark Connect.
 """
 
 from __future__ import annotations
 
 import asyncio
 import sqlite3
+import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
-from typing import Protocol
+from typing import Any, Protocol
 
 import duckdb
 import pandas as pd
@@ -24,6 +26,12 @@ DEFAULT_QUERY_TIMEOUT: float = 120.0
 
 # Default SQL result cache size (1 GiB). 0 disables caching.
 DEFAULT_SQL_CACHE_MAX_BYTES: int = 1 << 30
+
+# Default byte cap for Spark Connect results (100 MiB on the wire).
+# Spark sits in front of multi-TB datasets, so the client cannot afford to
+# materialize an unbounded result. This protects the FastAPI process from
+# OOMing when the agent forgets to aggregate.
+DEFAULT_SPARK_MAX_RESULT_BYTES: int = 100 * 1024 * 1024
 
 # Type alias for async SQL execution function
 RunSql = Callable[[str], Awaitable[pd.DataFrame]]
@@ -450,6 +458,196 @@ class FlightSqlRunner:
         except TimeoutError:
             raise QueryTimeoutError(
                 f"Query timed out after {self.timeout:.0f}s. "
+                "Try a simpler query or add filters to reduce the result set."
+            )
+
+
+class SparkConnectRunner:
+    """Execute SQL against an Apache Spark cluster via Spark Connect.
+
+    Streams Arrow batches from the server and stops once the accumulated
+    result exceeds ``max_result_bytes``. The returned DataFrame carries
+    ``df.attrs['truncated'] = True`` and ``df.attrs['truncation_reason']``
+    when truncation occurred so the UI can surface that to the user.
+
+    Cancellation on timeout uses Spark Connect's tag-based interrupt API
+    (``addTag`` / ``interruptTag``), which actually frees cluster resources
+    rather than just abandoning the gRPC stream client-side.
+    """
+
+    def __init__(
+        self,
+        remote: str = "sc://localhost:15002",
+        *,
+        token: str | None = None,
+        max_result_bytes: int = DEFAULT_SPARK_MAX_RESULT_BYTES,
+        query_timeout: float = DEFAULT_QUERY_TIMEOUT,
+        spark: Any = None,
+    ):
+        self._remote = remote
+        self._token = token
+        self._max_result_bytes = max(0, int(max_result_bytes))
+        self._query_timeout = query_timeout
+        self._spark: Any = spark
+        if self._spark is None:
+            self._connect()
+
+    def _connect(self) -> None:
+        try:
+            from pyspark.sql import SparkSession  # ty: ignore[unresolved-import]
+        except ImportError as e:
+            raise ConnectionError(
+                "Spark Connect support requires pyspark. "
+                "Install with: pip install 'datasight[spark]'"
+            ) from e
+        try:
+            builder = SparkSession.builder.remote(self._remote)
+            if self._token:
+                builder = builder.config("spark.connect.client.token", self._token)
+            self._spark = builder.getOrCreate()
+            logger.info(f"Connected to Spark Connect: {self._remote}")
+        except Exception as e:
+            logger.exception("Spark Connect connection error")
+            raise ConnectionError(f"Failed to connect to Spark Connect: {e}") from e
+
+    def close(self) -> None:
+        if self._spark is not None:
+            try:
+                self._spark.stop()
+            except Exception:
+                pass
+            self._spark = None
+
+    def __enter__(self) -> "SparkConnectRunner":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "SparkConnectRunner":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    @staticmethod
+    def _iter_arrow_batches(spark: Any, sdf: Any):
+        """Yield ``pyarrow.RecordBatch`` from a Spark DataFrame.
+
+        Prefers the Spark Connect client's streaming iterator so we can stop
+        before materializing the full result. Falls back to ``toArrow()`` /
+        ``toPandas()`` if the streaming API isn't exposed.
+        """
+        import pyarrow as pa
+
+        client = getattr(spark, "client", None)
+        plan = getattr(sdf, "_plan", None)
+        if client is not None and plan is not None and hasattr(client, "to_table_as_iterator"):
+            for table, _ in client.to_table_as_iterator(plan, observations={}):
+                for batch in table.to_batches():
+                    yield batch
+            return
+        if hasattr(sdf, "toArrow"):
+            table = sdf.toArrow()
+            for batch in table.to_batches():
+                yield batch
+            return
+        df = sdf.toPandas()
+        yield pa.RecordBatch.from_pandas(df)
+
+    def _execute(self, sql: str) -> pd.DataFrame:
+        if self._spark is None:
+            raise ConnectionError("SparkConnectRunner is closed")
+        import pyarrow as pa
+
+        sql = sql.strip().rstrip(";")
+        logger.info(f"Spark SQL: {sql[:200]}")
+        try:
+            sdf = self._spark.sql(sql)
+            iterator = self._iter_arrow_batches(self._spark, sdf)
+            batches: list[pa.RecordBatch] = []
+            schema: pa.Schema | None = None
+            total_bytes = 0
+            truncated = False
+            try:
+                for batch in iterator:
+                    if schema is None:
+                        schema = batch.schema
+                    batches.append(batch)
+                    total_bytes += batch.nbytes
+                    if total_bytes > self._max_result_bytes:
+                        truncated = True
+                        break
+            finally:
+                close = getattr(iterator, "close", None)
+                if close is not None:
+                    try:
+                        close()
+                    except Exception:
+                        pass
+        except Exception as e:
+            logger.debug(f"Spark SQL error: {e}\nSQL: {sql[:500]}")
+            raise QueryError(str(e)) from e
+
+        if not batches:
+            return pd.DataFrame()
+        table = pa.Table.from_batches(batches, schema=schema)
+        df = table.to_pandas()
+        if truncated:
+            df.attrs["truncated"] = True
+            df.attrs["truncation_reason"] = (
+                f"Result exceeded {self._max_result_bytes:,} bytes "
+                f"({total_bytes:,} bytes streamed). Add aggregation or a tighter "
+                "LIMIT to your question to see the full answer."
+            )
+            logger.warning(
+                f"Spark result truncated at {total_bytes:,} bytes ({len(df):,} rows returned)"
+            )
+        else:
+            logger.info(f"Spark returned {len(df)} rows, {len(df.columns)} columns")
+        return df
+
+    async def run_sql(self, sql: str) -> pd.DataFrame:
+        if self._spark is None:
+            raise ConnectionError("SparkConnectRunner is closed")
+
+        # Tag every query so we can interrupt server-side on timeout. Without
+        # this, asyncio.wait_for cancels the local task but the gRPC call and
+        # underlying Spark job keep running and burning cluster resources.
+        tag = f"datasight-{uuid.uuid4().hex}"
+        spark = self._spark
+        add_tag = getattr(spark, "addTag", None)
+        remove_tag = getattr(spark, "removeTag", None)
+        interrupt_tag = getattr(spark, "interruptTag", None)
+
+        def _exec() -> pd.DataFrame:
+            if add_tag is not None:
+                try:
+                    add_tag(tag)
+                except Exception:
+                    pass
+            try:
+                return self._execute(sql)
+            finally:
+                if remove_tag is not None:
+                    try:
+                        remove_tag(tag)
+                    except Exception:
+                        pass
+
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(_exec),
+                timeout=self._query_timeout,
+            )
+        except TimeoutError:
+            if interrupt_tag is not None:
+                try:
+                    interrupt_tag(tag)
+                except Exception:
+                    logger.warning("Failed to interrupt Spark query on timeout")
+            raise QueryTimeoutError(
+                f"Query timed out after {self._query_timeout:.0f}s. "
                 "Try a simpler query or add filters to reduce the result set."
             )
 

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -528,11 +528,54 @@ class SparkConnectRunner:
             if self._token:
                 builder = builder.config("spark.connect.client.token", self._token)
             self._spark = builder.getOrCreate()
+            self._probe_connection(self._spark, self._remote)
             logger.info(f"Connected to Spark Connect: {self._remote}")
             self._log_session_info(self._spark)
+        except ConnectionError:
+            raise
         except Exception as e:
             logger.exception("Spark Connect connection error")
             raise ConnectionError(f"Failed to connect to Spark Connect: {e}") from e
+
+    @staticmethod
+    def _probe_connection(spark: Any, remote: str, timeout: float = 5.0) -> None:
+        """Force a tiny gRPC round-trip so we fail loudly if the server is down.
+
+        ``SparkSession.builder.remote(...).getOrCreate()`` is lazy — it
+        returns immediately even if no Connect server is listening. The
+        first real call (a query, conf lookup, or even ``spark.version``)
+        is what blocks. Without this probe a missing/down server looks
+        like "Connected to Spark Connect …" followed by a multi-minute
+        hang. Probing here turns it into a fast, actionable error.
+        """
+        import queue
+        import threading
+
+        result_q: queue.Queue = queue.Queue(maxsize=1)
+
+        def _ping() -> None:
+            try:
+                # spark.version is a synchronous gRPC call to the server.
+                _ = spark.version
+                result_q.put(("ok", None))
+            except Exception as e:
+                result_q.put(("error", e))
+
+        threading.Thread(target=_ping, daemon=True).start()
+        try:
+            status, payload = result_q.get(timeout=timeout)
+        except queue.Empty:
+            raise ConnectionError(
+                f"Could not reach Spark Connect server at {remote} within "
+                f"{timeout:.0f}s. Is the Connect server actually running and "
+                "listening on that host/port? "
+                "(start-connect-server.sh on the cluster, then re-check the "
+                "URI in your .env)"
+            )
+        if status == "error":
+            raise ConnectionError(
+                f"Spark Connect server at {remote} rejected the handshake: {payload}"
+            )
 
     @staticmethod
     def _log_session_info(spark: Any) -> None:
@@ -681,6 +724,35 @@ class SparkConnectRunner:
         here later if we need approximate counts.
         """
         return None
+
+    def get_columns(self, table: str) -> list[Any]:
+        """Return ``ColumnInfo`` for ``table`` via ``spark.catalog.listColumns()``.
+
+        The generic SQL probes in ``schema._get_columns`` (DESCRIBE
+        "name", information_schema.columns, PRAGMA table_info) all use
+        DuckDB / Postgres / SQLite syntax that Spark rejects with
+        PARSE_SYNTAX_ERROR or TABLE_OR_VIEW_NOT_FOUND. Spark's catalog
+        API returns the same information without any SQL.
+        """
+        from datasight.schema import ColumnInfo
+
+        if self._spark is None:
+            raise ConnectionError("SparkConnectRunner is closed")
+        try:
+            columns = self._spark.catalog.listColumns(table)
+        except Exception as e:
+            logger.debug(f"Spark catalog.listColumns({table}) error: {e}")
+            raise QueryError(f"Failed to list Spark columns for {table}: {e}") from e
+        result: list[ColumnInfo] = []
+        for c in columns:
+            result.append(
+                ColumnInfo(
+                    name=str(getattr(c, "name", "")),
+                    dtype=str(getattr(c, "dataType", "") or "UNKNOWN"),
+                    nullable=bool(getattr(c, "nullable", True)),
+                )
+            )
+        return result
 
     @staticmethod
     def _iter_arrow_batches(spark: Any, sdf: Any):

--- a/src/datasight/schema.py
+++ b/src/datasight/schema.py
@@ -4,27 +4,21 @@ system tables.
 """
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
 from typing import Any
 
 import pandas as pd
 from loguru import logger
 
 from datasight.runner import RunSql, SQLiteRunner
+from datasight.schema_types import ColumnInfo, TableInfo
 
-
-@dataclass
-class ColumnInfo:
-    name: str
-    dtype: str
-    nullable: bool = True
-
-
-@dataclass
-class TableInfo:
-    name: str
-    columns: list[ColumnInfo] = field(default_factory=list)
-    row_count: int | None = None
+__all__ = [
+    "ColumnInfo",
+    "TableInfo",
+    "filter_tables",
+    "format_schema_context",
+    "introspect_schema",
+]
 
 
 def filter_tables(

--- a/src/datasight/schema.py
+++ b/src/datasight/schema.py
@@ -175,10 +175,20 @@ async def introspect_schema(
         logger.info(f"Introspecting {total_discovered} tables")
 
     runner_row_count = _runner_row_count_fn(runner)
+    runner_get_columns = _runner_get_columns_fn(runner)
     total = len(table_names)
     progress_every = max(1, total // 10) if total >= 20 else total + 1
     for idx, tname in enumerate(table_names, start=1):
-        cols = await _get_columns(run_sql, tname, prefer_sqlite=is_sqlite)
+        if runner_get_columns is not None:
+            try:
+                cols = runner_get_columns(tname)
+            except Exception as e:
+                logger.warning(
+                    f"runner.get_columns({tname}) failed, falling back to SQL probes: {e}"
+                )
+                cols = await _get_columns(run_sql, tname, prefer_sqlite=is_sqlite)
+        else:
+            cols = await _get_columns(run_sql, tname, prefer_sqlite=is_sqlite)
         if runner_row_count is not None:
             row_count = await runner_row_count(tname)
         else:
@@ -188,6 +198,25 @@ async def introspect_schema(
             logger.info(f"  introspected {idx}/{total} tables")
 
     return tables
+
+
+def _runner_get_columns_fn(runner: Any) -> Callable[[str], list[ColumnInfo]] | None:
+    """Return ``runner.get_columns`` if provided, walking ``_inner`` wrappers.
+
+    Backends with a native catalog API (Spark Connect's
+    ``spark.catalog.listColumns``) implement this to avoid the
+    DuckDB/Postgres/SQLite-specific SQL probes in ``_get_columns``,
+    which Spark rejects.
+    """
+    current = runner
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        fn = getattr(current, "get_columns", None)
+        if callable(fn):
+            return fn
+        seen.add(id(current))
+        current = getattr(current, "_inner", None)
+    return None
 
 
 def _runner_row_count_fn(runner: Any) -> Callable[[str], Awaitable[int | None]] | None:

--- a/src/datasight/schema.py
+++ b/src/datasight/schema.py
@@ -3,6 +3,7 @@ Auto-discover database schema by querying INFORMATION_SCHEMA or DuckDB-specific
 system tables.
 """
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -173,16 +174,39 @@ async def introspect_schema(
     else:
         logger.info(f"Introspecting {total_discovered} tables")
 
+    runner_row_count = _runner_row_count_fn(runner)
     total = len(table_names)
     progress_every = max(1, total // 10) if total >= 20 else total + 1
     for idx, tname in enumerate(table_names, start=1):
         cols = await _get_columns(run_sql, tname, prefer_sqlite=is_sqlite)
-        row_count = await _get_row_count(run_sql, tname)
+        if runner_row_count is not None:
+            row_count = await runner_row_count(tname)
+        else:
+            row_count = await _get_row_count(run_sql, tname)
         tables.append(TableInfo(name=tname, columns=cols, row_count=row_count))
         if idx % progress_every == 0 and idx < total:
             logger.info(f"  introspected {idx}/{total} tables")
 
     return tables
+
+
+def _runner_row_count_fn(runner: Any) -> Callable[[str], Awaitable[int | None]] | None:
+    """Return ``runner.get_row_count`` (async) if provided, walking ``_inner``.
+
+    Runners like ``SparkConnectRunner`` override row counting to avoid
+    triggering full-table scans at schema-introspection time. The
+    ``CachingSqlRunner`` wraps other runners, so we walk ``_inner`` to find
+    the concrete backend's method.
+    """
+    current = runner
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        fn = getattr(current, "get_row_count", None)
+        if callable(fn):
+            return fn
+        seen.add(id(current))
+        current = getattr(current, "_inner", None)
+    return None
 
 
 def format_schema_context(

--- a/src/datasight/schema_types.py
+++ b/src/datasight/schema_types.py
@@ -1,0 +1,23 @@
+"""Dataclasses describing introspected schema.
+
+Kept in a leaf module with no intra-package imports so both ``runner`` and
+``schema`` can reference the types without introducing a cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ColumnInfo:
+    name: str
+    dtype: str
+    nullable: bool = True
+
+
+@dataclass
+class TableInfo:
+    name: str
+    columns: list[ColumnInfo] = field(default_factory=list)
+    row_count: int | None = None

--- a/src/datasight/settings.py
+++ b/src/datasight/settings.py
@@ -70,6 +70,9 @@ _PROJECT_ENV_VARS = [
     "POSTGRES_PASSWORD",
     "POSTGRES_URL",
     "POSTGRES_SSLMODE",
+    "SPARK_REMOTE",
+    "SPARK_TOKEN",
+    "SPARK_MAX_RESULT_BYTES",
     # LLM settings
     "LLM_PROVIDER",
     "LLM_TIMEOUT",
@@ -165,7 +168,7 @@ def restore_original_env() -> None:
 # exists only for static typing and must be updated by hand when a provider
 # is added or removed (Python can't derive Literals from a runtime set).
 LLMProvider = Literal["anthropic", "ollama", "github", "openai"]
-DBMode = Literal["duckdb", "sqlite", "postgres", "flightsql"]
+DBMode = Literal["duckdb", "sqlite", "postgres", "flightsql", "spark"]
 
 # Mapping from database mode to SQL dialect for query generation
 DB_MODE_TO_DIALECT: dict[str, str] = {
@@ -173,6 +176,7 @@ DB_MODE_TO_DIALECT: dict[str, str] = {
     "sqlite": "sqlite",
     "postgres": "postgres",
     "flightsql": "duckdb",  # Flight SQL uses DuckDB dialect
+    "spark": "spark",
 }
 
 
@@ -266,6 +270,11 @@ class DatabaseSettings:
     postgres_url: str = ""
     postgres_sslmode: str = "prefer"
 
+    # Spark Connect settings
+    spark_remote: str = "sc://localhost:15002"
+    spark_token: str | None = None
+    spark_max_result_bytes: int = 100 * 1024 * 1024
+
     @property
     def sql_dialect(self) -> str:
         """Get the SQL dialect for the current mode."""
@@ -343,8 +352,10 @@ class Settings:
                 db_mode = "postgres"
             case "flightsql":
                 db_mode = "flightsql"
+            case "spark":
+                db_mode = "spark"
             case _:
-                valid_modes = "duckdb, sqlite, postgres, flightsql"
+                valid_modes = "duckdb, sqlite, postgres, flightsql, spark"
                 raise ConfigurationError(
                     f"Invalid DB_MODE: {db_mode_raw!r}. Valid modes: {valid_modes}"
                 )
@@ -381,6 +392,11 @@ class Settings:
                 postgres_password=os.environ.get("POSTGRES_PASSWORD", ""),
                 postgres_url=os.environ.get("POSTGRES_URL", ""),
                 postgres_sslmode=os.environ.get("POSTGRES_SSLMODE", "prefer"),
+                spark_remote=os.environ.get("SPARK_REMOTE", "sc://localhost:15002"),
+                spark_token=os.environ.get("SPARK_TOKEN") or None,
+                spark_max_result_bytes=_safe_int(
+                    os.environ.get("SPARK_MAX_RESULT_BYTES", ""), 100 * 1024 * 1024
+                ),
             ),
             app=AppSettings(
                 port=_safe_int(os.environ.get("PORT", ""), 8084),

--- a/src/datasight/settings.py
+++ b/src/datasight/settings.py
@@ -15,6 +15,7 @@ from typing import Literal, cast
 from dotenv import load_dotenv
 
 from datasight.exceptions import ConfigurationError
+from datasight.runner import DEFAULT_SPARK_MAX_RESULT_BYTES
 
 
 def _safe_int(value: str, default: int) -> int:
@@ -273,7 +274,7 @@ class DatabaseSettings:
     # Spark Connect settings
     spark_remote: str = "sc://localhost:15002"
     spark_token: str | None = None
-    spark_max_result_bytes: int = 100 * 1024 * 1024
+    spark_max_result_bytes: int = DEFAULT_SPARK_MAX_RESULT_BYTES
 
     @property
     def sql_dialect(self) -> str:
@@ -395,7 +396,8 @@ class Settings:
                 spark_remote=os.environ.get("SPARK_REMOTE", "sc://localhost:15002"),
                 spark_token=os.environ.get("SPARK_TOKEN") or None,
                 spark_max_result_bytes=_safe_int(
-                    os.environ.get("SPARK_MAX_RESULT_BYTES", ""), 100 * 1024 * 1024
+                    os.environ.get("SPARK_MAX_RESULT_BYTES", ""),
+                    DEFAULT_SPARK_MAX_RESULT_BYTES,
                 ),
             ),
             app=AppSettings(

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -860,9 +860,22 @@ async def _build_project_health(state: AppState) -> dict[str, Any]:
         1 for check in checks if not check["ok"] and check["category"] == "project"
     )
 
+    # Surface the configured backend identity at the top level so the UI
+    # can render compact "Project / DB / LLM" rows without parsing strings
+    # out of individual check details.
+    db_mode = settings.database.mode if settings is not None else None
+    db_target = next(
+        (c["detail"] for c in checks if c["name"] == "Database config" and c["ok"]),
+        None,
+    )
+    llm_provider = settings.llm.provider if settings is not None else None
+
     return {
         "project_loaded": state.project_loaded,
         "project_dir": state.project_dir,
+        "db_mode": db_mode,
+        "db_target": db_target,
+        "llm_provider": llm_provider,
         "checks": checks,
         "summary": {
             "ok_count": sum(1 for check in checks if check["ok"]),

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -71,7 +71,6 @@ from datasight.recent_projects import (
 )
 from datasight.explore import (
     add_files_to_connection,
-    create_ephemeral_session,
     save_ephemeral_as_project,
     scan_directory_for_data_files,
 )
@@ -2113,12 +2112,15 @@ async def explore_files(request: Request, state: AppState = Depends(get_state)):
         state.max_cost_usd_per_turn = settings.app.max_cost_usd_per_turn
         state.max_output_tokens = settings.app.max_output_tokens
 
-        # Create ephemeral session
-        runner, tables_info = create_ephemeral_session(file_paths)
+        # Route file-backed exploration through whichever backend the
+        # current settings point at (Spark when DB_MODE=spark, else DuckDB).
+        from datasight.explore import create_files_session_for_settings
+
+        runner, tables_info = create_files_session_for_settings(file_paths, settings.database)
         state.sql_runner = runner
         state.is_ephemeral = True
         state.ephemeral_tables_info = tables_info
-        state.sql_dialect = "duckdb"
+        state.sql_dialect = settings.database.sql_dialect
         state.project_loaded = True
 
         # Introspect schema

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -811,6 +811,9 @@ async def _build_project_health(state: AppState) -> dict[str, Any]:
         elif settings.database.mode == "flightsql":
             db_ok = bool(settings.database.flight_uri)
             db_detail = settings.database.flight_uri
+        elif settings.database.mode == "spark":
+            db_ok = bool(settings.database.spark_remote)
+            db_detail = settings.database.spark_remote
         add_check(
             "Database config",
             db_ok,

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -2128,12 +2128,17 @@ async def explore_files(request: Request, state: AppState = Depends(get_state)):
         # Route file-backed exploration through whichever backend the
         # current settings point at (Spark when DB_MODE=spark, else DuckDB).
         from datasight.explore import create_files_session_for_settings
+        from datasight.runner import SparkConnectRunner
 
         runner, tables_info = create_files_session_for_settings(file_paths, settings.database)
         state.sql_runner = runner
         state.is_ephemeral = True
         state.ephemeral_tables_info = tables_info
-        state.sql_dialect = settings.database.sql_dialect
+        # Dialect must match the effective runner, not the configured DB_MODE:
+        # for DB_MODE=postgres/flightsql/sqlite the file session falls back to
+        # an in-memory DuckDB, so SQL must be generated as DuckDB rather than
+        # the configured backend's dialect.
+        state.sql_dialect = "spark" if isinstance(runner, SparkConnectRunner) else "duckdb"
         state.project_loaded = True
 
         # Introspect schema

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -858,7 +858,9 @@ def test_inspect_json_output(csv_file):
     runner = CliRunner()
     result = runner.invoke(cli, ["inspect", csv_file, "--format", "json"])
     assert result.exit_code == 0
-    data = json.loads(result.output)
+    # Read stdout directly — result.output may include stderr log lines in
+    # some Click versions' default capture mode.
+    data = json.loads(result.stdout)
     assert "profile" in data
     assert "quality" in data
     assert "measures" in data
@@ -895,7 +897,7 @@ def test_inspect_multiple_files(csv_file, tmp_path):
     runner = CliRunner()
     result = runner.invoke(cli, ["inspect", csv_file, str(second), "--format", "json"])
     assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     assert data["profile"]["table_count"] == 2
 
 

--- a/tests/test_explore_spark.py
+++ b/tests/test_explore_spark.py
@@ -1,0 +1,163 @@
+"""Tests for Spark-backed file exploration.
+
+Exercises the dispatcher in ``datasight.explore`` that routes
+``inspect`` / ``generate --files`` / ``trends --files`` through Spark
+Connect when the project's ``DB_MODE=spark``, and through the legacy
+in-memory DuckDB session otherwise.
+"""
+
+from __future__ import annotations
+
+import pyarrow.parquet as pq
+import pytest
+
+from datasight.explore import (
+    create_files_session_for_settings,
+    create_spark_files_session,
+)
+from datasight.runner import EphemeralDuckDBRunner, SparkConnectRunner
+from datasight.settings import DatabaseSettings
+
+
+class _FakeReader:
+    def __init__(self, registry: dict[str, str]):
+        self._registry = registry
+        self._pending_path: str | None = None
+
+    def parquet(self, path: str):
+        return _FakeSparkDF(self._registry, path, "parquet")
+
+    def option(self, *_args, **_kwargs):
+        return self
+
+    def csv(self, path: str):
+        return _FakeSparkDF(self._registry, path, "csv")
+
+
+class _FakeSparkDF:
+    def __init__(self, registry: dict[str, str], path: str, fmt: str):
+        self._registry = registry
+        self._path = path
+        self._fmt = fmt
+
+    def createOrReplaceTempView(self, name: str):
+        self._registry[name] = f"{self._fmt}:{self._path}"
+
+
+class _FakeSpark:
+    def __init__(self):
+        self.registry: dict[str, str] = {}
+        self.read = _FakeReader(self.registry)
+
+    def stop(self):
+        pass
+
+
+def _write_parquet(path, rows):
+    import pyarrow as pa
+
+    table = pa.table({"id": [r[0] for r in rows], "value": [r[1] for r in rows]})
+    pq.write_table(table, path)
+
+
+def test_create_spark_files_session_registers_temp_views(tmp_path):
+    p1 = tmp_path / "generation.parquet"
+    p2 = tmp_path / "plants.parquet"
+    _write_parquet(p1, [(1, "wind"), (2, "solar")])
+    _write_parquet(p2, [(1, "plant_a"), (2, "plant_b")])
+
+    fake = _FakeSpark()
+    runner, tables = create_spark_files_session(
+        [str(p1), str(p2)],
+        spark_remote="sc://ignored",
+        spark=fake,
+    )
+
+    assert isinstance(runner, SparkConnectRunner)
+    assert {t["name"] for t in tables} == {"generation", "plants"}
+    assert set(fake.registry.keys()) == {"generation", "plants"}
+    assert fake.registry["generation"].startswith("parquet:")
+    assert str(p1) in fake.registry["generation"]
+
+
+def test_create_spark_files_session_rejects_duckdb_files(tmp_path):
+    p = tmp_path / "mydb.duckdb"
+    p.write_bytes(b"\x00" * 16)  # pretend-existing duckdb file
+
+    with pytest.raises(Exception) as excinfo:
+        create_spark_files_session([str(p)], spark_remote="sc://ignored", spark=_FakeSpark())
+    assert "Spark backend cannot read" in str(excinfo.value)
+
+
+def test_dispatcher_spark_mode_uses_spark(tmp_path, monkeypatch):
+    """DB_MODE=spark routes through create_spark_files_session."""
+    p = tmp_path / "generation.parquet"
+    _write_parquet(p, [(1, "wind")])
+
+    captured = {}
+
+    def _fake_spark_session(file_paths, *, spark_remote, spark_token, spark_max_result_bytes):
+        captured["file_paths"] = file_paths
+        captured["spark_remote"] = spark_remote
+        captured["spark_token"] = spark_token
+        captured["spark_max_result_bytes"] = spark_max_result_bytes
+        return "SPARK_RUNNER", [{"name": "generation", "path": file_paths[0], "type": "parquet"}]
+
+    monkeypatch.setattr("datasight.explore.create_spark_files_session", _fake_spark_session)
+
+    settings = DatabaseSettings(
+        mode="spark",
+        spark_remote="sc://test-cluster:15002",
+        spark_token="abc",
+        spark_max_result_bytes=12345,
+    )
+    runner, tables = create_files_session_for_settings([str(p)], settings)
+
+    assert runner == "SPARK_RUNNER"
+    assert captured["spark_remote"] == "sc://test-cluster:15002"
+    assert captured["spark_token"] == "abc"
+    assert captured["spark_max_result_bytes"] == 12345
+    assert len(tables) == 1
+
+
+def test_dispatcher_duckdb_mode_uses_ephemeral(tmp_path):
+    """DB_MODE=duckdb keeps the long-standing local-file behavior."""
+    p = tmp_path / "generation.parquet"
+    _write_parquet(p, [(1, "wind"), (2, "solar")])
+
+    settings = DatabaseSettings(mode="duckdb")
+    runner, tables = create_files_session_for_settings([str(p)], settings)
+
+    assert isinstance(runner, EphemeralDuckDBRunner)
+    assert [t["name"] for t in tables] == ["generation"]
+
+
+def test_dispatcher_no_settings_uses_ephemeral(tmp_path):
+    """No project / no settings → falls back to DuckDB (unchanged behavior)."""
+    p = tmp_path / "generation.parquet"
+    _write_parquet(p, [(1, "wind")])
+
+    runner, tables = create_files_session_for_settings([str(p)], None)
+
+    assert isinstance(runner, EphemeralDuckDBRunner)
+    assert [t["name"] for t in tables] == ["generation"]
+
+
+def test_dispatcher_postgres_mode_falls_back_with_warning(tmp_path, caplog):
+    """Postgres / FlightSQL can't read local files — fall back to DuckDB."""
+    from loguru import logger as _logger
+
+    p = tmp_path / "generation.parquet"
+    _write_parquet(p, [(1, "wind")])
+
+    sink_id = _logger.add(lambda msg: caplog.records.append(msg), level="WARNING")
+    try:
+        settings = DatabaseSettings(mode="postgres")
+        runner, _ = create_files_session_for_settings([str(p)], settings)
+    finally:
+        _logger.remove(sink_id)
+
+    assert isinstance(runner, EphemeralDuckDBRunner)
+    combined = "\n".join(str(r) for r in caplog.records)
+    assert "postgres" in combined
+    assert "local DuckDB" in combined

--- a/tests/test_explore_spark.py
+++ b/tests/test_explore_spark.py
@@ -143,6 +143,27 @@ def test_dispatcher_no_settings_uses_ephemeral(tmp_path):
     assert [t["name"] for t in tables] == ["generation"]
 
 
+def test_dispatcher_logs_chosen_backend_on_every_branch(tmp_path, caplog):
+    """Every dispatcher branch should log which backend was picked."""
+    from loguru import logger as _logger
+
+    p = tmp_path / "generation.parquet"
+    _write_parquet(p, [(1, "wind")])
+
+    sink_id = _logger.add(lambda msg: caplog.records.append(msg), level="INFO")
+    try:
+        # No settings → DuckDB (with explanation)
+        create_files_session_for_settings([str(p)], None)
+        # DB_MODE=duckdb → DuckDB (with mode in message)
+        create_files_session_for_settings([str(p)], DatabaseSettings(mode="duckdb"))
+    finally:
+        _logger.remove(sink_id)
+
+    combined = "\n".join(str(r) for r in caplog.records)
+    assert "no settings" in combined.lower() or "no .env" in combined.lower()
+    assert "DB_MODE=duckdb" in combined
+
+
 def test_dispatcher_postgres_mode_falls_back_with_warning(tmp_path, caplog):
     """Postgres / FlightSQL can't read local files — fall back to DuckDB."""
     from loguru import logger as _logger

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -182,6 +182,39 @@ class TestSampleEnumColumns:
         conn.close()
 
     @pytest.mark.asyncio
+    async def test_orders_by_output_alias_for_spark_ansi_compatibility(self):
+        """Spark's ANSI analyzer only lets ORDER BY reference post-DISTINCT columns.
+
+        The enum sample query must be `ORDER BY val` (the alias), not
+        `ORDER BY <original column>`. DuckDB and Postgres accept either
+        form, but Spark with spark.sql.ansi.enabled=true rejects the
+        pre-DISTINCT reference with UNRESOLVED_COLUMN.WITH_SUGGESTION.
+        """
+        import pandas as pd
+
+        seen: list[str] = []
+
+        async def run_sql(sql):
+            seen.append(sql)
+            if "COUNT(DISTINCT" in sql:
+                return pd.DataFrame({"n": [3]})
+            return pd.DataFrame({"val": ["a", "b", "c"]})
+
+        tables = [
+            TableInfo(
+                name="t",
+                columns=[ColumnInfo(name="status", dtype="VARCHAR")],
+                row_count=3,
+            )
+        ]
+        await sample_enum_columns(run_sql, tables)
+
+        distinct_sql = next((s for s in seen if "SELECT DISTINCT" in s), None)
+        assert distinct_sql is not None, seen
+        assert "ORDER BY val" in distinct_sql, distinct_sql
+        assert 'ORDER BY "status"' not in distinct_sql, distinct_sql
+
+    @pytest.mark.asyncio
     async def test_skips_high_cardinality(self):
         """Skip columns with > 50 distinct values."""
         import duckdb

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -190,6 +190,57 @@ def test_generate_respects_custom_db_path(tmp_path, parquet_file, stub_llm):
     assert "DB_PATH=./db/custom.duckdb" in env_text
 
 
+def test_generate_preserves_existing_spark_backend(tmp_path, parquet_file, stub_llm, monkeypatch):
+    """generate <file> must not clobber DB_MODE=spark with DB_MODE=duckdb.
+
+    The 'new project from parquet files' flow creates a local DuckDB
+    mirror and writes DB_MODE=duckdb. When the project is already
+    configured for Spark (or another non-DuckDB backend), that would
+    silently replace the user's real backend. The command should
+    preserve the existing .env and skip the DuckDB mirror.
+    """
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "ANTHROPIC_API_KEY=test-key\nDB_MODE=spark\nSPARK_REMOTE=sc://my-cluster:15002\n",
+        encoding="utf-8",
+    )
+
+    # Route the Spark-mode files session through the DuckDB path so the
+    # test doesn't need a real Spark cluster. We're only exercising the
+    # CLI's env-preservation logic here; the Spark plumbing is tested
+    # separately in test_spark_runner.py.
+    from datasight.explore import create_ephemeral_session
+
+    def _fake_session(file_paths, settings):
+        return create_ephemeral_session(file_paths)
+
+    # cli imports create_files_session_for_settings locally inside the
+    # _run coroutine, so we patch where it lives in explore.
+    monkeypatch.setattr("datasight.explore.create_files_session_for_settings", _fake_session)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["generate", str(parquet_file), "--project-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+
+    # No local DuckDB mirror.
+    assert not (tmp_path / "database.duckdb").exists(), result.output
+
+    # DB_MODE stays on spark; SPARK_REMOTE is preserved; no DB_PATH was added.
+    env_text = env_path.read_text(encoding="utf-8")
+    assert "DB_MODE=spark" in env_text, env_text
+    assert "DB_MODE=duckdb" not in env_text, env_text
+    assert "SPARK_REMOTE=sc://my-cluster:15002" in env_text, env_text
+    assert "DB_PATH=" not in env_text, env_text
+
+    # Schema description and queries are still written — those describe
+    # the tables regardless of which backend serves them.
+    assert (tmp_path / "schema_description.md").exists()
+    assert (tmp_path / "queries.yaml").exists()
+
+
 def test_generate_sqlite_file_updates_env_without_creating_duckdb(tmp_path, stub_llm):
     db_path = tmp_path / "generation.sqlite"
     conn = sqlite3.connect(str(db_path))

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -18,7 +18,12 @@ from datasight.runner import SparkConnectRunner
 
 
 class _FakePlan:
-    pass
+    """Mimics pyspark 4.0's LogicalPlan — needs a ``to_proto(client)`` method."""
+
+    def to_proto(self, _client):
+        # Production code just passes the returned value back into
+        # client.to_table_as_iterator; our fake client ignores it.
+        return self
 
 
 class _FakeClient:
@@ -26,10 +31,14 @@ class _FakeClient:
         self._batches = batches
         self.iterator_consumed = 0
 
-    def to_table_as_iterator(self, plan, observations):
+    def to_table_as_iterator(self, plan_proto, observations):
+        # Real Spark 4.0 yields a StructType schema first, then one pa.Table
+        # per batch. Mirror that so the runner's isinstance(item, pa.Table)
+        # filter is exercised by tests.
+        yield "schema-placeholder"  # non-pa.Table, must be skipped by caller
         for batch in self._batches:
             self.iterator_consumed += 1
-            yield pa.Table.from_batches([batch]), None
+            yield pa.Table.from_batches([batch])
 
 
 class _FakeSparkDataFrame:

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -46,14 +46,26 @@ class _FakeCatalog:
         return [type("Table", (), {"name": n})() for n in self._table_names]
 
 
+class _FakeConf:
+    def __init__(self, values: dict[str, str] | None = None):
+        self._values = values or {}
+
+    def get(self, key: str) -> str | None:
+        return self._values.get(key)
+
+
 class _FakeSpark:
     def __init__(
         self,
         batches: list[pa.RecordBatch],
         table_names: list[str] | None = None,
+        conf: dict[str, str] | None = None,
+        version: str = "3.5.1",
     ):
         self.client = _FakeClient(batches)
         self.catalog = _FakeCatalog(table_names or [])
+        self.conf = _FakeConf(conf)
+        self.version = version
         self._sql_seen: list[str] = []
         self.tags_added: list[str] = []
         self.tags_removed: list[str] = []
@@ -169,6 +181,49 @@ async def test_spark_runner_interrupts_on_timeout():
     await asyncio.sleep(0.05)
     assert len(spark.tags_interrupted) == 1
     assert spark.tags_interrupted[0].startswith("datasight-")
+
+
+def test_log_session_info_includes_version_and_master(caplog):
+    from loguru import logger as _logger
+
+    spark = _FakeSpark(
+        [],
+        conf={
+            "spark.master": "spark://master:7077",
+            "spark.app.id": "app-20260422-0001",
+            "spark.executor.instances": "8",
+        },
+        version="3.5.1",
+    )
+
+    sink_id = _logger.add(lambda msg: caplog.records.append(msg), level="INFO")
+    try:
+        SparkConnectRunner._log_session_info(spark)
+    finally:
+        _logger.remove(sink_id)
+
+    combined = "\n".join(str(r) for r in caplog.records)
+    assert "version" in combined and "3.5.1" in combined
+    assert "spark.master" in combined and "spark://master:7077" in combined
+    assert "app-20260422-0001" in combined
+    # Distributed master → no local-mode warning.
+    assert "running all work in one JVM" not in combined
+
+
+def test_log_session_info_warns_on_local_master(caplog):
+    from loguru import logger as _logger
+
+    spark = _FakeSpark([], conf={"spark.master": "local[*]"})
+
+    sink_id = _logger.add(lambda msg: caplog.records.append(msg), level="INFO")
+    try:
+        SparkConnectRunner._log_session_info(spark)
+    finally:
+        _logger.remove(sink_id)
+
+    combined = "\n".join(str(r) for r in caplog.records)
+    assert "local[*]" in combined
+    assert "running all work in one JVM" in combined
 
 
 def test_spark_runner_get_table_names_uses_catalog():

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -210,6 +210,43 @@ def test_log_session_info_includes_version_and_master(caplog):
     assert "running all work in one JVM" not in combined
 
 
+def test_log_session_info_times_out_on_unresponsive_server(caplog, monkeypatch):
+    """A hung gRPC call must not freeze the CLI — probe should time out."""
+    import queue as _queue
+
+    from loguru import logger as _logger
+
+    # Shrink the wait inside the runner so the test takes ms, not 30s. The
+    # daemon thread itself is left to be cleaned up by interpreter exit
+    # because that's exactly the production behavior we want to prove.
+    real_get = _queue.Queue.get
+
+    def _quick_get(self, *args, **kwargs):
+        kwargs["timeout"] = 0.2
+        return real_get(self, *args, **kwargs)
+
+    monkeypatch.setattr(_queue.Queue, "get", _quick_get)
+
+    class _HangingConf:
+        def get(self, _key):
+            import time as _time
+
+            _time.sleep(5)
+            return "never"
+
+    spark = _FakeSpark([])
+    spark.conf = _HangingConf()
+
+    sink_id = _logger.add(lambda msg: caplog.records.append(msg), level="INFO")
+    try:
+        SparkConnectRunner._log_session_info(spark)
+    finally:
+        _logger.remove(sink_id)
+
+    combined = "\n".join(str(r) for r in caplog.records)
+    assert "timed out" in combined
+
+
 def test_log_session_info_warns_on_local_master(caplog):
     from loguru import logger as _logger
 

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pandas as pd
 import pyarrow as pa
 import pytest
 
@@ -37,9 +38,22 @@ class _FakeSparkDataFrame:
         self.columns = columns or ["id", "payload"]
 
 
+class _FakeCatalog:
+    def __init__(self, table_names: list[str]):
+        self._table_names = table_names
+
+    def listTables(self):
+        return [type("Table", (), {"name": n})() for n in self._table_names]
+
+
 class _FakeSpark:
-    def __init__(self, batches: list[pa.RecordBatch]):
+    def __init__(
+        self,
+        batches: list[pa.RecordBatch],
+        table_names: list[str] | None = None,
+    ):
         self.client = _FakeClient(batches)
+        self.catalog = _FakeCatalog(table_names or [])
         self._sql_seen: list[str] = []
         self.tags_added: list[str] = []
         self.tags_removed: list[str] = []
@@ -90,8 +104,10 @@ async def test_spark_runner_returns_full_result_when_under_cap():
 
 @pytest.mark.asyncio
 async def test_spark_runner_truncates_at_byte_cap():
-    # Each batch is ~10k rows × ~88 bytes = roughly 880KB. With a 1MB cap,
-    # we should truncate after the second batch.
+    # Each batch is ~10k rows × ~88 bytes = roughly 880KB. The cap is
+    # checked *before* appending, so with a 1MB cap the first batch fits
+    # (880KB) and adding the second would push total past the cap —
+    # streaming halts after the first batch is accepted.
     batches = [_make_batch(10_000) for _ in range(5)]
     spark = _FakeSpark(batches)
     runner = SparkConnectRunner(spark=spark, max_result_bytes=1_000_000)
@@ -134,7 +150,7 @@ async def test_spark_runner_truncates_immediately_when_byte_cap_is_zero():
 
 
 @pytest.mark.asyncio
-async def test_spark_runner_interrupts_on_timeout(monkeypatch):
+async def test_spark_runner_interrupts_on_timeout():
     # Hand-rolled spark whose sql() call blocks forever so wait_for fires.
     class _BlockingSpark(_FakeSpark):
         def sql(self, query: str):
@@ -153,3 +169,107 @@ async def test_spark_runner_interrupts_on_timeout(monkeypatch):
     await asyncio.sleep(0.05)
     assert len(spark.tags_interrupted) == 1
     assert spark.tags_interrupted[0].startswith("datasight-")
+
+
+def test_spark_runner_get_table_names_uses_catalog():
+    spark = _FakeSpark([], table_names=["generation_fuel", "plants", "boilers"])
+    runner = SparkConnectRunner(spark=spark)
+
+    assert runner.get_table_names() == ["generation_fuel", "plants", "boilers"]
+
+
+@pytest.mark.asyncio
+async def test_spark_runner_get_row_count_returns_none():
+    """Spark skips row counts so introspection never triggers a full scan."""
+    runner = SparkConnectRunner(spark=_FakeSpark([]))
+
+    assert await runner.get_row_count("any_table") is None
+
+
+@pytest.mark.asyncio
+async def test_introspect_schema_skips_row_count_for_spark(monkeypatch):
+    """SparkConnectRunner.get_row_count wins over the generic COUNT(*) probe."""
+    from datasight import schema as schema_mod
+
+    calls: list[str] = []
+
+    async def _fake_run_sql(sql: str):
+        calls.append(sql)
+        if "DESCRIBE" in sql:
+            return pd.DataFrame(
+                {"column_name": ["id", "payload"], "column_type": ["INT", "STRING"]}
+            )
+        return pd.DataFrame()
+
+    async def _count_boom(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("_get_row_count must not be called for Spark runner")
+
+    monkeypatch.setattr(schema_mod, "_get_row_count", _count_boom)
+
+    spark = _FakeSpark([], table_names=["generation_fuel"])
+    runner = SparkConnectRunner(spark=spark)
+
+    tables = await schema_mod.introspect_schema(_fake_run_sql, runner=runner)
+
+    assert [t.name for t in tables] == ["generation_fuel"]
+    assert tables[0].row_count is None
+    assert not any("COUNT(*)" in sql for sql in calls)
+
+
+@pytest.mark.asyncio
+async def test_agent_surfaces_truncation_in_tool_result():
+    """When the runner truncates, the LLM-facing text and HTML should say so."""
+    from datasight.agent import _execute_run_sql
+
+    batches = [_make_batch(10_000) for _ in range(5)]
+    spark = _FakeSpark(batches)
+    # Cap sized so the first batch fits but accumulation trips before the end.
+    runner = SparkConnectRunner(spark=spark, max_result_bytes=2_000_000)
+
+    async def _run_sql(sql: str):
+        return await runner.run_sql(sql)
+
+    result = await _execute_run_sql(
+        input_data={"sql": "SELECT * FROM huge"},
+        run_sql=_run_sql,
+        schema_map=None,
+        dialect="spark",
+        measure_rules=None,
+        query_logger=None,
+        session_id="test",
+        user_question="everything please",
+    )
+
+    assert result.meta.get("truncated") is True
+    assert "truncation_reason" in result.meta
+    assert "Partial result" in result.result_text
+    assert result.result_html is not None
+    assert "sql-warning" in result.result_html
+
+
+@pytest.mark.asyncio
+async def test_agent_reports_truncated_empty_result_distinctly():
+    """An empty result caused by truncation must not be reported as 'no rows'."""
+    from datasight.agent import _execute_run_sql
+
+    batches = [_make_batch(10)]
+    spark = _FakeSpark(batches)
+    runner = SparkConnectRunner(spark=spark, max_result_bytes=0)
+
+    async def _run_sql(sql: str):
+        return await runner.run_sql(sql)
+
+    result = await _execute_run_sql(
+        input_data={"sql": "SELECT * FROM anything"},
+        run_sql=_run_sql,
+        schema_map=None,
+        dialect="spark",
+        measure_rules=None,
+        query_logger=None,
+        session_id="test",
+        user_question="everything please",
+    )
+
+    assert result.meta.get("truncated") is True
+    assert "No rows returned" not in result.result_text
+    assert "truncated before any rows" in result.result_text.lower()

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -32,8 +32,9 @@ class _FakeClient:
 
 
 class _FakeSparkDataFrame:
-    def __init__(self):
+    def __init__(self, columns: list[str] | None = None):
         self._plan = _FakePlan()
+        self.columns = columns or ["id", "payload"]
 
 
 class _FakeSpark:
@@ -102,6 +103,34 @@ async def test_spark_runner_truncates_at_byte_cap():
     # Should have stopped streaming early — not consumed all 5 batches.
     assert spark.client.iterator_consumed < 5
     assert len(df) < 50_000
+
+
+@pytest.mark.asyncio
+async def test_spark_runner_preserves_columns_for_zero_row_result():
+    spark = _FakeSpark([_make_batch(0)])
+    runner = SparkConnectRunner(spark=spark, max_result_bytes=10 * 1024 * 1024)
+
+    df = await runner.run_sql("SELECT * FROM empty_t")
+
+    assert df.empty
+    assert list(df.columns) == ["id", "payload"]
+    assert "truncated" not in df.attrs
+
+
+@pytest.mark.asyncio
+async def test_spark_runner_truncates_immediately_when_byte_cap_is_zero():
+    batches = [_make_batch(10), _make_batch(10)]
+    spark = _FakeSpark(batches)
+    runner = SparkConnectRunner(spark=spark, max_result_bytes=0)
+
+    df = await runner.run_sql("SELECT * FROM tiny")
+
+    assert df.empty
+    assert list(df.columns) == ["id", "payload"]
+    assert df.attrs.get("truncated") is True
+    assert "truncation_reason" in df.attrs
+    # Cap enforced before the first non-empty batch is appended.
+    assert spark.client.iterator_consumed <= 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -263,6 +263,123 @@ def test_log_session_info_warns_on_local_master(caplog):
     assert "running all work in one JVM" in combined
 
 
+def test_probe_connection_raises_quickly_when_server_unreachable(monkeypatch):
+    """An unresponsive server should fail in seconds, not hang for minutes."""
+    import queue as _queue
+
+    real_get = _queue.Queue.get
+
+    def _quick_get(self, *args, **kwargs):
+        kwargs["timeout"] = 0.2
+        return real_get(self, *args, **kwargs)
+
+    monkeypatch.setattr(_queue.Queue, "get", _quick_get)
+
+    class _HangingSpark:
+        @property
+        def version(self):
+            import time as _time
+
+            _time.sleep(5)  # simulate a hung gRPC call
+
+    from datasight.exceptions import ConnectionError as _ConnErr
+
+    with pytest.raises(_ConnErr) as excinfo:
+        SparkConnectRunner._probe_connection(_HangingSpark(), "sc://nowhere:15002", timeout=999.0)
+    assert "Could not reach Spark Connect" in str(excinfo.value)
+    assert "sc://nowhere:15002" in str(excinfo.value)
+
+
+def test_probe_connection_propagates_handshake_error():
+    """When spark.version raises (e.g. auth failure) we surface it cleanly."""
+
+    class _RejectingSpark:
+        @property
+        def version(self):
+            raise RuntimeError("UNAUTHENTICATED: invalid token")
+
+    from datasight.exceptions import ConnectionError as _ConnErr
+
+    with pytest.raises(_ConnErr) as excinfo:
+        SparkConnectRunner._probe_connection(_RejectingSpark(), "sc://x:15002")
+    assert "rejected the handshake" in str(excinfo.value)
+    assert "UNAUTHENTICATED" in str(excinfo.value)
+
+
+def test_spark_runner_get_columns_uses_catalog_api():
+    """Use spark.catalog.listColumns rather than SQL DESCRIBE/information_schema."""
+    from types import SimpleNamespace
+
+    class _SparkWithColumns(_FakeSpark):
+        def __init__(self, columns_by_table):
+            super().__init__([])
+            self._columns_by_table = columns_by_table
+
+            class _Cat:
+                def __init__(self, parent):
+                    self._parent = parent
+
+                def listTables(self):
+                    return []
+
+                def listColumns(self, table):
+                    return self._parent._columns_by_table.get(table, [])
+
+            self.catalog = _Cat(self)
+
+    cols = [
+        SimpleNamespace(name="id", dataType="bigint", nullable=False),
+        SimpleNamespace(name="value", dataType="double", nullable=True),
+    ]
+    runner = SparkConnectRunner(spark=_SparkWithColumns({"generation": cols}))
+
+    result = runner.get_columns("generation")
+    assert [c.name for c in result] == ["id", "value"]
+    assert [c.dtype for c in result] == ["bigint", "double"]
+    assert [c.nullable for c in result] == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_introspect_schema_uses_runner_get_columns_for_spark(monkeypatch):
+    """Schema introspection should call runner.get_columns instead of SQL probes."""
+    from types import SimpleNamespace
+
+    from datasight import schema as schema_mod
+
+    sql_calls: list[str] = []
+
+    async def _fake_run_sql(sql: str):
+        sql_calls.append(sql)
+        return pd.DataFrame()
+
+    async def _no_count(*args, **kwargs):
+        return None
+
+    class _Cat:
+        def listTables(self):
+            return [SimpleNamespace(name="generation")]
+
+        def listColumns(self, table):
+            return [
+                SimpleNamespace(name="id", dataType="bigint", nullable=False),
+                SimpleNamespace(name="report_date", dataType="date", nullable=False),
+            ]
+
+    spark = _FakeSpark([])
+    spark.catalog = _Cat()
+    runner = SparkConnectRunner(spark=spark)
+    monkeypatch.setattr(runner, "get_row_count", _no_count)
+
+    tables = await schema_mod.introspect_schema(_fake_run_sql, runner=runner)
+
+    assert [t.name for t in tables] == ["generation"]
+    assert [c.name for c in tables[0].columns] == ["id", "report_date"]
+    # Critically: the broken DuckDB/Postgres/SQLite SQL probes must not run.
+    assert not any("DESCRIBE" in s for s in sql_calls), sql_calls
+    assert not any("information_schema" in s for s in sql_calls), sql_calls
+    assert not any("PRAGMA" in s for s in sql_calls), sql_calls
+
+
 def test_spark_runner_get_table_names_uses_catalog():
     spark = _FakeSpark([], table_names=["generation_fuel", "plants", "boilers"])
     runner = SparkConnectRunner(spark=spark)

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -281,7 +281,7 @@ def test_enable_ansi_quoted_identifiers_sets_session_config():
 
     SparkConnectRunner._enable_ansi_quoted_identifiers(spark)
 
-    assert spark.conf.values.get("spark.sql.ansi.double_quoted_identifiers") == "true"
+    assert spark.conf.values.get("spark.sql.ansi.doubleQuotedIdentifiers") == "true"
 
 
 def test_enable_ansi_quoted_identifiers_warns_but_does_not_raise(caplog):
@@ -303,7 +303,7 @@ def test_enable_ansi_quoted_identifiers_warns_but_does_not_raise(caplog):
         _logger.remove(sink_id)
 
     combined = "\n".join(str(r) for r in caplog.records)
-    assert "double_quoted_identifiers" in combined
+    assert "doubleQuotedIdentifiers" in combined
     assert "config locked by admin" in combined
 
 

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -263,6 +263,50 @@ def test_log_session_info_warns_on_local_master(caplog):
     assert "running all work in one JVM" in combined
 
 
+def test_enable_ansi_quoted_identifiers_sets_session_config():
+    """Spark must be told to treat "name" as an identifier, not a string."""
+
+    class _RecordingConf:
+        def __init__(self):
+            self.values: dict[str, str] = {}
+
+        def set(self, key, value):
+            self.values[key] = value
+
+        def get(self, key):
+            return self.values.get(key)
+
+    spark = _FakeSpark([])
+    spark.conf = _RecordingConf()
+
+    SparkConnectRunner._enable_ansi_quoted_identifiers(spark)
+
+    assert spark.conf.values.get("spark.sql.ansi.double_quoted_identifiers") == "true"
+
+
+def test_enable_ansi_quoted_identifiers_warns_but_does_not_raise(caplog):
+    """If the conf can't be set, log a warning but keep the connection alive."""
+    from loguru import logger as _logger
+
+    class _RejectingConf:
+        def set(self, *_args, **_kwargs):
+            raise RuntimeError("config locked by admin")
+
+    spark = _FakeSpark([])
+    spark.conf = _RejectingConf()
+
+    sink_id = _logger.add(lambda msg: caplog.records.append(msg), level="WARNING")
+    try:
+        # Must not raise even if conf.set blows up.
+        SparkConnectRunner._enable_ansi_quoted_identifiers(spark)
+    finally:
+        _logger.remove(sink_id)
+
+    combined = "\n".join(str(r) for r in caplog.records)
+    assert "double_quoted_identifiers" in combined
+    assert "config locked by admin" in combined
+
+
 def test_probe_connection_raises_quickly_when_server_unreachable(monkeypatch):
     """An unresponsive server should fail in seconds, not hang for minutes."""
     import queue as _queue

--- a/tests/test_spark_runner.py
+++ b/tests/test_spark_runner.py
@@ -1,0 +1,126 @@
+"""Tests for SparkConnectRunner.
+
+These tests inject a fake Spark session so they can run without pyspark
+or a live Spark cluster. They verify the byte-cap truncation behavior
+and the cancellation-tag plumbing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pyarrow as pa
+import pytest
+
+from datasight.exceptions import QueryTimeoutError
+from datasight.runner import SparkConnectRunner
+
+
+class _FakePlan:
+    pass
+
+
+class _FakeClient:
+    def __init__(self, batches: list[pa.RecordBatch]):
+        self._batches = batches
+        self.iterator_consumed = 0
+
+    def to_table_as_iterator(self, plan, observations):
+        for batch in self._batches:
+            self.iterator_consumed += 1
+            yield pa.Table.from_batches([batch]), None
+
+
+class _FakeSparkDataFrame:
+    def __init__(self):
+        self._plan = _FakePlan()
+
+
+class _FakeSpark:
+    def __init__(self, batches: list[pa.RecordBatch]):
+        self.client = _FakeClient(batches)
+        self._sql_seen: list[str] = []
+        self.tags_added: list[str] = []
+        self.tags_removed: list[str] = []
+        self.tags_interrupted: list[str] = []
+
+    def sql(self, query: str) -> _FakeSparkDataFrame:
+        self._sql_seen.append(query)
+        return _FakeSparkDataFrame()
+
+    def addTag(self, tag: str) -> None:
+        self.tags_added.append(tag)
+
+    def removeTag(self, tag: str) -> None:
+        self.tags_removed.append(tag)
+
+    def interruptTag(self, tag: str) -> None:
+        self.tags_interrupted.append(tag)
+
+    def stop(self) -> None:
+        pass
+
+
+def _make_batch(n_rows: int) -> pa.RecordBatch:
+    return pa.RecordBatch.from_pydict(
+        {
+            "id": list(range(n_rows)),
+            # ~80 bytes per row of payload
+            "payload": ["x" * 80] * n_rows,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_spark_runner_returns_full_result_when_under_cap():
+    batches = [_make_batch(100), _make_batch(100)]
+    spark = _FakeSpark(batches)
+    runner = SparkConnectRunner(spark=spark, max_result_bytes=10 * 1024 * 1024)
+
+    df = await runner.run_sql("SELECT * FROM t")
+
+    assert len(df) == 200
+    assert "truncated" not in df.attrs
+    assert spark._sql_seen == ["SELECT * FROM t"]
+    # Tag added then removed; never interrupted on success.
+    assert spark.tags_added == spark.tags_removed
+    assert spark.tags_interrupted == []
+
+
+@pytest.mark.asyncio
+async def test_spark_runner_truncates_at_byte_cap():
+    # Each batch is ~10k rows × ~88 bytes = roughly 880KB. With a 1MB cap,
+    # we should truncate after the second batch.
+    batches = [_make_batch(10_000) for _ in range(5)]
+    spark = _FakeSpark(batches)
+    runner = SparkConnectRunner(spark=spark, max_result_bytes=1_000_000)
+
+    df = await runner.run_sql("SELECT * FROM huge")
+
+    assert df.attrs.get("truncated") is True
+    assert "truncation_reason" in df.attrs
+    # Should have stopped streaming early — not consumed all 5 batches.
+    assert spark.client.iterator_consumed < 5
+    assert len(df) < 50_000
+
+
+@pytest.mark.asyncio
+async def test_spark_runner_interrupts_on_timeout(monkeypatch):
+    # Hand-rolled spark whose sql() call blocks forever so wait_for fires.
+    class _BlockingSpark(_FakeSpark):
+        def sql(self, query: str):
+            import time
+
+            time.sleep(10)
+            return super().sql(query)
+
+    spark = _BlockingSpark([])
+    runner = SparkConnectRunner(spark=spark, query_timeout=0.1)
+
+    with pytest.raises(QueryTimeoutError):
+        await runner.run_sql("SELECT 1")
+
+    # Give the cancellation a moment to propagate.
+    await asyncio.sleep(0.05)
+    assert len(spark.tags_interrupted) == 1
+    assert spark.tags_interrupted[0].startswith("datasight-")

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ requires-dist = [
     { name = "prek", marker = "extra == 'dev'", specifier = ">=0.2,<1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1,<4" },
     { name = "pyarrow", specifier = ">=14.0,<19" },
-    { name = "pyspark", extras = ["connect"], marker = "extra == 'spark'", specifier = ">=3.5,<5" },
+    { name = "pyspark", extras = ["connect"], marker = "extra == 'spark'", specifier = ">=4.0,<5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<9" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23,<1" },
     { name = "pytest-cov", marker = "extra == 'dev'" },

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ toml = [
 
 [[package]]
 name = "datasight"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-flightsql" },
@@ -300,6 +300,9 @@ dev = [
 export = [
     { name = "kaleido" },
 ]
+spark = [
+    { name = "pyspark", extra = ["connect"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -318,6 +321,7 @@ requires-dist = [
     { name = "prek", marker = "extra == 'dev'", specifier = ">=0.2,<1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1,<4" },
     { name = "pyarrow", specifier = ">=14.0,<19" },
+    { name = "pyspark", extras = ["connect"], marker = "extra == 'spark'", specifier = ">=3.5,<5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<9" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23,<1" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
@@ -332,7 +336,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.29,<1" },
     { name = "zensical", marker = "extra == 'dev'", specifier = ">=0.0.31" },
 ]
-provides-extras = ["export", "dev"]
+provides-extras = ["export", "spark", "dev"]
 
 [[package]]
 name = "deepmerge"
@@ -411,6 +415,83 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
 ]
 
 [[package]]
@@ -832,6 +913,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -898,6 +994,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
     { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
     { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "py4j"
+version = "0.10.9.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/31/0b210511177070c8d5d3059556194352e5753602fa64b85b7ab81ec1a009/py4j-0.10.9.9.tar.gz", hash = "sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879", size = 761089, upload-time = "2025-01-15T03:53:18.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/db/ea0203e495be491c85af87b66e37acfd3bf756fd985f87e46fc5e3bf022c/py4j-0.10.9.9-py2.py3-none-any.whl", hash = "sha256:c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533", size = 203008, upload-time = "2025-01-15T03:53:15.648Z" },
 ]
 
 [[package]]
@@ -1067,6 +1172,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pyspark"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py4j" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/bf/58ee13add151469c25825b7125bbf62c3bdcec05eec4d458fcb5c5516066/pyspark-4.1.1.tar.gz", hash = "sha256:77f78984aa84fbe865c717dd37b49913b4e5c97d76ef6824f932f1aefa6621ec", size = 455359625, upload-time = "2026-01-09T09:38:38.28Z" }
+
+[package.optional-dependencies]
+connect = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "zstandard" },
 ]
 
 [[package]]
@@ -1465,4 +1590,78 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/35/0c6d0b57187bd470a05e8a391c0edd1d690eb429e12b9755c99cf60a370e/zensical-0.0.32-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0a73a53b1dd41fd239875a3cb57c4284747989c45b6933f18e9b51f1b5f3d8ef", size = 12975593, upload-time = "2026-04-07T11:41:21.436Z" },
     { url = "https://files.pythonhosted.org/packages/ee/2d/4e88bcefc33b7af22f0637fd002d3cf5384e8354f0a7f8a9dbfcd40cfa24/zensical-0.0.32-cp310-abi3-win32.whl", hash = "sha256:f8cb579bdb9b56f1704b93f4e17b42895c8cb466e8eec933fbe0153b5b1e3459", size = 12012163, upload-time = "2026-04-07T11:41:23.975Z" },
     { url = "https://files.pythonhosted.org/packages/8a/ae/a80a2f15fd10201fe3dfd6b5cdf85351165f820cf5b29e3c3b24092c158c/zensical-0.0.32-cp310-abi3-win_amd64.whl", hash = "sha256:6d662f42b5d0eadfac6d281e9d86574bc7a9f812f1ed496335d15f2d581d4b28", size = 12205948, upload-time = "2026-04-07T11:41:27.056Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
## Summary
- New `SparkConnectRunner` that streams Arrow batches from Spark Connect with a 100 MiB client-side cap (configurable via `SPARK_MAX_RESULT_BYTES`); truncation is surfaced via `df.attrs['truncated']` so the UI can warn the user instead of OOMing on multi-TB tables
- Timeouts use Spark Connect's `addTag` / `interruptTag` API so cancelled queries actually free cluster resources rather than just abandoning the gRPC stream client-side
- New `spark` dialect hint in `prompts.py` that tells the LLM the data is multi-TB — always aggregate, no `SELECT *`, partition predicates, mandatory `LIMIT`
- `pyspark[connect]>=3.5,<5` added as the optional `spark` extra (`pip install 'datasight[spark]'`)
- New `SPARK_REMOTE` / `SPARK_TOKEN` / `SPARK_MAX_RESULT_BYTES` env vars wired through `settings.py`, `config.py`, and the `cli`/`web` status displays

## Test plan
- [x] `pytest tests/test_spark_runner.py` — 3 new tests using a fake Spark session: full result under cap, truncation stops streaming early, timeout calls `interruptTag`
- [x] `pytest -m "not integration"` — full suite (1158 tests) green
- [x] `ruff check`, `ruff format --check`, `ty check` — clean
- [ ] Smoke test against a live Spark Connect cluster (pending — schema introspection should work as-is via `SHOW TABLES` / `DESCRIBE`, but not exercised yet)
- [ ] `datasight init` flow doesn't yet prompt for Spark settings; follow-up if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)