### PR TITLE
Add edit-and-replay for chat prompts

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,7 +64,7 @@ datasight [OPTIONS] COMMAND [ARGS]...
 - `measures`: Surface likely measures and default aggregations.
 - `quality`: Audit data quality - nulls, suspicious ranges, and date coverage.
 - `integrity`: Audit cross-table referential integrity - keys, orphans, and join risks.
-- `distribution`: Profile value distributions - percentiles, outliers, and energy flags.
+- `distribution`: Profile value distributions - percentiles, outliers, and measure flags.
 - `validate`: Run declarative validation rules against the database.
 - `audit-report`: Generate a comprehensive audit report combining all checks.
 - `dimensions`: Surface likely grouping dimensions and category breakdowns.
@@ -519,10 +519,10 @@ datasight integrity [OPTIONS]
 
 ### `datasight distribution`
 
-Profile value distributions - percentiles, outliers, and energy flags.
+Profile value distributions - percentiles, outliers, and measure flags.
 
 Use this to inspect numeric ranges, skew, zero/negative rates, outliers,
-and energy-domain flags before building charts or validation rules.
+and measure-semantic flags before building charts or validation rules.
 
 Examples:
 

--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -286,10 +286,20 @@ function handleSSEEvent(eventType: SSEEventType, data: SSEData): void {
   }
 }
 
+export interface SendMessageOptions {
+  /** When provided, the server drops turn N and everything after it before
+   *  running this prompt. Used by the edit-and-replay flow so the first call
+   *  truncates atomically with the new prompt. */
+  truncateBeforeTurn?: number;
+}
+
 /**
  * Send a chat message and process the SSE stream.
  */
-export async function sendMessage(text: string): Promise<void> {
+export async function sendMessage(
+  text: string,
+  options: SendMessageOptions = {},
+): Promise<void> {
   if (dashboardStore.currentView !== "chat") {
     dashboardStore.currentView = "chat";
   }
@@ -303,14 +313,19 @@ export async function sendMessage(text: string): Promise<void> {
   // Show typing indicator
   chatStore.pushMessage({ type: "typing" });
 
+  const body: Record<string, unknown> = {
+    message: text,
+    session_id: sessionStore.sessionId,
+  };
+  if (options.truncateBeforeTurn !== undefined) {
+    body.truncate_before_turn = options.truncateBeforeTurn;
+  }
+
   try {
     const resp = await fetch("/api/chat", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        message: text,
-        session_id: sessionStore.sessionId,
-      }),
+      body: JSON.stringify(body),
       signal: controller.signal,
     });
 
@@ -396,6 +411,38 @@ export async function respondSqlConfirm(
   } catch (e) {
     console.error("Failed to confirm SQL:", e);
   }
+}
+
+/**
+ * Replay the conversation from an edited turn forward. Drops the edited turn
+ * and every turn after it (server-side and locally), then re-sends the new
+ * prompt followed by the originals at later turns. Stops if any replayed turn
+ * errors or is aborted by the user.
+ */
+export async function replayFromEdit(
+  truncateBeforeTurn: number,
+  editedPrompt: string,
+  subsequentPrompts: string[],
+): Promise<void> {
+  await sendMessage(editedPrompt, { truncateBeforeTurn });
+  if (replayShouldStop()) return;
+  for (const prompt of subsequentPrompts) {
+    await sendMessage(prompt);
+    if (replayShouldStop()) return;
+  }
+}
+
+function replayShouldStop(): boolean {
+  const msgs = chatStore.messages;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
+    if (m.type === "error") return true;
+    if (m.type === "assistant_message") {
+      return m.content === "Generation stopped.";
+    }
+    if (m.type === "user_message") return false;
+  }
+  return false;
 }
 
 /**

--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -424,11 +424,19 @@ export async function replayFromEdit(
   editedPrompt: string,
   subsequentPrompts: string[],
 ): Promise<void> {
-  await sendMessage(editedPrompt, { truncateBeforeTurn });
-  if (replayShouldStop()) return;
-  for (const prompt of subsequentPrompts) {
-    await sendMessage(prompt);
+  // Hold isReplaying for the whole sequence so user input, summarize, and
+  // further edits can't interleave between turns while sendMessage briefly
+  // toggles isStreaming false.
+  chatStore.isReplaying = true;
+  try {
+    await sendMessage(editedPrompt, { truncateBeforeTurn });
     if (replayShouldStop()) return;
+    for (const prompt of subsequentPrompts) {
+      await sendMessage(prompt);
+      if (replayShouldStop()) return;
+    }
+  } finally {
+    chatStore.isReplaying = false;
   }
 }
 

--- a/frontend/src/lib/api/summarize.ts
+++ b/frontend/src/lib/api/summarize.ts
@@ -10,7 +10,7 @@ import { chatStore } from "$lib/stores/chat.svelte";
 const HEADER = "**Dataset Summary**\n\n";
 
 export async function summarizeDataset(): Promise<void> {
-  if (chatStore.isStreaming) return;
+  if (chatStore.isBusy) return;
 
   chatStore.isStreaming = true;
   chatStore.currentAssistantText = HEADER;

--- a/frontend/src/lib/components/ChatInput.svelte
+++ b/frontend/src/lib/components/ChatInput.svelte
@@ -39,7 +39,7 @@
 
   function handleSubmit() {
     const text = inputValue.trim();
-    if (!text || chatStore.isStreaming) return;
+    if (!text || chatStore.isBusy) return;
     inputValue = "";
     if (textareaEl) {
       textareaEl.style.height = "auto";
@@ -53,7 +53,7 @@
 
   /** Allow external code to send a message (e.g., suggestion/example clicks). */
   export function sendText(text: string) {
-    if (chatStore.isStreaming) return;
+    if (chatStore.isBusy) return;
     sendMessage(text);
   }
 </script>

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -208,7 +208,7 @@
         <button
           class="btn-icon"
           title="Summarize dataset"
-          disabled={chatStore.isStreaming}
+          disabled={chatStore.isBusy}
           onclick={() => summarizeDataset()}
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">

--- a/frontend/src/lib/components/MessageBubble.svelte
+++ b/frontend/src/lib/components/MessageBubble.svelte
@@ -11,6 +11,9 @@
     onDelete?: () => void;
     onCopy?: () => void;
     onDeleteBlock?: () => void;
+    /** When provided on a user bubble, renders an Edit button that opens an
+     *  inline editor. Submitting calls this with the new prompt text. */
+    onEdit?: (newText: string) => void;
   }
 
   let {
@@ -20,10 +23,50 @@
     onDelete,
     onCopy,
     onDeleteBlock,
+    onEdit,
   }: Props = $props();
 
   let bubbleEl = $state<HTMLElement | null>(null);
   let copied = $state(false);
+  let editing = $state(false);
+  let editText = $state("");
+  let editTextareaEl = $state<HTMLTextAreaElement | null>(null);
+
+  function startEdit() {
+    if (!onEdit) return;
+    editText = content;
+    editing = true;
+    tick().then(() => {
+      editTextareaEl?.focus();
+      const len = editTextareaEl?.value.length ?? 0;
+      editTextareaEl?.setSelectionRange(len, len);
+    });
+  }
+
+  function cancelEdit() {
+    editing = false;
+    editText = "";
+  }
+
+  function submitEdit() {
+    const trimmed = editText.trim();
+    if (!trimmed || trimmed === content) {
+      cancelEdit();
+      return;
+    }
+    editing = false;
+    onEdit?.(trimmed);
+  }
+
+  function onEditKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEdit();
+    } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      submitEdit();
+    }
+  }
 
   let displayText = $derived(
     streaming ? chatStore.currentAssistantText : content,
@@ -84,40 +127,87 @@
 <div class="message-row flex min-w-0 w-full animate-fade-in {role === 'user' ? 'justify-end' : ''} group"
   style="margin-bottom: 18px;">
   {#if role === "user"}
-    <div class="message-bubble relative max-w-[85%] rounded-xl bg-user-bg text-user-text whitespace-pre-wrap break-words"
-      style="padding: 12px {(onCopy || onDeleteBlock) ? '72px' : '16px'} 12px 16px; border-bottom-right-radius: 4px; font-size: 0.925rem; line-height: 1.6;">
-      <!-- User actions -->
-      <div
-        class="absolute flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
-        style="top: 8px; right: 8px;"
-      >
-        {#if onCopy}
+    {#if editing}
+      <div class="max-w-[85%] w-full flex flex-col rounded-xl bg-user-bg text-user-text"
+        style="padding: 10px 12px; border-bottom-right-radius: 4px; gap: 8px;">
+        <textarea
+          bind:this={editTextareaEl}
+          bind:value={editText}
+          onkeydown={onEditKeydown}
+          rows="3"
+          aria-label="Edit prompt"
+          class="w-full resize-y rounded-md bg-surface text-text-primary border border-border focus:outline-none focus:border-teal"
+          style="padding: 8px 10px; font-family: inherit; font-size: 0.925rem; line-height: 1.5; min-height: 64px;"
+        ></textarea>
+        <div class="flex items-center justify-end gap-2" style="font-size: 0.8rem;">
+          <span class="opacity-70" style="margin-right: auto;">
+            Replays from this prompt forward. ⌘/Ctrl+Enter to submit, Esc to cancel.
+          </span>
           <button
-            class="p-1 rounded hover:bg-surface-alt text-user-text cursor-pointer"
-            style="background: rgba(255,255,255,0.12);"
-            title="Copy prompt"
-            onclick={handleCopy}
+            class="rounded-md cursor-pointer"
+            style="padding: 4px 10px; background: rgba(255,255,255,0.15); color: var(--user-text);"
+            onclick={cancelEdit}
+            type="button"
           >
-            {#if copied}
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5l3 3 6-7" /></svg>
-            {:else}
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5" /><path d="M5 11H3.5A1.5 1.5 0 0 1 2 9.5v-7A1.5 1.5 0 0 1 3.5 1h7A1.5 1.5 0 0 1 12 2.5V5" /></svg>
-            {/if}
+            Cancel
           </button>
-        {/if}
-        {#if onDeleteBlock}
           <button
-            class="p-1 rounded hover:bg-surface-alt text-user-text cursor-pointer"
-            style="background: rgba(255,255,255,0.12);"
-            title="Delete question and responses"
-            onclick={onDeleteBlock}
+            class="rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            style="padding: 4px 10px; background: var(--teal); color: white;"
+            onclick={submitEdit}
+            disabled={!editText.trim() || editText.trim() === content}
+            type="button"
           >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M2 4h12M5.33 4V2.67a1.33 1.33 0 0 1 1.34-1.34h2.66a1.33 1.33 0 0 1 1.34 1.34V4M12.67 4v9.33a1.33 1.33 0 0 1-1.34 1.34H4.67a1.33 1.33 0 0 1-1.34-1.34V4" /></svg>
+            Replay
           </button>
-        {/if}
+        </div>
       </div>
-      {content}
-    </div>
+    {:else}
+      <div class="message-bubble relative max-w-[85%] rounded-xl bg-user-bg text-user-text whitespace-pre-wrap break-words"
+        style="padding: 12px {(onCopy || onDeleteBlock || onEdit) ? '104px' : '16px'} 12px 16px; border-bottom-right-radius: 4px; font-size: 0.925rem; line-height: 1.6;">
+        <!-- User actions -->
+        <div
+          class="absolute flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+          style="top: 8px; right: 8px;"
+        >
+          {#if onEdit}
+            <button
+              class="p-1 rounded hover:bg-surface-alt text-user-text cursor-pointer"
+              style="background: rgba(255,255,255,0.12);"
+              title="Edit prompt and replay"
+              onclick={startEdit}
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 2.5l2 2L5 13H3v-2l8.5-8.5z" /><path d="M10 4l2 2" /></svg>
+            </button>
+          {/if}
+          {#if onCopy}
+            <button
+              class="p-1 rounded hover:bg-surface-alt text-user-text cursor-pointer"
+              style="background: rgba(255,255,255,0.12);"
+              title="Copy prompt"
+              onclick={handleCopy}
+            >
+              {#if copied}
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5l3 3 6-7" /></svg>
+              {:else}
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5" /><path d="M5 11H3.5A1.5 1.5 0 0 1 2 9.5v-7A1.5 1.5 0 0 1 3.5 1h7A1.5 1.5 0 0 1 12 2.5V5" /></svg>
+              {/if}
+            </button>
+          {/if}
+          {#if onDeleteBlock}
+            <button
+              class="p-1 rounded hover:bg-surface-alt text-user-text cursor-pointer"
+              style="background: rgba(255,255,255,0.12);"
+              title="Delete question and responses"
+              onclick={onDeleteBlock}
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M2 4h12M5.33 4V2.67a1.33 1.33 0 0 1 1.34-1.34h2.66a1.33 1.33 0 0 1 1.34 1.34V4M12.67 4v9.33a1.33 1.33 0 0 1-1.34 1.34H4.67a1.33 1.33 0 0 1-1.34-1.34V4" /></svg>
+            </button>
+          {/if}
+        </div>
+        {content}
+      </div>
+    {/if}
   {:else}
     <!-- Assistant bubble -->
     <div class="max-w-[85%] min-w-0 relative">

--- a/frontend/src/lib/components/MessageList.svelte
+++ b/frontend/src/lib/components/MessageList.svelte
@@ -4,7 +4,7 @@
   import { schemaStore } from "$lib/stores/schema.svelte";
   import { settingsStore } from "$lib/stores/settings.svelte";
   import type { ChatEvent } from "$lib/stores/chat.svelte";
-  import { sendMessage, loadPlotlySpec } from "$lib/api/chat";
+  import { sendMessage, loadPlotlySpec, replayFromEdit } from "$lib/api/chat";
   import { summarizeDataset } from "$lib/api/summarize";
   import { addBookmark } from "$lib/api/saved";
   import { addReport } from "$lib/api/saved";
@@ -75,6 +75,22 @@
       ...messages.slice(0, index),
       ...messages.slice(end),
     ];
+  }
+
+  async function editAndReplay(index: number, newText: string) {
+    if (chatStore.isStreaming) return;
+    const turnIdx = turnIndices[index];
+    if (turnIdx == null || turnIdx < 0) return;
+
+    // Capture every later user prompt before truncating locally.
+    const subsequent: string[] = [];
+    for (let i = index + 1; i < chatStore.messages.length; i++) {
+      const msg = chatStore.messages[i];
+      if (msg.type === "user_message") subsequent.push(msg.content);
+    }
+
+    chatStore.messages = chatStore.messages.slice(0, index);
+    await replayFromEdit(turnIdx, newText, subsequent);
   }
 
   async function pinResult(
@@ -246,6 +262,7 @@
         content={event.content}
         onCopy={() => navigator.clipboard.writeText(event.content)}
         onDeleteBlock={() => deleteUserBlock(idx)}
+        onEdit={(newText) => editAndReplay(idx, newText)}
       />
     {:else if event.type === "assistant_message"}
       <MessageBubble

--- a/frontend/src/lib/components/MessageList.svelte
+++ b/frontend/src/lib/components/MessageList.svelte
@@ -78,7 +78,7 @@
   }
 
   async function editAndReplay(index: number, newText: string) {
-    if (chatStore.isStreaming) return;
+    if (chatStore.isBusy) return;
     const turnIdx = turnIndices[index];
     if (turnIdx == null || turnIdx < 0) return;
 

--- a/frontend/src/lib/stores/chat.svelte.ts
+++ b/frontend/src/lib/stores/chat.svelte.ts
@@ -87,6 +87,7 @@ export type ChatEvent =
 function createChatStore() {
   let messages = $state<ChatEvent[]>([]);
   let isStreaming = $state(false);
+  let isReplaying = $state(false);
   let currentAssistantText = $state("");
   let abortController = $state<AbortController | null>(null);
   let lastSql = $state("");
@@ -106,6 +107,15 @@ function createChatStore() {
     },
     set isStreaming(v: boolean) {
       isStreaming = v;
+    },
+    get isReplaying() {
+      return isReplaying;
+    },
+    set isReplaying(v: boolean) {
+      isReplaying = v;
+    },
+    get isBusy() {
+      return isStreaming || isReplaying;
     },
     get currentAssistantText() {
       return currentAssistantText;

--- a/frontend/tests/replay.test.ts
+++ b/frontend/tests/replay.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * Tests for edit-and-replay: the first call must carry truncate_before_turn,
+ * subsequent replayed prompts must not, and replay stops on error.
+ */
+
+interface CapturedRequest {
+  body: Record<string, unknown>;
+}
+
+function makeFetchStub(
+  scriptedResponses: Array<{ events: Array<{ event: string; data: unknown }> }>,
+) {
+  const requests: CapturedRequest[] = [];
+  let callIndex = 0;
+  const fetchStub = vi.fn(async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    requests.push({ body });
+
+    const script = scriptedResponses[callIndex++] ?? { events: [] };
+    const lines = script.events
+      .map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`)
+      .join("");
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(lines));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  });
+  return { fetchStub, requests };
+}
+
+describe("replayFromEdit", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { chatStore } = await import("$lib/stores/chat.svelte");
+    chatStore.clear();
+    chatStore.messages = [];
+  });
+
+  it("sends truncate_before_turn only on the first replayed call", async () => {
+    const okResponse = {
+      events: [
+        { event: "token", data: { text: "ok" } },
+        { event: "done", data: {} },
+      ],
+    };
+    const { fetchStub, requests } = makeFetchStub([
+      okResponse,
+      okResponse,
+      okResponse,
+    ]);
+    vi.stubGlobal("fetch", fetchStub);
+
+    const { replayFromEdit } = await import("$lib/api/chat");
+    await replayFromEdit(1, "edited q1", ["original q2", "original q3"]);
+
+    expect(requests).toHaveLength(3);
+    expect(requests[0].body.message).toBe("edited q1");
+    expect(requests[0].body.truncate_before_turn).toBe(1);
+    expect(requests[1].body.message).toBe("original q2");
+    expect(requests[1].body.truncate_before_turn).toBeUndefined();
+    expect(requests[2].body.message).toBe("original q3");
+    expect(requests[2].body.truncate_before_turn).toBeUndefined();
+  });
+
+  it("stops the replay loop after an error event", async () => {
+    const okResponse = {
+      events: [
+        { event: "token", data: { text: "ok" } },
+        { event: "done", data: {} },
+      ],
+    };
+    const errorResponse = {
+      events: [
+        { event: "error", data: { error: "boom" } },
+        { event: "done", data: {} },
+      ],
+    };
+    const { fetchStub, requests } = makeFetchStub([
+      okResponse,
+      errorResponse,
+      okResponse,
+    ]);
+    vi.stubGlobal("fetch", fetchStub);
+
+    const { replayFromEdit } = await import("$lib/api/chat");
+    await replayFromEdit(0, "edited q0", ["q1", "q2"]);
+
+    // First two calls happen; third never fires because we stopped.
+    expect(requests).toHaveLength(2);
+    expect(requests[0].body.message).toBe("edited q0");
+    expect(requests[1].body.message).toBe("q1");
+  });
+
+  it("omits truncate_before_turn from the body when no replay is in progress", async () => {
+    const okResponse = {
+      events: [
+        { event: "token", data: { text: "ok" } },
+        { event: "done", data: {} },
+      ],
+    };
+    const { fetchStub, requests } = makeFetchStub([okResponse]);
+    vi.stubGlobal("fetch", fetchStub);
+
+    const { sendMessage } = await import("$lib/api/chat");
+    await sendMessage("plain question");
+
+    expect(requests[0].body.message).toBe("plain question");
+    expect(requests[0].body).not.toHaveProperty("truncate_before_turn");
+  });
+});

--- a/src/datasight/cli_commands/distribution.py
+++ b/src/datasight/cli_commands/distribution.py
@@ -93,10 +93,10 @@ async def _run_ask_pipeline(*args, **kwargs):
     help="Write the distribution profile to a file instead of stdout.",
 )
 def distribution(project_dir, table, column, output_format, output_path):
-    """Profile value distributions - percentiles, outliers, and energy flags.
+    """Profile value distributions - percentiles, outliers, and measure flags.
 
     Use this to inspect numeric ranges, skew, zero/negative rates, outliers,
-    and energy-domain flags before building charts or validation rules.
+    and measure-semantic flags before building charts or validation rules.
     """
     from rich.console import Console
 

--- a/src/datasight/data_profile.py
+++ b/src/datasight/data_profile.py
@@ -11,6 +11,21 @@ from datasight.runner import RunSql
 from datasight.schema import _quote_identifier
 
 
+def _to_int_or_none(value: Any) -> int | None:
+    """Convert a SQL count value to ``int``. Returns ``None`` for ``None`` and NaN.
+
+    pandas surfaces SQL NULL as ``float('nan')`` for numeric columns (e.g. when
+    ``SUM`` runs over an empty table), so a plain ``None`` check misses it and
+    ``int(NaN)`` raises ``ValueError``.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _is_date_dtype(dtype: str) -> bool:
     lower = dtype.lower()
     return any(token in lower for token in ("date", "time", "timestamp"))
@@ -473,14 +488,13 @@ async def _get_dimension_stats(
     if stats_df.empty:
         return None
 
-    distinct_count = stats_df.iloc[0].get("distinct_count")
-    null_count = stats_df.iloc[0].get("null_count")
+    # SUM over an empty table returns SQL NULL, which pandas surfaces as NaN
+    # (a float), not None. Use _to_int_or_none to handle both shapes.
+    distinct_count = _to_int_or_none(stats_df.iloc[0].get("distinct_count"))
+    null_count = _to_int_or_none(stats_df.iloc[0].get("null_count"))
     null_rate = None
-    if row_count:
-        try:
-            null_rate = round((float(null_count or 0) / row_count) * 100, 1)
-        except (TypeError, ValueError, ZeroDivisionError):
-            null_rate = None
+    if row_count and null_count is not None:
+        null_rate = round(null_count / row_count * 100, 1)
 
     samples = []
     if not sample_df.empty and "value" in sample_df.columns:
@@ -489,8 +503,8 @@ async def _get_dimension_stats(
     return {
         "table": table,
         "column": column,
-        "distinct_count": None if distinct_count is None else int(distinct_count),
-        "null_count": None if null_count is None else int(null_count),
+        "distinct_count": distinct_count,
+        "null_count": null_count,
         "null_rate": null_rate,
         "sample_values": samples,
     }

--- a/src/datasight/data_profile.py
+++ b/src/datasight/data_profile.py
@@ -1217,17 +1217,15 @@ async def build_table_profile(table_info: dict[str, Any], run_sql: RunSql) -> di
             ),
             "value",
         )
+        null_count_int = _to_int_or_none(null_count)
         null_rate = None
-        if row_count:
-            try:
-                null_rate = round((float(null_count or 0) / row_count) * 100, 1)
-            except (TypeError, ValueError, ZeroDivisionError):
-                null_rate = None
-        if null_count:
+        if row_count and null_count_int is not None:
+            null_rate = round(null_count_int / row_count * 100, 1)
+        if null_count_int:
             null_columns.append(
                 {
                     "column": column_name,
-                    "null_count": int(null_count),
+                    "null_count": null_count_int,
                     "null_rate": null_rate,
                 }
             )
@@ -1296,13 +1294,11 @@ async def build_column_profile(
         "value",
     )
 
-    profile["null_count"] = None if null_count is None else int(null_count)
-    profile["distinct_count"] = None if distinct_count is None else int(distinct_count)
-    if row_count:
-        try:
-            profile["null_rate"] = round((float(null_count or 0) / row_count) * 100, 1)
-        except (TypeError, ValueError, ZeroDivisionError):
-            profile["null_rate"] = None
+    null_count_int = _to_int_or_none(null_count)
+    profile["null_count"] = null_count_int
+    profile["distinct_count"] = _to_int_or_none(distinct_count)
+    if row_count and null_count_int is not None:
+        profile["null_rate"] = round(null_count_int / row_count * 100, 1)
     else:
         profile["null_rate"] = None
 

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -1285,23 +1285,66 @@ def _compact_chart_tool_result_for_stream(
 # ---------------------------------------------------------------------------
 
 
+def _truncate_session_at_turn(
+    messages: list[dict[str, Any]],
+    evt_log: list[dict[str, Any]],
+    turn_index: int,
+) -> None:
+    """Drop turn ``turn_index`` and everything after it from a session.
+
+    A turn is anchored by a user prompt: the Nth ``USER_MESSAGE`` event in
+    ``evt_log`` and the Nth ``role=user`` string entry in ``messages``. After
+    truncation, the next ``messages.append({"role": "user", ...})`` and matching
+    user-message event resume the conversation cleanly at turn ``turn_index``.
+    Out-of-range indices leave the lists untouched.
+    """
+    if turn_index < 0:
+        return
+
+    user_count = 0
+    evt_cut = len(evt_log)
+    for i, evt in enumerate(evt_log):
+        if evt.get("event") == EventType.USER_MESSAGE:
+            if user_count == turn_index:
+                evt_cut = i
+                break
+            user_count += 1
+    del evt_log[evt_cut:]
+
+    user_count = 0
+    msg_cut = len(messages)
+    for i, msg in enumerate(messages):
+        if msg.get("role") == "user" and isinstance(msg.get("content"), str):
+            if user_count == turn_index:
+                msg_cut = i
+                break
+            user_count += 1
+    del messages[msg_cut:]
+
+
 async def generate_chat_response(
     message: str,
     session_id: str,
     state: AppState,
     request: Request | None = None,
+    truncate_before_turn: int | None = None,
 ) -> AsyncIterator[str]:
     """Generate SSE events for a chat message."""
     if state.llm_client is None:
         raise ConfigurationError("LLM not configured. Open Settings to add your API key.")
 
     messages = state.get_session_messages(session_id)
+    conv = state.conversations.get(session_id) if state.conversations else None
+    evt_log_pre = conv["events"] if conv else []
+    if truncate_before_turn is not None:
+        _truncate_session_at_turn(messages, evt_log_pre, truncate_before_turn)
+        if conv and truncate_before_turn == 0:
+            conv["title"] = "Untitled"
     messages.append({"role": "user", "content": message})
     turn_id = str(uuid.uuid4())
     tool_provenance: list[dict[str, Any]] = []
 
-    conv = state.conversations.get(session_id) if state.conversations else None
-    evt_log = conv["events"] if conv else []
+    evt_log = evt_log_pre
     evt_log.append(
         {"event": EventType.USER_MESSAGE, "data": {"text": message, "turn_id": turn_id}}
     )
@@ -3702,6 +3745,19 @@ async def chat(request: Request, state: AppState = Depends(get_state)):
     body = await request.json()
     message = body.get("message", "").strip()
     session_id = body.get("session_id", "default")
+    truncate_raw = body.get("truncate_before_turn")
+    truncate_before_turn: int | None = None
+    if truncate_raw is not None:
+        if not isinstance(truncate_raw, int) or isinstance(truncate_raw, bool) or truncate_raw < 0:
+            return StreamingResponse(
+                iter(
+                    [
+                        f'event: {EventType.ERROR}\ndata: {{"error":"Invalid truncate_before_turn"}}\n\n'
+                    ]
+                ),
+                media_type="text/event-stream",
+            )
+        truncate_before_turn = truncate_raw
 
     try:
         validate_session_id(session_id)
@@ -3723,7 +3779,11 @@ async def chat(request: Request, state: AppState = Depends(get_state)):
         async with session_lock:
             try:
                 async for event in generate_chat_response(
-                    message, session_id, state, request=request
+                    message,
+                    session_id,
+                    state,
+                    request=request,
+                    truncate_before_turn=truncate_before_turn,
                 ):
                     yield event
             except Exception as exc:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -388,10 +388,15 @@ def test_validate_runs_rules(tv_project_isolated):
     assert result.exit_code == 0
 
 
-def test_audit_report_on_tv_project(tv_project):
+def test_audit_report_on_tv_project(tv_project, tmp_path):
+    out_path = tmp_path / "report.html"
     runner = CliRunner()
-    result = runner.invoke(cli, ["audit-report", "--project-dir", tv_project])
+    result = runner.invoke(
+        cli,
+        ["audit-report", "--project-dir", tv_project, "--output", str(out_path)],
+    )
     assert result.exit_code == 0
+    assert out_path.exists()
 
 
 def test_audit_report_html_output(tv_project, tmp_path):

--- a/tests/test_data_profile_extra.py
+++ b/tests/test_data_profile_extra.py
@@ -432,6 +432,39 @@ async def test_build_column_profile_text(energy_conn):
 
 
 @pytest.mark.asyncio
+async def test_build_table_profile_empty_table(energy_conn):
+    """Empty table → SUM returns NaN; profile must not raise on int(NaN)."""
+    energy_conn.execute("CREATE TABLE empty_tbl (label VARCHAR, value INTEGER)")
+    schema = {
+        "name": "empty_tbl",
+        "row_count": 0,
+        "columns": [
+            {"name": "label", "dtype": "VARCHAR"},
+            {"name": "value", "dtype": "INTEGER"},
+        ],
+    }
+    out = await build_table_profile(schema, _rs(energy_conn))
+    assert out["table"] == "empty_tbl"
+    assert out["null_columns"] == []
+
+
+@pytest.mark.asyncio
+async def test_build_column_profile_empty_table(energy_conn):
+    """Empty table → SUM returns NaN; column profile must not raise."""
+    energy_conn.execute("CREATE TABLE empty_col (label VARCHAR)")
+    schema = {
+        "name": "empty_col",
+        "row_count": 0,
+        "columns": [{"name": "label", "dtype": "VARCHAR"}],
+    }
+    col = {"name": "label", "dtype": "VARCHAR"}
+    out = await build_column_profile(schema, col, _rs(energy_conn))
+    assert out["null_count"] is None
+    assert out["distinct_count"] == 0
+    assert out["null_rate"] is None
+
+
+@pytest.mark.asyncio
 async def test_build_column_profile_other_type(energy_conn):
     """Fall-through branch: neither numeric/date/text -> sample_values path."""
     energy_conn.execute("CREATE TABLE bools (b BOOLEAN)")

--- a/tests/test_data_profile_extra.py
+++ b/tests/test_data_profile_extra.py
@@ -281,6 +281,19 @@ async def test_get_dimension_stats_query_error(energy_conn):
 
 
 @pytest.mark.asyncio
+async def test_get_dimension_stats_empty_table_returns_none_counts(energy_conn):
+    """An empty table makes SUM(...) return SQL NULL → pandas NaN; counts must
+    fall back to None instead of raising ValueError when cast to int."""
+    energy_conn.execute("CREATE TABLE empty_dim (label VARCHAR)")
+    out = await _get_dimension_stats(_rs(energy_conn), "empty_dim", "label", 0)
+    assert out is not None
+    assert out["distinct_count"] == 0
+    assert out["null_count"] is None
+    assert out["null_rate"] is None
+    assert out["sample_values"] == []
+
+
+@pytest.mark.asyncio
 async def test_get_numeric_stats_query_error(energy_conn):
     out = await _get_numeric_stats(_rs(energy_conn), "nonexistent", "x")
     assert out is None

--- a/tests/test_web_app_extra.py
+++ b/tests/test_web_app_extra.py
@@ -983,3 +983,66 @@ def test_measure_editor_validate_non_list(isolated_web_state: None, project_dir:
     body = resp.json()
     assert body["ok"] is False
     assert any("list" in e.lower() for e in body["errors"])
+
+
+def _make_session_state(num_turns: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Build a (messages, evt_log) pair with ``num_turns`` user turns.
+
+    Each turn looks like a real conversation: a user prompt, a tool call, a
+    tool result, and an assistant reply. Turn N's prompt text is ``"qN"``.
+    """
+    messages: list[dict[str, Any]] = []
+    evt_log: list[dict[str, Any]] = []
+    for n in range(num_turns):
+        messages.append({"role": "user", "content": f"q{n}"})
+        messages.append({"role": "assistant", "content": [{"type": "tool_use"}]})
+        messages.append({"role": "user", "content": [{"type": "tool_result"}]})
+        messages.append({"role": "assistant", "content": f"a{n}"})
+
+        evt_log.append({"event": web_app.EventType.USER_MESSAGE, "data": {"text": f"q{n}"}})
+        evt_log.append({"event": web_app.EventType.TOOL_START, "data": {}})
+        evt_log.append({"event": web_app.EventType.TOOL_RESULT, "data": {}})
+        evt_log.append({"event": web_app.EventType.ASSISTANT_MESSAGE, "data": {"text": f"a{n}"}})
+    return messages, evt_log
+
+
+def test_truncate_session_at_turn_drops_turn_and_after() -> None:
+    messages, evt_log = _make_session_state(3)
+    web_app._truncate_session_at_turn(messages, evt_log, 1)
+
+    # Only turn 0 should remain in messages (4 entries) and evt_log (4 entries).
+    assert [
+        m.get("content") for m in messages if m["role"] == "user" and isinstance(m["content"], str)
+    ] == ["q0"]
+    user_events = [e for e in evt_log if e["event"] == web_app.EventType.USER_MESSAGE]
+    assert [e["data"]["text"] for e in user_events] == ["q0"]
+
+
+def test_truncate_session_at_turn_zero_clears_all() -> None:
+    messages, evt_log = _make_session_state(2)
+    web_app._truncate_session_at_turn(messages, evt_log, 0)
+    assert messages == []
+    assert evt_log == []
+
+
+def test_truncate_session_at_turn_out_of_range_is_noop() -> None:
+    messages, evt_log = _make_session_state(2)
+    msgs_before = list(messages)
+    evt_before = list(evt_log)
+    web_app._truncate_session_at_turn(messages, evt_log, 99)
+    assert messages == msgs_before
+    assert evt_log == evt_before
+
+
+def test_chat_rejects_invalid_truncate_before_turn(isolated_web_state: None) -> None:
+    with TestClient(web_app.app) as client:
+        resp = client.post(
+            "/api/chat",
+            json={
+                "message": "hi",
+                "session_id": "sess",
+                "truncate_before_turn": -1,
+            },
+        )
+    assert resp.status_code == 200
+    assert "Invalid truncate_before_turn" in resp.text

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ toml = [
 
 [[package]]
 name = "datasight"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-flightsql" },


### PR DESCRIPTION
## Summary

- **Edit-and-replay** for chat prompts — click a past user prompt, edit it, and the edited turn plus every later turn replay against the new state. Frontend wires up the editor + sequential replay loop; backend `POST /api/chat` accepts an optional `truncate_before_turn` so the truncate + new-prompt happen atomically under the session lock.
- **`datasight recipes list` crash fix** — `_get_dimension_stats` cast `null_count` with `int(...)` after a `null is None` guard, but pandas surfaces SQL NULL as `float('nan')` for empty tables, so `int(NaN)` raised. Added a `_to_int_or_none` helper and a regression test against an empty table.
- **Stop creating `report.html` in repo root** — `test_audit_report_on_tv_project` invoked `audit-report` with no `--output`, leaking the default `./report.html` into the repo. Now writes to `tmp_path`.
- **Drop energy-domain wording from `distribution` help text** — "energy flags" → "measure flags". Examples should still use energy language; feature descriptions should stay domain-neutral.

Also includes a one-line `uv.lock` bump (datasight 0.6.1 → 0.6.2) that the prior version-bump commit missed; the ty pre-commit hook regenerated it.

## Test plan

- [x] `pytest -m "not integration"` — 1213 pass
- [x] `cd frontend && npm test` — 93 pass (3 new in `replay.test.ts`)
- [x] `cd frontend && npm run check` — 0 errors, 0 warnings
- [x] `prek run --all-files` — all green
- [ ] Manual UI check: open a chat, click pencil on a past prompt, edit, confirm replay re-runs all later turns; verify Stop and error mid-replay halt the loop
- [ ] Manual: `datasight recipes list` against a project that has an empty dimension column no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)