### PR TITLE
Add import modes for file-backed ingestion

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -317,7 +317,7 @@ datasight generate [OPTIONS] [FILES]...
 | `--overwrite` | Overwrite existing files. |
 | `--table`, `-t` | Table or view to include (can be specified multiple times). If omitted, all tables are included. |
 | `--db-path` | Output DuckDB path to create from CSV/Parquet/Excel or mixed file inputs (default: database.duckdb). Do not use this with a single existing DuckDB or SQLite database; those are referenced directly. |
-| `--import-mode` | When FILES are CSV/Parquet/Excel inputs, choose whether datasight creates source-backed views or materialized DuckDB tables. 'auto' preserves the existing cheap behavior and keeps CSV/Parquet source-backed; use 'table' to opt into materialization. Default: `auto`. |
+| `--import-mode` | When FILES are CSV/Parquet inputs, choose whether datasight creates source-backed views or materialized DuckDB tables. 'auto' preserves the existing cheap behavior and keeps CSV/Parquet source-backed; use 'table' to opt into materialization. Excel workbooks are always materialized as tables. Default: `auto`. |
 | `--compact-schema` | Write schema.yaml with table names only. Default adds an empty 'excluded_columns: []' placeholder per table so you can fill in glob patterns for columns to hide. |
 | `-v`, `--verbose` | Enable debug logging. |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -317,6 +317,7 @@ datasight generate [OPTIONS] [FILES]...
 | `--overwrite` | Overwrite existing files. |
 | `--table`, `-t` | Table or view to include (can be specified multiple times). If omitted, all tables are included. |
 | `--db-path` | Output DuckDB path to create from CSV/Parquet/Excel or mixed file inputs (default: database.duckdb). Do not use this with a single existing DuckDB or SQLite database; those are referenced directly. |
+| `--import-mode` | When FILES are CSV/Parquet/Excel inputs, choose whether datasight creates source-backed views or materialized DuckDB tables. 'auto' prefers tables for CSV and views for Parquet. Default: `auto`. |
 | `--compact-schema` | Write schema.yaml with table names only. Default adds an empty 'excluded_columns: []' placeholder per table so you can fill in glob patterns for columns to hide. |
 | `-v`, `--verbose` | Enable debug logging. |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -317,7 +317,7 @@ datasight generate [OPTIONS] [FILES]...
 | `--overwrite` | Overwrite existing files. |
 | `--table`, `-t` | Table or view to include (can be specified multiple times). If omitted, all tables are included. |
 | `--db-path` | Output DuckDB path to create from CSV/Parquet/Excel or mixed file inputs (default: database.duckdb). Do not use this with a single existing DuckDB or SQLite database; those are referenced directly. |
-| `--import-mode` | When FILES are CSV/Parquet/Excel inputs, choose whether datasight creates source-backed views or materialized DuckDB tables. 'auto' prefers tables for CSV and views for Parquet. Default: `auto`. |
+| `--import-mode` | When FILES are CSV/Parquet/Excel inputs, choose whether datasight creates source-backed views or materialized DuckDB tables. 'auto' preserves the existing cheap behavior and keeps CSV/Parquet source-backed; use 'table' to opt into materialization. Default: `auto`. |
 | `--compact-schema` | Write schema.yaml with table names only. Default adds an empty 'excluded_columns: []' placeholder per table so you can fill in glob patterns for columns to hide. |
 | `-v`, `--verbose` | Enable debug logging. |
 

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -121,7 +121,8 @@ async def _run_ask_pipeline(*args, **kwargs):
     help=(
         "When FILES are CSV/Parquet/Excel inputs, choose whether datasight "
         "creates source-backed views or materialized DuckDB tables. "
-        "'auto' prefers tables for CSV and views for Parquet."
+        "'auto' preserves the existing cheap behavior and keeps CSV/Parquet "
+        "source-backed; use 'table' to opt into materialization."
     ),
 )
 @click.option(

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -173,6 +173,9 @@ def generate(
     # configured for a non-DuckDB backend; we're not going to touch the
     # local DuckDB in that case.
     use_files = bool(files)
+    inspection_import_mode = (
+        "auto" if use_files and normalized_import_mode == "table" else normalized_import_mode
+    )
     db_target: Path | None = None
     sqlite_source_path: Path | None = None
     duckdb_source_path: Path | None = None
@@ -341,7 +344,7 @@ def generate(
             from datasight.explore import create_files_session_for_settings
 
             sql_runner, tables_info = create_files_session_for_settings(
-                list(files), settings.database, import_mode=normalized_import_mode
+                list(files), settings.database, import_mode=inspection_import_mode
             )
         else:
             sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
@@ -513,8 +516,16 @@ def generate(
             from datasight.explore import build_persistent_duckdb
 
             assert db_target is not None  # set above when use_files is True
+            persistent_tables_info = tables_info
+            if normalized_import_mode == "table":
+                persistent_tables_info = []
+                for table_info in tables_info:
+                    updated = dict(table_info)
+                    if updated.get("type") not in {"duckdb", "xlsx"}:
+                        updated["import_mode"] = "table"
+                    persistent_tables_info.append(updated)
             try:
-                build_persistent_duckdb(db_target, tables_info, overwrite=overwrite)
+                build_persistent_duckdb(db_target, persistent_tables_info, overwrite=overwrite)
             except FileExistsError:
                 # Preflight above rejects pre-existing DBs without --overwrite,
                 # so reaching here means the file appeared mid-run.

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -119,10 +119,11 @@ async def _run_ask_pipeline(*args, **kwargs):
     default="auto",
     show_default=True,
     help=(
-        "When FILES are CSV/Parquet/Excel inputs, choose whether datasight "
+        "When FILES are CSV/Parquet inputs, choose whether datasight "
         "creates source-backed views or materialized DuckDB tables. "
         "'auto' preserves the existing cheap behavior and keeps CSV/Parquet "
-        "source-backed; use 'table' to opt into materialization."
+        "source-backed; use 'table' to opt into materialization. Excel "
+        "workbooks are always materialized as tables."
     ),
 )
 @click.option(
@@ -163,6 +164,7 @@ def generate(
     _configure_logging(level)
     settings, resolved_model = _resolve_settings(project_dir, model)
     _validate_settings_for_llm(settings)
+    normalized_import_mode = import_mode.lower()
 
     # Resolve the would-be DB path up front so we can include it in the
     # preflight check — otherwise a stale database.duckdb would abort the
@@ -174,6 +176,12 @@ def generate(
     db_target: Path | None = None
     sqlite_source_path: Path | None = None
     duckdb_source_path: Path | None = None
+    if not use_files and normalized_import_mode != "auto":
+        click.echo(
+            "Error: --import-mode only applies when importing CSV/Parquet/Excel files.",
+            err=True,
+        )
+        sys.exit(1)
     if use_files:
         from datasight.explore import detect_file_type
 
@@ -181,6 +189,22 @@ def generate(
             (Path(file_path).resolve(), detect_file_type(str(Path(file_path).resolve())))
             for file_path in files
         ]
+        if normalized_import_mode == "view" and any(
+            file_type == "xlsx" for _, file_type in resolved_file_types
+        ):
+            click.echo(
+                "Error: Excel inputs are always materialized as DuckDB tables; "
+                "--import-mode=view is not supported for .xlsx files.",
+                err=True,
+            )
+            sys.exit(1)
+        if settings.database.mode == "spark" and normalized_import_mode == "table":
+            click.echo(
+                "Error: --import-mode=table is not supported when DB_MODE=spark; "
+                "Spark file sessions always register temp views.",
+                err=True,
+            )
+            sys.exit(1)
         sqlite_files = [
             file_path for file_path, file_type in resolved_file_types if file_type == "sqlite"
         ]
@@ -194,7 +218,7 @@ def generate(
                     err=True,
                 )
                 sys.exit(1)
-            if import_mode.lower() != "auto":
+            if normalized_import_mode != "auto":
                 click.echo(
                     "Error: --import-mode only applies when importing CSV/Parquet/Excel "
                     "or mixed file inputs into DuckDB.",
@@ -210,7 +234,7 @@ def generate(
                 sys.exit(1)
             sqlite_source_path = sqlite_files[0]
         elif len(duckdb_files) == 1 and len(files) == 1:
-            if import_mode.lower() != "auto":
+            if normalized_import_mode != "auto":
                 click.echo(
                     "Error: --import-mode only applies when importing CSV/Parquet/Excel "
                     "or mixed file inputs into DuckDB.",
@@ -317,7 +341,7 @@ def generate(
             from datasight.explore import create_files_session_for_settings
 
             sql_runner, tables_info = create_files_session_for_settings(
-                list(files), settings.database, import_mode=import_mode.lower()
+                list(files), settings.database, import_mode=normalized_import_mode
             )
         else:
             sql_runner = create_sql_runner_from_settings(settings.database, project_dir)

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -114,6 +114,17 @@ async def _run_ask_pipeline(*args, **kwargs):
     ),
 )
 @click.option(
+    "--import-mode",
+    type=click.Choice(["auto", "view", "table"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help=(
+        "When FILES are CSV/Parquet/Excel inputs, choose whether datasight "
+        "creates source-backed views or materialized DuckDB tables. "
+        "'auto' prefers tables for CSV and views for Parquet."
+    ),
+)
+@click.option(
     "--compact-schema",
     is_flag=True,
     help=(
@@ -123,7 +134,17 @@ async def _run_ask_pipeline(*args, **kwargs):
     ),
 )
 @click.option("-v", "--verbose", is_flag=True, help="Enable debug logging.")
-def generate(files, project_dir, model, overwrite, table, db_path, compact_schema, verbose):
+def generate(
+    files,
+    project_dir,
+    model,
+    overwrite,
+    table,
+    db_path,
+    import_mode,
+    compact_schema,
+    verbose,
+):
     """Generate schema_description.md, queries.yaml, measures.yaml, and time_series.yaml from your database.
 
     Connects to the database, inspects tables and columns, samples
@@ -172,6 +193,13 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
                     err=True,
                 )
                 sys.exit(1)
+            if import_mode.lower() != "auto":
+                click.echo(
+                    "Error: --import-mode only applies when importing CSV/Parquet/Excel "
+                    "or mixed file inputs into DuckDB.",
+                    err=True,
+                )
+                sys.exit(1)
             if db_path:
                 click.echo(
                     "Error: --db-path is only used when creating a project DuckDB from "
@@ -181,6 +209,13 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
                 sys.exit(1)
             sqlite_source_path = sqlite_files[0]
         elif len(duckdb_files) == 1 and len(files) == 1:
+            if import_mode.lower() != "auto":
+                click.echo(
+                    "Error: --import-mode only applies when importing CSV/Parquet/Excel "
+                    "or mixed file inputs into DuckDB.",
+                    err=True,
+                )
+                sys.exit(1)
             if db_path:
                 click.echo(
                     "Error: --db-path is only used when creating a project DuckDB from "
@@ -281,7 +316,7 @@ def generate(files, project_dir, model, overwrite, table, db_path, compact_schem
             from datasight.explore import create_files_session_for_settings
 
             sql_runner, tables_info = create_files_session_for_settings(
-                list(files), settings.database
+                list(files), settings.database, import_mode=import_mode.lower()
             )
         else:
             sql_runner = create_sql_runner_from_settings(settings.database, project_dir)

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -173,9 +173,6 @@ def generate(
     # configured for a non-DuckDB backend; we're not going to touch the
     # local DuckDB in that case.
     use_files = bool(files)
-    inspection_import_mode = (
-        "auto" if use_files and normalized_import_mode == "table" else normalized_import_mode
-    )
     db_target: Path | None = None
     sqlite_source_path: Path | None = None
     duckdb_source_path: Path | None = None
@@ -192,22 +189,14 @@ def generate(
             (Path(file_path).resolve(), detect_file_type(str(Path(file_path).resolve())))
             for file_path in files
         ]
-        if normalized_import_mode == "view" and any(
-            file_type == "xlsx" for _, file_type in resolved_file_types
-        ):
-            click.echo(
-                "Error: Excel inputs are always materialized as DuckDB tables; "
-                "--import-mode=view is not supported for .xlsx files.",
-                err=True,
-            )
-            sys.exit(1)
-        if settings.database.mode == "spark" and normalized_import_mode == "table":
-            click.echo(
-                "Error: --import-mode=table is not supported when DB_MODE=spark; "
-                "Spark file sessions always register temp views.",
-                err=True,
-            )
-            sys.exit(1)
+        if normalized_import_mode == "view":
+            for file_path, file_type in resolved_file_types:
+                if file_type == "xlsx":
+                    click.echo(
+                        "Warning: Excel inputs are always materialized as DuckDB tables; "
+                        f"{file_path.name} will be loaded as a table.",
+                        err=True,
+                    )
         sqlite_files = [
             file_path for file_path, file_type in resolved_file_types if file_type == "sqlite"
         ]
@@ -252,6 +241,19 @@ def generate(
                 )
                 sys.exit(1)
             duckdb_source_path = duckdb_files[0]
+        elif settings.database.mode == "spark" and normalized_import_mode == "table":
+            click.echo(
+                "Error: --import-mode=table is not supported when DB_MODE=spark; "
+                "Spark file sessions always register temp views.",
+                err=True,
+            )
+            sys.exit(1)
+        elif settings.database.mode != "duckdb" and normalized_import_mode == "table":
+            click.echo(
+                "Error: --import-mode=table requires DB_MODE=duckdb when importing files.",
+                err=True,
+            )
+            sys.exit(1)
         elif settings.database.mode == "duckdb":
             _db_target = Path(db_path or "database.duckdb")
             if not _db_target.is_absolute():
@@ -340,11 +342,42 @@ def generate(
 
             sql_runner = DuckDBRunner(str(duckdb_source_path))
             tables_info = []
+        elif (
+            use_files and settings.database.mode == "duckdb" and normalized_import_mode == "table"
+        ):
+            from datasight.explore import (
+                build_persistent_duckdb,
+                create_files_session_for_settings,
+            )
+            from datasight.runner import DuckDBRunner
+
+            planning_runner, planning_tables_info = create_files_session_for_settings(
+                list(files), settings.database, import_mode="auto"
+            )
+            planning_runner.close()
+            persistent_tables_info = []
+            for table_info in planning_tables_info:
+                updated = dict(table_info)
+                if updated.get("type") not in {"duckdb", "xlsx"}:
+                    updated["import_mode"] = "table"
+                persistent_tables_info.append(updated)
+
+            assert db_target is not None
+            try:
+                build_persistent_duckdb(db_target, persistent_tables_info, overwrite=overwrite)
+            except FileExistsError:
+                click.echo(
+                    f"Error: Database file already exists: {db_target}.",
+                    err=True,
+                )
+                sys.exit(1)
+            sql_runner = DuckDBRunner(str(db_target))
+            tables_info = persistent_tables_info
         elif use_files:
             from datasight.explore import create_files_session_for_settings
 
             sql_runner, tables_info = create_files_session_for_settings(
-                list(files), settings.database, import_mode=inspection_import_mode
+                list(files), settings.database, import_mode=normalized_import_mode
             )
         else:
             sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
@@ -517,23 +550,17 @@ def generate(
 
             assert db_target is not None  # set above when use_files is True
             persistent_tables_info = tables_info
-            if normalized_import_mode == "table":
-                persistent_tables_info = []
-                for table_info in tables_info:
-                    updated = dict(table_info)
-                    if updated.get("type") not in {"duckdb", "xlsx"}:
-                        updated["import_mode"] = "table"
-                    persistent_tables_info.append(updated)
-            try:
-                build_persistent_duckdb(db_target, persistent_tables_info, overwrite=overwrite)
-            except FileExistsError:
-                # Preflight above rejects pre-existing DBs without --overwrite,
-                # so reaching here means the file appeared mid-run.
-                click.echo(
-                    f"Error: Database file already exists: {db_target}.",
-                    err=True,
-                )
-                sys.exit(1)
+            if normalized_import_mode != "table":
+                try:
+                    build_persistent_duckdb(db_target, persistent_tables_info, overwrite=overwrite)
+                except FileExistsError:
+                    # Preflight above rejects pre-existing DBs without --overwrite,
+                    # so reaching here means the file appeared mid-run.
+                    click.echo(
+                        f"Error: Database file already exists: {db_target}.",
+                        err=True,
+                    )
+                    sys.exit(1)
             db_size_mb = db_target.stat().st_size / (1024 * 1024)
             written.append(f"{db_target.name} ({db_size_mb:.2f} MB)")
 

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -33,8 +33,8 @@ ImportMode = Literal["auto", "view", "table"]
 
 
 _AUTO_IMPORT_MODES: dict[str, Literal["view", "table"]] = {
-    "csv": "table",
-    "csv_dir": "table",
+    "csv": "view",
+    "csv_dir": "view",
     "parquet": "view",
     "hive_parquet": "view",
     "xlsx": "table",

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -420,11 +420,14 @@ def create_ephemeral_session(
     resolved_paths = [
         (str(Path(p).resolve()), detect_file_type(str(Path(p).resolve()))) for p in file_paths
     ]
-    if import_mode == "view" and any(file_type == "xlsx" for _, file_type in resolved_paths):
-        raise ConfigurationError(
-            "Excel inputs are always materialized as DuckDB tables; "
-            "--import-mode=view is not supported for .xlsx files."
-        )
+    if import_mode == "view":
+        excel_paths = [path for path, file_type in resolved_paths if file_type == "xlsx"]
+        for path in excel_paths:
+            logger.warning(
+                "Excel input {} will be materialized as a DuckDB table; "
+                "import_mode=view only applies to non-Excel inputs.",
+                path,
+            )
     duckdb_files = [p for p, t in resolved_paths if t == "duckdb"]
     other_files = [(p, t) for p, t in resolved_paths if t is not None and t != "duckdb"]
     invalid_files = [p for p, t in resolved_paths if t is None]
@@ -712,11 +715,14 @@ def add_files_to_connection(
     for path in file_paths:
         resolved_path = str(Path(path).resolve())
         resolved_paths.append((resolved_path, detect_file_type(resolved_path)))
-    if import_mode == "view" and any(file_type == "xlsx" for _, file_type in resolved_paths):
-        raise ConfigurationError(
-            "Excel inputs are always materialized as DuckDB tables; "
-            "--import-mode=view is not supported for .xlsx files."
-        )
+    if import_mode == "view":
+        excel_paths = [path for path, file_type in resolved_paths if file_type == "xlsx"]
+        for path in excel_paths:
+            logger.warning(
+                "Excel input {} will be materialized as a DuckDB table; "
+                "import_mode=view only applies to non-Excel inputs.",
+                path,
+            )
 
     for path, file_type in resolved_paths:
         if file_type is None:

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import duckdb
 from loguru import logger
@@ -27,6 +27,18 @@ from datasight.runner import (
 
 if TYPE_CHECKING:
     from datasight.settings import DatabaseSettings
+
+
+ImportMode = Literal["auto", "view", "table"]
+
+
+_AUTO_IMPORT_MODES: dict[str, Literal["view", "table"]] = {
+    "csv": "table",
+    "csv_dir": "table",
+    "parquet": "view",
+    "hive_parquet": "view",
+    "xlsx": "table",
+}
 
 
 def detect_file_type(path: str) -> str | None:
@@ -168,6 +180,49 @@ def sanitize_table_name(name: str) -> str:
     return sanitized.lower()
 
 
+def resolve_import_mode(file_type: str, import_mode: ImportMode) -> Literal["view", "table"]:
+    """Resolve an explicit or automatic import mode for a supported file type."""
+    if import_mode != "auto":
+        return import_mode
+    try:
+        return _AUTO_IMPORT_MODES[file_type]
+    except KeyError as e:
+        raise ValueError(f"Unsupported import mode for file type: {file_type}") from e
+
+
+def _select_from_file_sql(file_path: str, file_type: str) -> str:
+    """Generate a SELECT statement that reads from a supported file source."""
+    escaped_path = file_path.replace("'", "''")
+
+    if file_type == "csv":
+        return f"SELECT * FROM read_csv_auto('{escaped_path}')"
+    if file_type == "parquet":
+        return f"SELECT * FROM read_parquet('{escaped_path}')"
+    if file_type == "hive_parquet":
+        glob_path = f"{escaped_path}/**/*.parquet"
+        return f"SELECT * FROM read_parquet('{glob_path}', hive_partitioning=true)"
+    if file_type == "csv_dir":
+        glob_path = f"{escaped_path}/*.csv"
+        return f"SELECT * FROM read_csv_auto('{glob_path}')"
+    raise ValueError(f"Unknown file type: {file_type}")
+
+
+def create_relation_sql(
+    table_name: str,
+    file_path: str,
+    file_type: str,
+    *,
+    import_mode: ImportMode = "view",
+) -> str:
+    """Generate SQL to create a view or table for a data file."""
+    quoted_name = f'"{table_name}"'
+    select_sql = _select_from_file_sql(file_path, file_type)
+    resolved_mode = resolve_import_mode(file_type, import_mode)
+    if resolved_mode == "table":
+        return f"CREATE TABLE {quoted_name} AS {select_sql}"
+    return f"CREATE VIEW {quoted_name} AS {select_sql}"
+
+
 def create_view_sql(table_name: str, file_path: str, file_type: str) -> str:
     """Generate SQL to create a view for a data file.
 
@@ -184,24 +239,7 @@ def create_view_sql(table_name: str, file_path: str, file_type: str) -> str:
     -------
     SQL CREATE VIEW statement.
     """
-    # Escape single quotes in path
-    escaped_path = file_path.replace("'", "''")
-
-    # Double-quote the view name to handle reserved words (e.g., "select")
-    quoted_name = f'"{table_name}"'
-
-    if file_type == "csv":
-        return f"CREATE VIEW {quoted_name} AS SELECT * FROM read_csv_auto('{escaped_path}')"
-    elif file_type == "parquet":
-        return f"CREATE VIEW {quoted_name} AS SELECT * FROM read_parquet('{escaped_path}')"
-    elif file_type == "hive_parquet":
-        glob_path = f"{escaped_path}/**/*.parquet"
-        return f"CREATE VIEW {quoted_name} AS SELECT * FROM read_parquet('{glob_path}', hive_partitioning=true)"
-    elif file_type == "csv_dir":
-        glob_path = f"{escaped_path}/*.csv"
-        return f"CREATE VIEW {quoted_name} AS SELECT * FROM read_csv_auto('{glob_path}')"
-    else:
-        raise ValueError(f"Unknown file type: {file_type}")
+    return create_relation_sql(table_name, file_path, file_type, import_mode="view")
 
 
 def _materialize_excel_sheet(
@@ -271,6 +309,7 @@ def _load_excel_workbook(
                 "path": file_path,
                 "type": "xlsx",
                 "sheet_name": sheet_name,
+                "import_mode": "table",
             }
         )
         logger.info(f"Created table '{table_name}' from Excel sheet '{sheet_name}' in {file_path}")
@@ -347,8 +386,11 @@ def _attach_duckdb_file(
     return tables_info
 
 
-def create_ephemeral_session(file_paths: list[str]) -> tuple[EphemeralDuckDBRunner, list[dict]]:
-    """Create an ephemeral DuckDB session with views for the given files.
+def create_ephemeral_session(
+    file_paths: list[str],
+    import_mode: ImportMode = "auto",
+) -> tuple[EphemeralDuckDBRunner, list[dict]]:
+    """Create an ephemeral DuckDB session with views or tables for the given files.
 
     Parameters
     ----------
@@ -406,7 +448,7 @@ def create_ephemeral_session(file_paths: list[str]) -> tuple[EphemeralDuckDBRunn
         except duckdb.Error as e:
             raise ConfigurationError(f"Failed to open DuckDB file {db_path}: {e}") from e
 
-    # General case: create in-memory DB with views
+    # General case: create in-memory DB with imported relations
     conn = duckdb.connect(":memory:")
     tables_info: list[dict] = []
     errors: list[str] = list(f"Unrecognized or missing file: {p}" for p in invalid_files)
@@ -444,14 +486,22 @@ def create_ephemeral_session(file_paths: list[str]) -> tuple[EphemeralDuckDBRunn
             table_name = f"{table_name}_{counter}"
 
         try:
-            sql = create_view_sql(table_name, path, file_type)
+            resolved_mode = resolve_import_mode(file_type, import_mode)
+            sql = create_relation_sql(table_name, path, file_type, import_mode=resolved_mode)
             conn.execute(sql)
             existing_names.add(table_name)
-            tables_info.append({"name": table_name, "path": path, "type": file_type})
-            logger.info(f"Created view '{table_name}' from {file_type}: {path}")
+            tables_info.append(
+                {
+                    "name": table_name,
+                    "path": path,
+                    "type": file_type,
+                    "import_mode": resolved_mode,
+                }
+            )
+            logger.info(f"Created {resolved_mode} '{table_name}' from {file_type}: {path}")
         except Exception as e:
-            errors.append(f"Failed to create view for {path}: {e}")
-            logger.warning(f"Failed to create view for {path}: {e}")
+            errors.append(f"Failed to create relation for {path}: {e}")
+            logger.warning(f"Failed to create relation for {path}: {e}")
 
     if not tables_info:
         conn.close()
@@ -571,6 +621,7 @@ def _register_spark_view(spark: Any, view_name: str, path: str, file_type: str) 
 def create_files_session_for_settings(
     file_paths: list[str],
     settings: DatabaseSettings | None = None,
+    import_mode: ImportMode = "auto",
 ) -> tuple[Any, list[dict]]:
     """Pick a file-session backend based on the project's configured DB_MODE.
 
@@ -584,10 +635,10 @@ def create_files_session_for_settings(
     """
     if settings is None:
         logger.info("File session: in-memory DuckDB (no settings / no .env)")
-        return create_ephemeral_session(file_paths)
+        return create_ephemeral_session(file_paths, import_mode=import_mode)
     if settings.mode in ("duckdb", "sqlite"):
         logger.info(f"File session: in-memory DuckDB (DB_MODE={settings.mode})")
-        return create_ephemeral_session(file_paths)
+        return create_ephemeral_session(file_paths, import_mode=import_mode)
     if settings.mode == "spark":
         logger.info(
             f"File session: Spark Connect at {settings.spark_remote} "
@@ -604,13 +655,14 @@ def create_files_session_for_settings(
         "file inspection will use a local DuckDB session, independent of "
         "the configured database."
     )
-    return create_ephemeral_session(file_paths)
+    return create_ephemeral_session(file_paths, import_mode=import_mode)
 
 
 def add_files_to_connection(
     conn: duckdb.DuckDBPyConnection,
     file_paths: list[str],
     existing_table_names: set[str],
+    import_mode: ImportMode = "auto",
 ) -> list[dict]:
     """Add new file views to an existing DuckDB connection.
 
@@ -671,13 +723,21 @@ def add_files_to_connection(
             table_name = f"{table_name}_{counter}"
 
         try:
-            sql = create_view_sql(table_name, path, file_type)
+            resolved_mode = resolve_import_mode(file_type, import_mode)
+            sql = create_relation_sql(table_name, path, file_type, import_mode=resolved_mode)
             conn.execute(sql)
             names.add(table_name)
-            tables_info.append({"name": table_name, "path": path, "type": file_type})
-            logger.info(f"Added view '{table_name}' from {file_type}: {path}")
+            tables_info.append(
+                {
+                    "name": table_name,
+                    "path": path,
+                    "type": file_type,
+                    "import_mode": resolved_mode,
+                }
+            )
+            logger.info(f"Added {resolved_mode} '{table_name}' from {file_type}: {path}")
         except Exception as e:
-            errors.append(f"Failed to create view for {path}: {e}")
+            errors.append(f"Failed to create relation for {path}: {e}")
 
     if not tables_info:
         msg = "No valid data files found."
@@ -694,7 +754,7 @@ def build_persistent_duckdb(
     *,
     overwrite: bool = False,
 ) -> Path:
-    """Create a DuckDB file with views pointing at the given data sources.
+    """Create a DuckDB file with imported relations pointing at the given data sources.
 
     Parameters
     ----------
@@ -746,8 +806,16 @@ def build_persistent_duckdb(
                 _materialize_excel_sheet(conn, table["name"], table["path"], table["sheet_name"])
                 object_type = "table"
             else:
-                conn.execute(create_view_sql(table["name"], table["path"], table["type"]))
-                object_type = "view"
+                relation_mode = table.get("import_mode", "view")
+                conn.execute(
+                    create_relation_sql(
+                        table["name"],
+                        table["path"],
+                        table["type"],
+                        import_mode=relation_mode,
+                    )
+                )
+                object_type = str(relation_mode)
             logger.info(f"Created {object_type} '{table['name']}' in {db_path}")
     finally:
         conn.close()
@@ -764,7 +832,7 @@ def save_ephemeral_as_project(
     """Save an ephemeral session as a proper datasight project.
 
     Creates a project directory with:
-    - A DuckDB database file containing views to the original data files
+    - A DuckDB database file containing imported views/tables from the original data files
       (or references an existing DuckDB file if that was the source)
     - A .env file configured for DuckDB
     - A basic schema_description.md
@@ -807,7 +875,7 @@ def save_ephemeral_as_project(
         # Just reference the existing database
         db_path_str = next(iter(unique_paths))
     else:
-        # Create the DuckDB database file with views (remove old one if overwriting)
+        # Create the DuckDB database file with imported relations (remove old one if overwriting)
         db_path = dest / "data.duckdb"
         if db_path.exists():
             db_path.unlink()
@@ -846,9 +914,15 @@ def save_ephemeral_as_project(
                 )
                 object_type = "table"
             else:
-                sql = create_view_sql(table["name"], table["path"], table["type"])
+                relation_mode = table.get("import_mode", "view")
+                sql = create_relation_sql(
+                    table["name"],
+                    table["path"],
+                    table["type"],
+                    import_mode=relation_mode,
+                )
                 db_conn.execute(sql)
-                object_type = "view"
+                object_type = str(relation_mode)
             logger.info(f"Created persistent {object_type} '{table['name']}' in {db_path}")
 
         db_conn.close()

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -40,6 +40,8 @@ _AUTO_IMPORT_MODES: dict[str, Literal["view", "table"]] = {
     "xlsx": "table",
 }
 
+_VALID_IMPORT_MODES = {"auto", "view", "table"}
+
 
 def detect_file_type(path: str) -> str | None:
     """Detect the type of a data file or directory.
@@ -182,8 +184,10 @@ def sanitize_table_name(name: str) -> str:
 
 def resolve_import_mode(file_type: str, import_mode: ImportMode) -> Literal["view", "table"]:
     """Resolve an explicit or automatic import mode for a supported file type."""
-    if import_mode != "auto":
+    if import_mode == "view" or import_mode == "table":
         return import_mode
+    if import_mode != "auto":
+        raise ValueError(f"Unsupported import mode: {import_mode}")
     try:
         return _AUTO_IMPORT_MODES[file_type]
     except KeyError as e:
@@ -409,11 +413,18 @@ def create_ephemeral_session(
     """
     if not file_paths:
         raise ConfigurationError("No file paths provided")
+    if import_mode not in _VALID_IMPORT_MODES:
+        raise ConfigurationError(f"Unsupported import mode: {import_mode}")
 
     # Categorize files by type
     resolved_paths = [
         (str(Path(p).resolve()), detect_file_type(str(Path(p).resolve()))) for p in file_paths
     ]
+    if import_mode == "view" and any(file_type == "xlsx" for _, file_type in resolved_paths):
+        raise ConfigurationError(
+            "Excel inputs are always materialized as DuckDB tables; "
+            "--import-mode=view is not supported for .xlsx files."
+        )
     duckdb_files = [p for p, t in resolved_paths if t == "duckdb"]
     other_files = [(p, t) for p, t in resolved_paths if t is not None and t != "duckdb"]
     invalid_files = [p for p, t in resolved_paths if t is None]
@@ -633,6 +644,8 @@ def create_files_session_for_settings(
     - ``postgres`` / ``flightsql``: fall back to DuckDB with a warning —
       those backends can't read arbitrary local files.
     """
+    if import_mode not in _VALID_IMPORT_MODES:
+        raise ConfigurationError(f"Unsupported import mode: {import_mode}")
     if settings is None:
         logger.info("File session: in-memory DuckDB (no settings / no .env)")
         return create_ephemeral_session(file_paths, import_mode=import_mode)
@@ -640,6 +653,11 @@ def create_files_session_for_settings(
         logger.info(f"File session: in-memory DuckDB (DB_MODE={settings.mode})")
         return create_ephemeral_session(file_paths, import_mode=import_mode)
     if settings.mode == "spark":
+        if import_mode == "table":
+            raise ConfigurationError(
+                "--import-mode=table is not supported when DB_MODE=spark; "
+                "Spark file sessions always register temp views."
+            )
         logger.info(
             f"File session: Spark Connect at {settings.spark_remote} "
             f"(DB_MODE=spark, byte cap {settings.spark_max_result_bytes:,})"
@@ -687,11 +705,20 @@ def add_files_to_connection(
     tables_info: list[dict] = []
     errors: list[str] = []
     names = set(existing_table_names)
+    if import_mode not in _VALID_IMPORT_MODES:
+        raise ConfigurationError(f"Unsupported import mode: {import_mode}")
 
+    resolved_paths: list[tuple[str, str | None]] = []
     for path in file_paths:
-        path = str(Path(path).resolve())
-        file_type = detect_file_type(path)
+        resolved_path = str(Path(path).resolve())
+        resolved_paths.append((resolved_path, detect_file_type(resolved_path)))
+    if import_mode == "view" and any(file_type == "xlsx" for _, file_type in resolved_paths):
+        raise ConfigurationError(
+            "Excel inputs are always materialized as DuckDB tables; "
+            "--import-mode=view is not supported for .xlsx files."
+        )
 
+    for path, file_type in resolved_paths:
         if file_type is None:
             errors.append(f"Unrecognized or missing file: {path}")
             continue

--- a/tests/test_explore_extra.py
+++ b/tests/test_explore_extra.py
@@ -185,21 +185,52 @@ def test_create_ephemeral_session_invalid_import_mode_raises(tmp_path):
         create_ephemeral_session([str(csv)], import_mode=cast(Any, "bogus"))
 
 
-def test_create_ephemeral_session_rejects_excel_view_mode(tmp_path):
+def test_create_ephemeral_session_allows_mixed_excel_and_view_mode(tmp_path):
     xlsx = tmp_path / "plants.xlsx"
     _write_xlsx(xlsx, {"Sheet1": pd.DataFrame({"plant_id": [1]})})
+    csv = tmp_path / "generation.csv"
+    csv.write_text("net_generation_mwh\n100\n", encoding="utf-8")
 
-    with pytest.raises(ConfigurationError, match="Excel inputs are always materialized"):
-        create_ephemeral_session([str(xlsx)], import_mode="view")
+    runner, tables = create_ephemeral_session([str(xlsx), str(csv)], import_mode="view")
+    with runner:
+        by_name = {table["name"]: table for table in tables}
+        assert by_name["plants"]["type"] == "xlsx"
+        assert by_name["plants"]["import_mode"] == "table"
+        assert by_name["generation"]["import_mode"] == "view"
+        relation_types = dict(
+            runner._conn.execute(  # ty: ignore[unresolved-attribute]
+                "SELECT table_name, table_type FROM information_schema.tables "
+                "WHERE table_schema='main'"
+            ).fetchall()
+        )
+        assert relation_types["plants"] == "BASE TABLE"
+        assert relation_types["generation"] == "VIEW"
 
 
-def test_add_files_to_connection_rejects_excel_view_mode(tmp_path):
+def test_add_files_to_connection_allows_mixed_excel_and_view_mode(tmp_path):
     conn = duckdb.connect(":memory:")
     xlsx = tmp_path / "plants.xlsx"
     _write_xlsx(xlsx, {"Sheet1": pd.DataFrame({"plant_id": [1]})})
+    csv = tmp_path / "generation.csv"
+    csv.write_text("net_generation_mwh\n100\n", encoding="utf-8")
 
-    with pytest.raises(ConfigurationError, match="Excel inputs are always materialized"):
-        add_files_to_connection(conn, [str(xlsx)], existing_table_names=set(), import_mode="view")
+    tables = add_files_to_connection(
+        conn,
+        [str(xlsx), str(csv)],
+        existing_table_names=set(),
+        import_mode="view",
+    )
+    by_name = {table["name"]: table for table in tables}
+    assert by_name["plants"]["type"] == "xlsx"
+    assert by_name["plants"]["import_mode"] == "table"
+    assert by_name["generation"]["import_mode"] == "view"
+    relation_types = dict(
+        conn.execute(
+            "SELECT table_name, table_type FROM information_schema.tables WHERE table_schema='main'"
+        ).fetchall()
+    )
+    assert relation_types["plants"] == "BASE TABLE"
+    assert relation_types["generation"] == "VIEW"
     conn.close()
 
 
@@ -422,5 +453,25 @@ def test_save_project_rebuilds_xlsx_sheets(tmp_path):
     try:
         assert conn.execute("SELECT COUNT(*) FROM raw").fetchone()[0] == 2  # ty: ignore[not-subscriptable]
         assert conn.execute("SELECT id FROM clean").fetchone() == (10,)
+    finally:
+        conn.close()
+
+
+def test_save_project_preserves_materialized_csv_tables(tmp_path):
+    csv = tmp_path / "generation.csv"
+    csv.write_text("net_generation_mwh\n100\n", encoding="utf-8")
+
+    runner, tables = create_ephemeral_session([str(csv)], import_mode="table")
+    project_dir = tmp_path / "proj"
+    save_ephemeral_as_project(runner, tables, str(project_dir))
+    runner.close()
+
+    conn = duckdb.connect(str(project_dir / "data.duckdb"), read_only=True)
+    try:
+        relation = conn.execute(
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("BASE TABLE",)
     finally:
         conn.close()

--- a/tests/test_explore_extra.py
+++ b/tests/test_explore_extra.py
@@ -107,7 +107,7 @@ def test_single_duckdb_file_unreadable_raises(tmp_path):
 
 
 def test_add_files_to_connection_basic(tmp_path):
-    """add_files_to_connection adds new CSV views to an existing connection."""
+    """add_files_to_connection uses auto import mode for new CSV tables."""
     conn = duckdb.connect(":memory:")
 
     csv1 = tmp_path / "a.csv"
@@ -116,10 +116,46 @@ def test_add_files_to_connection_basic(tmp_path):
     tables = add_files_to_connection(conn, [str(csv1)], existing_table_names=set())
     assert len(tables) == 1
     assert tables[0]["name"] == "a"
+    assert tables[0]["import_mode"] == "table"
+
+    relation = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_schema='main' AND table_name='a'"
+    ).fetchone()
+    assert relation == ("BASE TABLE",)
 
     df = conn.execute("SELECT * FROM a").fetchdf()
     assert len(df) == 1
     conn.close()
+
+
+def test_create_ephemeral_session_csv_view_mode(tmp_path):
+    """CSV inputs can stay source-backed views when requested explicitly."""
+    csv = tmp_path / "generation.csv"
+    csv.write_text("x\n1\n2\n", encoding="utf-8")
+
+    runner, tables = create_ephemeral_session([str(csv)], import_mode="view")
+    with runner:
+        assert tables[0]["import_mode"] == "view"
+        relation = runner._conn.execute(  # ty: ignore[unresolved-attribute]
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("VIEW",)
+
+
+def test_create_ephemeral_session_parquet_auto_mode_uses_view(tmp_path):
+    """Parquet auto mode remains view-backed."""
+    parquet = tmp_path / "generation.parquet"
+    pd.DataFrame({"x": [1, 2]}).to_parquet(parquet)
+
+    runner, tables = create_ephemeral_session([str(parquet)])
+    with runner:
+        assert tables[0]["import_mode"] == "view"
+        relation = runner._conn.execute(  # ty: ignore[unresolved-attribute]
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("VIEW",)
 
 
 def test_add_files_to_connection_with_duckdb(tmp_path):

--- a/tests/test_explore_extra.py
+++ b/tests/test_explore_extra.py
@@ -1,5 +1,8 @@
 """Extra tests for datasight.explore covering duplicate handling and error paths."""
 
+from types import SimpleNamespace
+from typing import Any, cast
+
 import duckdb
 import pandas as pd
 import pytest
@@ -8,6 +11,7 @@ from datasight.exceptions import ConfigurationError
 from datasight.explore import (
     add_files_to_connection,
     create_ephemeral_session,
+    create_files_session_for_settings,
     detect_file_type,
     save_ephemeral_as_project,
     scan_directory_for_data_files,
@@ -171,6 +175,46 @@ def test_create_ephemeral_session_csv_table_mode_materializes(tmp_path):
             "WHERE table_schema='main' AND table_name='generation'"
         ).fetchone()
         assert relation == ("BASE TABLE",)
+
+
+def test_create_ephemeral_session_invalid_import_mode_raises(tmp_path):
+    csv = tmp_path / "generation.csv"
+    csv.write_text("x\n1\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="Unsupported import mode"):
+        create_ephemeral_session([str(csv)], import_mode=cast(Any, "bogus"))
+
+
+def test_create_ephemeral_session_rejects_excel_view_mode(tmp_path):
+    xlsx = tmp_path / "plants.xlsx"
+    _write_xlsx(xlsx, {"Sheet1": pd.DataFrame({"plant_id": [1]})})
+
+    with pytest.raises(ConfigurationError, match="Excel inputs are always materialized"):
+        create_ephemeral_session([str(xlsx)], import_mode="view")
+
+
+def test_add_files_to_connection_rejects_excel_view_mode(tmp_path):
+    conn = duckdb.connect(":memory:")
+    xlsx = tmp_path / "plants.xlsx"
+    _write_xlsx(xlsx, {"Sheet1": pd.DataFrame({"plant_id": [1]})})
+
+    with pytest.raises(ConfigurationError, match="Excel inputs are always materialized"):
+        add_files_to_connection(conn, [str(xlsx)], existing_table_names=set(), import_mode="view")
+    conn.close()
+
+
+def test_create_files_session_for_settings_rejects_spark_table_mode(tmp_path):
+    parquet = tmp_path / "generation.parquet"
+    pd.DataFrame({"x": [1]}).to_parquet(parquet)
+    settings = SimpleNamespace(
+        mode="spark",
+        spark_remote="sc://cluster:15002",
+        spark_token=None,
+        spark_max_result_bytes=1_000_000,
+    )
+
+    with pytest.raises(ConfigurationError, match="--import-mode=table is not supported"):
+        create_files_session_for_settings([str(parquet)], cast(Any, settings), import_mode="table")
 
 
 def test_add_files_to_connection_with_duckdb(tmp_path):

--- a/tests/test_explore_extra.py
+++ b/tests/test_explore_extra.py
@@ -107,7 +107,7 @@ def test_single_duckdb_file_unreadable_raises(tmp_path):
 
 
 def test_add_files_to_connection_basic(tmp_path):
-    """add_files_to_connection uses auto import mode for new CSV tables."""
+    """add_files_to_connection keeps CSV source-backed in auto mode."""
     conn = duckdb.connect(":memory:")
 
     csv1 = tmp_path / "a.csv"
@@ -116,12 +116,12 @@ def test_add_files_to_connection_basic(tmp_path):
     tables = add_files_to_connection(conn, [str(csv1)], existing_table_names=set())
     assert len(tables) == 1
     assert tables[0]["name"] == "a"
-    assert tables[0]["import_mode"] == "table"
+    assert tables[0]["import_mode"] == "view"
 
     relation = conn.execute(
         "SELECT table_type FROM information_schema.tables WHERE table_schema='main' AND table_name='a'"
     ).fetchone()
-    assert relation == ("BASE TABLE",)
+    assert relation == ("VIEW",)
 
     df = conn.execute("SELECT * FROM a").fetchdf()
     assert len(df) == 1
@@ -156,6 +156,21 @@ def test_create_ephemeral_session_parquet_auto_mode_uses_view(tmp_path):
             "WHERE table_schema='main' AND table_name='generation'"
         ).fetchone()
         assert relation == ("VIEW",)
+
+
+def test_create_ephemeral_session_csv_table_mode_materializes(tmp_path):
+    """CSV inputs can be materialized when requested explicitly."""
+    csv = tmp_path / "generation.csv"
+    csv.write_text("x\n1\n2\n", encoding="utf-8")
+
+    runner, tables = create_ephemeral_session([str(csv)], import_mode="table")
+    with runner:
+        assert tables[0]["import_mode"] == "table"
+        relation = runner._conn.execute(  # ty: ignore[unresolved-attribute]
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("BASE TABLE",)
 
 
 def test_add_files_to_connection_with_duckdb(tmp_path):

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -333,6 +333,56 @@ def test_generate_import_mode_view_keeps_csv_as_view(tmp_path, stub_llm):
         assert relation == ("VIEW",)
 
 
+def test_generate_import_mode_table_inspects_with_views_but_persists_tables(
+    tmp_path, stub_llm, monkeypatch
+):
+    csv_path = tmp_path / "generation.csv"
+    csv_path.write_text(
+        "energy_source_code,net_generation_mwh\nWND,100\nSUN,80\n", encoding="utf-8"
+    )
+
+    from datasight import explore as explore_module
+
+    original_session = explore_module.create_files_session_for_settings
+    original_build = explore_module.build_persistent_duckdb
+    captured: dict[str, object] = {}
+
+    def _capturing_session(file_paths, settings, import_mode="auto"):
+        captured["session_import_mode"] = import_mode
+        return original_session(file_paths, settings, import_mode=import_mode)
+
+    def _capturing_build(db_path, tables_info, *, overwrite=False):
+        captured["persistent_import_modes"] = [t.get("import_mode") for t in tables_info]
+        return original_build(db_path, tables_info, overwrite=overwrite)
+
+    monkeypatch.setattr(explore_module, "create_files_session_for_settings", _capturing_session)
+    monkeypatch.setattr(explore_module, "build_persistent_duckdb", _capturing_build)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(csv_path),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "table",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["session_import_mode"] == "auto"
+    assert captured["persistent_import_modes"] == ["table"]
+
+    db_path = tmp_path / "database.duckdb"
+    with duckdb.connect(str(db_path), read_only=True) as conn:
+        relation = conn.execute(
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("BASE TABLE",)
+
+
 def test_generate_rejects_import_mode_with_existing_duckdb(tmp_path, stub_llm):
     db_path = tmp_path / "generation.duckdb"
     conn = duckdb.connect(str(db_path))

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -59,7 +59,7 @@ def test_build_persistent_duckdb_creates_views(tmp_path, parquet_file):
 def test_build_persistent_duckdb_materializes_csv_tables(tmp_path):
     csv_path = tmp_path / "generation.csv"
     csv_path.write_text("x\n1\n2\n", encoding="utf-8")
-    _, tables_info = create_ephemeral_session([str(csv_path)])
+    _, tables_info = create_ephemeral_session([str(csv_path)], import_mode="table")
 
     db_path = tmp_path / "out.duckdb"
     build_persistent_duckdb(db_path, tables_info)

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -356,6 +356,75 @@ def test_generate_rejects_import_mode_with_existing_duckdb(tmp_path, stub_llm):
     assert not stub_llm.calls
 
 
+def test_generate_rejects_import_mode_without_files(tmp_path, stub_llm):
+    db_path = tmp_path / "generation.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.close()
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "ANTHROPIC_API_KEY=test-key\nDB_MODE=duckdb\nDB_PATH=./generation.duckdb\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["generate", "--project-dir", str(tmp_path), "--import-mode", "table"],
+    )
+    assert result.exit_code != 0
+    assert "--import-mode only applies when importing CSV/Parquet/Excel files" in result.output
+    assert not stub_llm.calls
+
+
+def test_generate_rejects_import_mode_view_for_excel(tmp_path, stub_llm):
+    xlsx_path = tmp_path / "generation.xlsx"
+    pd.DataFrame({"energy_source_code": ["WND"], "net_generation_mwh": [100]}).to_excel(
+        xlsx_path, index=False
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(xlsx_path),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "view",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Excel inputs are always materialized" in result.output
+    assert not stub_llm.calls
+
+
+def test_generate_rejects_import_mode_table_for_spark_files(tmp_path, parquet_file, stub_llm):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "ANTHROPIC_API_KEY=test-key\nDB_MODE=spark\nSPARK_REMOTE=sc://my-cluster:15002\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(parquet_file),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "table",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--import-mode=table is not supported when DB_MODE=spark" in result.output
+    assert not stub_llm.calls
+
+
 def test_generate_rejects_db_path_with_existing_sqlite(tmp_path, stub_llm):
     db_path = tmp_path / "generation.sqlite"
     conn = sqlite3.connect(str(db_path))

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -56,6 +56,22 @@ def test_build_persistent_duckdb_creates_views(tmp_path, parquet_file):
         assert int(df["n"].iloc[0]) == 3
 
 
+def test_build_persistent_duckdb_materializes_csv_tables(tmp_path):
+    csv_path = tmp_path / "generation.csv"
+    csv_path.write_text("x\n1\n2\n", encoding="utf-8")
+    _, tables_info = create_ephemeral_session([str(csv_path)])
+
+    db_path = tmp_path / "out.duckdb"
+    build_persistent_duckdb(db_path, tables_info)
+
+    with duckdb.connect(str(db_path), read_only=True) as conn:
+        relation = conn.execute(
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("BASE TABLE",)
+
+
 def test_build_persistent_duckdb_refuses_overwrite(tmp_path, parquet_file):
     _, tables_info = create_ephemeral_session([str(parquet_file)])
     db_path = tmp_path / "out.duckdb"
@@ -211,8 +227,8 @@ def test_generate_preserves_existing_spark_backend(tmp_path, parquet_file, stub_
     # separately in test_spark_runner.py.
     from datasight.explore import create_ephemeral_session
 
-    def _fake_session(file_paths, settings):
-        return create_ephemeral_session(file_paths)
+    def _fake_session(file_paths, settings, import_mode="auto"):
+        return create_ephemeral_session(file_paths, import_mode=import_mode)
 
     # cli imports create_files_session_for_settings locally inside the
     # _run coroutine, so we patch where it lives in explore.
@@ -286,6 +302,58 @@ def test_generate_duckdb_file_updates_env_without_creating_default_db(tmp_path, 
     assert "DB_MODE=duckdb" in env_text
     assert "DB_PATH=./generation.duckdb" in env_text
     assert "duckdb" in stub_llm.calls[0]["messages"][0]["content"].lower()
+
+
+def test_generate_import_mode_view_keeps_csv_as_view(tmp_path, stub_llm):
+    csv_path = tmp_path / "generation.csv"
+    csv_path.write_text(
+        "energy_source_code,net_generation_mwh\nWND,100\nSUN,80\n", encoding="utf-8"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(csv_path),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "view",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    db_path = tmp_path / "database.duckdb"
+    with duckdb.connect(str(db_path), read_only=True) as conn:
+        relation = conn.execute(
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_schema='main' AND table_name='generation'"
+        ).fetchone()
+        assert relation == ("VIEW",)
+
+
+def test_generate_rejects_import_mode_with_existing_duckdb(tmp_path, stub_llm):
+    db_path = tmp_path / "generation.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.close()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(db_path),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "table",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--import-mode only applies" in result.output
+    assert not stub_llm.calls
 
 
 def test_generate_rejects_db_path_with_existing_sqlite(tmp_path, stub_llm):

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -333,7 +333,7 @@ def test_generate_import_mode_view_keeps_csv_as_view(tmp_path, stub_llm):
         assert relation == ("VIEW",)
 
 
-def test_generate_import_mode_table_inspects_with_views_but_persists_tables(
+def test_generate_import_mode_table_materializes_before_introspection(
     tmp_path, stub_llm, monkeypatch
 ):
     csv_path = tmp_path / "generation.csv"
@@ -342,21 +342,30 @@ def test_generate_import_mode_table_inspects_with_views_but_persists_tables(
     )
 
     from datasight import explore as explore_module
+    import datasight.schema as schema_module
 
     original_session = explore_module.create_files_session_for_settings
     original_build = explore_module.build_persistent_duckdb
     captured: dict[str, object] = {}
+    session_import_modes: list[str] = []
+    introspect_runner_types: list[str] = []
 
     def _capturing_session(file_paths, settings, import_mode="auto"):
-        captured["session_import_mode"] = import_mode
+        session_import_modes.append(import_mode)
         return original_session(file_paths, settings, import_mode=import_mode)
 
     def _capturing_build(db_path, tables_info, *, overwrite=False):
         captured["persistent_import_modes"] = [t.get("import_mode") for t in tables_info]
         return original_build(db_path, tables_info, overwrite=overwrite)
 
+    async def _capturing_introspect_schema(run_sql, runner=None):
+        introspect_runner_types.append(type(runner).__name__)
+        return await original_introspect_schema(run_sql, runner=runner)
+
+    original_introspect_schema = schema_module.introspect_schema
     monkeypatch.setattr(explore_module, "create_files_session_for_settings", _capturing_session)
     monkeypatch.setattr(explore_module, "build_persistent_duckdb", _capturing_build)
+    monkeypatch.setattr(schema_module, "introspect_schema", _capturing_introspect_schema)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -371,8 +380,9 @@ def test_generate_import_mode_table_inspects_with_views_but_persists_tables(
         ],
     )
     assert result.exit_code == 0, result.output
-    assert captured["session_import_mode"] == "auto"
+    assert session_import_modes == ["auto"]
     assert captured["persistent_import_modes"] == ["table"]
+    assert introspect_runner_types == ["DuckDBRunner"] * 3
 
     db_path = tmp_path / "database.duckdb"
     with duckdb.connect(str(db_path), read_only=True) as conn:
@@ -428,11 +438,13 @@ def test_generate_rejects_import_mode_without_files(tmp_path, stub_llm):
     assert not stub_llm.calls
 
 
-def test_generate_rejects_import_mode_view_for_excel(tmp_path, stub_llm):
+def test_generate_warns_and_allows_excel_in_view_mode(tmp_path, stub_llm):
     xlsx_path = tmp_path / "generation.xlsx"
     pd.DataFrame({"energy_source_code": ["WND"], "net_generation_mwh": [100]}).to_excel(
         xlsx_path, index=False
     )
+    csv_path = tmp_path / "plants.csv"
+    csv_path.write_text("plant_id,name\n1,Alpha\n", encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -440,15 +452,27 @@ def test_generate_rejects_import_mode_view_for_excel(tmp_path, stub_llm):
         [
             "generate",
             str(xlsx_path),
+            str(csv_path),
             "--project-dir",
             str(tmp_path),
             "--import-mode",
             "view",
         ],
     )
-    assert result.exit_code != 0
-    assert "Excel inputs are always materialized" in result.output
-    assert not stub_llm.calls
+    assert result.exit_code == 0, result.output
+    assert "Warning: Excel inputs are always materialized as DuckDB tables" in result.output
+    assert stub_llm.calls
+
+    db_path = tmp_path / "database.duckdb"
+    with duckdb.connect(str(db_path), read_only=True) as conn:
+        relation_types = dict(
+            conn.execute(
+                "SELECT table_name, table_type FROM information_schema.tables "
+                "WHERE table_schema='main'"
+            ).fetchall()
+        )
+        assert relation_types["generation"] == "BASE TABLE"
+        assert relation_types["plants"] == "VIEW"
 
 
 def test_generate_rejects_import_mode_table_for_spark_files(tmp_path, parquet_file, stub_llm):
@@ -472,6 +496,64 @@ def test_generate_rejects_import_mode_table_for_spark_files(tmp_path, parquet_fi
     )
     assert result.exit_code != 0
     assert "--import-mode=table is not supported when DB_MODE=spark" in result.output
+    assert not stub_llm.calls
+
+
+def test_generate_rejects_import_mode_table_for_non_duckdb_file_projects(
+    tmp_path, parquet_file, stub_llm
+):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "ANTHROPIC_API_KEY=test-key\nDB_MODE=postgres\nDB_HOST=localhost\nDB_NAME=grid\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(parquet_file),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "table",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--import-mode=table requires DB_MODE=duckdb" in result.output
+    assert not stub_llm.calls
+
+
+def test_generate_reports_generic_import_mode_error_for_direct_db_inputs_in_spark_project(
+    tmp_path, stub_llm
+):
+    db_path = tmp_path / "generation.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.close()
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "ANTHROPIC_API_KEY=test-key\nDB_MODE=spark\nSPARK_REMOTE=sc://my-cluster:15002\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(db_path),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "table",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--import-mode only applies when importing CSV/Parquet/Excel" in result.output
+    assert "DB_MODE=spark" not in result.output
     assert not stub_llm.calls
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -276,7 +276,7 @@ toml = [
 
 [[package]]
 name = "datasight"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-flightsql" },


### PR DESCRIPTION
## Summary

- add `import_mode` handling to file-backed DuckDB ingestion paths
- add `generate --import-mode auto|view|table`
- preserve import mode when building persisted DuckDB project databases
- add coverage for CSV table materialization, explicit view mode, and invalid CLI combinations
- sync `uv.lock` package version from `0.6.2` to the current project version `0.7.0`

## Testing

- `uv run pytest tests/test_explore_extra.py tests/test_generate_persist_db.py -q`
- `uv run ruff check src/datasight/explore.py src/datasight/cli_commands/generate.py tests/test_explore_extra.py tests/test_generate_persist_db.py`
