### PR TITLE
Add session archive export and import

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -362,7 +362,7 @@ Examples:
 
 ```
 datasight session list
-datasight session export abc123 analysis.zip
+datasight session export abc123 --output-path analysis.zip
 datasight session export abc123 --include-data
 datasight session import analysis.zip
 datasight session import analysis.zip --session-id copied-session --overwrite

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,6 +58,7 @@ datasight [OPTIONS] COMMAND [ARGS]...
 - `demo`: Create ready-to-run demo projects with sample datasets.
 - `generate`: Generate schema_description.md, queries.yaml, measures.yaml, and time_series.yaml from your database.
 - `run`: Start the datasight web UI.
+- `session`: Export and import shareable datasight session archives.
 - `verify`: Verify LLM-generated SQL against expected results.
 - `ask`: Ask a question about your data from the command line.
 - `profile`: Profile your dataset - row counts, date coverage, and column statistics.
@@ -352,6 +353,78 @@ datasight run [OPTIONS]
 | `--model` | LLM model name (overrides .env). |
 | `--project-dir` | Auto-load this project on startup (optional). |
 | `-v`, `--verbose` | Enable debug logging. |
+
+### `datasight session`
+
+Export and import shareable datasight session archives.
+
+Examples:
+
+```
+datasight session list
+datasight session export abc123 analysis.zip
+datasight session export abc123 --include-data
+datasight session import analysis.zip
+datasight session import analysis.zip --session-id copied-session --overwrite
+```
+
+```bash
+datasight session [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands**
+
+- `list`: List saved sessions available for export.
+- `export`: Export SESSION_ID as a versioned datasight session archive.
+- `import`: Import a datasight session archive into PROJECT_DIR.
+
+#### `datasight session list`
+
+List saved sessions available for export.
+
+```bash
+datasight session list [OPTIONS]
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `--project-dir` | Project directory containing .datasight/ state (default: cwd). Default: `.`. |
+
+#### `datasight session export`
+
+Export SESSION_ID as a versioned datasight session archive.
+
+```bash
+datasight session export [OPTIONS] SESSION_ID
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `SESSION_ID` |   |
+| `--project-dir` | Project directory containing .datasight/ state (default: cwd). Default: `.`. |
+| `--output-path` | Output archive path. Defaults to <session_id>.zip in the current directory. |
+| `--include-data` | Embed the DuckDB or SQLite database file into the archive for a runnable import. |
+
+#### `datasight session import`
+
+Import a datasight session archive into PROJECT_DIR.
+
+```bash
+datasight session import [OPTIONS] ARCHIVE_PATH
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `ARCHIVE_PATH` |   |
+| `--project-dir` | Project directory containing .datasight/ state (default: cwd). Default: `.`. |
+| `--session-id` | Import under this session ID instead of the archived ID. |
+| `--overwrite` | Replace an existing session with the same ID. |
 
 ### `datasight verify`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -424,7 +424,7 @@ datasight session import [OPTIONS] ARCHIVE_PATH
 | `ARCHIVE_PATH` |   |
 | `--project-dir` | Project directory containing .datasight/ state (default: cwd). Default: `.`. |
 | `--session-id` | Import under this session ID instead of the archived ID. |
-| `--overwrite` | Replace an existing session with the same ID. |
+| `--overwrite` | Replace an existing session or restored database file. |
 
 ### `datasight verify`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -358,12 +358,15 @@ datasight run [OPTIONS]
 
 Export and import shareable datasight session archives.
 
+Archives carry the conversation transcript and per-session dashboard
+only — never .env or LLM credentials, and never the underlying
+database. Recipients need to bring their own data.
+
 Examples:
 
 ```
 datasight session list
 datasight session export abc123 --output-path analysis.zip
-datasight session export abc123 --include-data
 datasight session import analysis.zip
 datasight session import analysis.zip --session-id copied-session --overwrite
 ```
@@ -407,7 +410,6 @@ datasight session export [OPTIONS] SESSION_ID
 | `SESSION_ID` |   |
 | `--project-dir` | Project directory containing .datasight/ state (default: cwd). Default: `.`. |
 | `--output-path` | Output archive path. Defaults to <session_id>.zip in the current directory. |
-| `--include-data` | Embed the DuckDB or SQLite database file into the archive for a runnable import. |
 
 #### `datasight session import`
 
@@ -424,7 +426,7 @@ datasight session import [OPTIONS] ARCHIVE_PATH
 | `ARCHIVE_PATH` |   |
 | `--project-dir` | Project directory containing .datasight/ state (default: cwd). Default: `.`. |
 | `--session-id` | Import under this session ID instead of the archived ID. |
-| `--overwrite` | Replace an existing session or restored database file. |
+| `--overwrite` | Replace an existing session with the same ID. |
 
 ### `datasight verify`
 

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -1464,6 +1464,7 @@ def _register_commands() -> None:
     from datasight.cli_commands.recipes import recipes
     from datasight.cli_commands.report import report
     from datasight.cli_commands.run import run
+    from datasight.cli_commands.session import session
     from datasight.cli_commands.templates import templates
     from datasight.cli_commands.trends import trends
     from datasight.cli_commands.validate import validate
@@ -1474,6 +1475,7 @@ def _register_commands() -> None:
     cli.add_command(demo)
     cli.add_command(generate)
     cli.add_command(run)
+    cli.add_command(session)
     cli.add_command(verify)
     cli.add_command(ask)
     cli.add_command(profile)

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -5,7 +5,6 @@ import json
 import os
 import shutil
 import sys
-from textwrap import dedent
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,6 +15,16 @@ import yaml
 from loguru import logger
 
 from datasight import __version__
+
+# Helpers used by both this module and the subcommand modules live in
+# datasight.cli_helpers so that subcommand modules can import them
+# without forming an import cycle with this file. Re-exported here for
+# back-compat with ``from datasight.cli import _epilog`` callers.
+from datasight.cli_helpers import (
+    _epilog as _epilog,
+    _resolve_db_path as _resolve_db_path,
+    _resolve_settings as _resolve_settings,
+)
 from datasight.config import create_sql_runner_from_settings
 from datasight.data_profile import (
     build_column_profile,
@@ -85,13 +94,6 @@ _SHARED_EXPORTS = (
 )
 
 
-def _epilog(text: str) -> str:
-    """Normalize Click epilog text defined in indented decorators."""
-    # Rich Click reflows epilog paragraphs. Treat each authored line as its
-    # own paragraph so examples remain scannable in terminal help.
-    return "\n\n".join(line.rstrip() for line in dedent(text).strip().splitlines())
-
-
 # One-line log format that shows the module name but not the function or
 # line number — ``function:line`` noise rarely helps users diagnose their
 # own CLI runs, and leaving it out makes each line fit comfortably.
@@ -107,37 +109,6 @@ def _configure_logging(level: str = "INFO") -> None:
     """
     logger.remove()
     logger.add(sys.stderr, level=level, format=_LOG_FORMAT)
-
-
-def _resolve_settings(
-    project_dir: str,
-    model_override: str | None = None,
-) -> tuple[Settings, str]:
-    """Load settings from project directory and apply any CLI overrides.
-
-    Parameters
-    ----------
-    project_dir:
-        Path to the project directory containing .env.
-    model_override:
-        Optional model name to override settings.
-
-    Returns
-    -------
-    Tuple of (settings, resolved_model).
-    """
-    from dotenv import load_dotenv
-
-    env_path = os.path.join(project_dir, ".env")
-    if os.path.exists(env_path):
-        load_dotenv(env_path, override=False)
-    load_global_env(override=False)
-    settings = Settings.from_env()
-
-    # Apply model override if provided
-    resolved_model = model_override if model_override else settings.llm.model
-
-    return settings, resolved_model
 
 
 def _current_db_settings_or_none():
@@ -178,22 +149,6 @@ def _validate_settings_for_llm(settings: Settings) -> None:
         if "API_KEY" in error or "TOKEN" in error:
             click.echo(f"Error: {error}", err=True)
             sys.exit(1)
-
-
-def _resolve_db_path(settings: Settings, project_dir: str) -> str:
-    """Resolve database path, making relative paths absolute.
-
-    Returns
-    -------
-    Resolved database path, or empty string for non-file databases.
-    """
-    if settings.database.mode not in ("duckdb", "sqlite"):
-        return ""
-
-    raw_path = settings.database.path
-    if os.path.isabs(raw_path):
-        return raw_path
-    return str(Path(project_dir) / raw_path)
 
 
 async def _run_ask_pipeline(

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -1,0 +1,229 @@
+# ruff: noqa: F401, F403, F405
+"""CLI command module."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from datasight import cli as cli_root
+from datasight.cli import *  # noqa: F403
+from datasight.cli import (
+    _build_metric_table,
+    _build_profile_detail_table,
+    _build_sql_script,
+    _configure_logging,
+    _current_db_settings_or_none,
+    _default_chart_extension,
+    _default_data_extension,
+    _emit_ask_result,
+    _emit_cli_provenance,
+    _epilog,
+    _fmt_dist,
+    _format_profile_value,
+    _iter_sql_tool_results,
+    _load_batch_entries,
+    _load_recipe_entries,
+    _load_schema_info_for_project,
+    _prepare_web_runtime,
+    _print_sql_queries,
+    _question_table_prefix,
+    _render_dimensions_markdown,
+    _render_distribution_markdown,
+    _render_doctor_markdown,
+    _render_integrity_markdown,
+    _render_measures_markdown,
+    _render_profile_markdown,
+    _render_quality_markdown,
+    _render_recipes_markdown,
+    _render_trends_markdown,
+    _render_validation_markdown,
+    _resolve_db_path,
+    _resolve_settings,
+    _sanitize_sql_identifier,
+    _slugify_filename,
+    _sql_comment_lines,
+    _validate_batch_entry,
+    _validate_settings_for_llm,
+    _write_batch_result_files,
+    _write_or_print,
+)
+
+
+def create_llm_client(*args, **kwargs):
+    return cli_root.create_llm_client(*args, **kwargs)
+
+
+async def _run_ask_pipeline(*args, **kwargs):
+    return await cli_root._run_ask_pipeline(*args, **kwargs)
+
+
+_PROJECT_DIR_OPT = click.option(
+    "--project-dir",
+    "project_dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=".",
+    help="Project directory containing .datasight/ state (default: cwd).",
+)
+
+
+def _conversation_dir(project_dir: str) -> Path:
+    return Path(project_dir).resolve() / ".datasight" / "conversations"
+
+
+def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
+    from datasight.session_archive import validate_session_archive_id
+
+    validate_session_archive_id(session_id)
+    path = _conversation_dir(project_dir) / f"{session_id}.json"
+    if not path.exists():
+        raise click.ClickException(
+            f"Session not found: {session_id}. Use 'datasight session list' to see available sessions."
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        raise click.ClickException(f"Session JSON is invalid: {err}") from err
+    if not isinstance(data, dict):
+        raise click.ClickException("Session JSON must be an object.")
+    return data
+
+
+@click.group(
+    epilog=_epilog(
+        """
+        Examples:
+
+            datasight session list
+            datasight session export abc123 analysis.zip
+            datasight session export abc123 --include-data
+            datasight session import analysis.zip
+            datasight session import analysis.zip --session-id copied-session --overwrite
+        """
+    )
+)
+def session():
+    """Export and import shareable datasight session archives."""
+
+
+@click.command(name="list")
+@_PROJECT_DIR_OPT
+def session_list(project_dir: str):
+    """List saved sessions available for export."""
+    conv_dir = _conversation_dir(project_dir)
+    if not conv_dir.exists():
+        click.echo("No conversations found.")
+        return
+
+    sessions: list[dict[str, Any]] = []
+    for path in sorted(conv_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        events = data.get("events", [])
+        if not events and not data.get("dashboard"):
+            continue
+        sessions.append(
+            {
+                "id": path.stem,
+                "title": data.get("title", "Untitled"),
+                "messages": sum(1 for event in events if event.get("event") == "user_message"),
+            }
+        )
+
+    if not sessions:
+        click.echo("No conversations found.")
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    table = Table(title="Available Sessions")
+    table.add_column("Session ID", style="cyan", no_wrap=True)
+    table.add_column("Title", overflow="fold")
+    table.add_column("Messages", justify="right")
+    for item in sessions:
+        table.add_row(item["id"], item["title"], str(item["messages"]))
+    console.print(table)
+
+
+@click.command(name="export")
+@click.argument("session_id")
+@_PROJECT_DIR_OPT
+@click.option(
+    "--output-path",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output archive path. Defaults to <session_id>.zip in the current directory.",
+)
+@click.option(
+    "--include-data",
+    is_flag=True,
+    help="Embed the DuckDB or SQLite database file into the archive for a runnable import.",
+)
+def session_export(
+    session_id: str,
+    project_dir: str,
+    output_path: Path | None,
+    include_data: bool,
+):
+    """Export SESSION_ID as a versioned datasight session archive."""
+    from datasight.session_archive import build_session_archive
+
+    project_root = str(Path(project_dir).resolve())
+    session_data = _load_session(project_root, session_id)
+    resolved_output_path = output_path or Path(f"{session_id[:20]}.zip")
+
+    settings, _ = _resolve_settings(project_root)
+    archive = build_session_archive(
+        session_id=session_id,
+        conversation=session_data,
+        dashboard=session_data.get("dashboard") or {},
+        project_dir=project_root,
+        db_mode=settings.database.mode or "duckdb",
+        db_path=_resolve_db_path(settings, project_root),
+        include_data=include_data,
+    )
+    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_output_path.write_bytes(archive)
+    click.echo(f"Session archive exported to {resolved_output_path}")
+
+
+@click.command(name="import")
+@click.argument("archive_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@_PROJECT_DIR_OPT
+@click.option(
+    "--session-id",
+    default=None,
+    help="Import under this session ID instead of the archived ID.",
+)
+@click.option("--overwrite", is_flag=True, help="Replace an existing session with the same ID.")
+def session_import(
+    archive_path: Path,
+    project_dir: str,
+    session_id: str | None,
+    overwrite: bool,
+):
+    """Import a datasight session archive into PROJECT_DIR."""
+    from datasight.session_archive import import_session_archive
+
+    try:
+        result = import_session_archive(
+            archive=archive_path.read_bytes(),
+            project_dir=str(Path(project_dir).resolve()),
+            session_id=session_id,
+            overwrite=overwrite,
+        )
+    except ValueError as err:
+        raise click.ClickException(str(err)) from err
+
+    click.echo(
+        f"Imported session {result['session_id']} into {result['conversation_path'].parent.parent}"
+    )
+
+
+session.add_command(session_list)
+session.add_command(session_export)
+session.add_command(session_import)

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -1,61 +1,19 @@
-# ruff: noqa: F401, F403, F405
-"""CLI command module."""
+"""Session archive CLI commands."""
+
+from __future__ import annotations
 
 import json
 from pathlib import Path
 from typing import Any
 
-from datasight import cli as cli_root
-from datasight.cli import *  # noqa: F403
-from datasight.cli import (
-    _build_metric_table,
-    _build_profile_detail_table,
-    _build_sql_script,
-    _configure_logging,
-    _current_db_settings_or_none,
-    _default_chart_extension,
-    _default_data_extension,
-    _emit_ask_result,
-    _emit_cli_provenance,
-    _epilog,
-    _fmt_dist,
-    _format_profile_value,
-    _iter_sql_tool_results,
-    _load_batch_entries,
-    _load_recipe_entries,
-    _load_schema_info_for_project,
-    _prepare_web_runtime,
-    _print_sql_queries,
-    _question_table_prefix,
-    _render_dimensions_markdown,
-    _render_distribution_markdown,
-    _render_doctor_markdown,
-    _render_integrity_markdown,
-    _render_measures_markdown,
-    _render_profile_markdown,
-    _render_quality_markdown,
-    _render_recipes_markdown,
-    _render_trends_markdown,
-    _render_validation_markdown,
-    _resolve_db_path,
-    _resolve_settings,
-    _sanitize_sql_identifier,
-    _slugify_filename,
-    _sql_comment_lines,
-    _validate_batch_entry,
-    _validate_settings_for_llm,
-    _write_batch_result_files,
-    _write_or_print,
+import click
+
+from datasight.cli import _epilog, _resolve_db_path, _resolve_settings
+from datasight.session_archive import (
+    build_session_archive,
+    import_session_archive,
+    validate_session_archive_id,
 )
-
-
-def create_llm_client(*args, **kwargs):
-    return cli_root.create_llm_client(*args, **kwargs)
-
-
-async def _run_ask_pipeline(*args, **kwargs):
-    return await cli_root._run_ask_pipeline(*args, **kwargs)
-
 
 _PROJECT_DIR_OPT = click.option(
     "--project-dir",
@@ -71,8 +29,6 @@ def _conversation_dir(project_dir: str) -> Path:
 
 
 def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
-    from datasight.session_archive import validate_session_archive_id
-
     validate_session_archive_id(session_id)
     path = _conversation_dir(project_dir) / f"{session_id}.json"
     if not path.exists():
@@ -94,20 +50,20 @@ def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
         Examples:
 
             datasight session list
-            datasight session export abc123 analysis.zip
+            datasight session export abc123 --output-path analysis.zip
             datasight session export abc123 --include-data
             datasight session import analysis.zip
             datasight session import analysis.zip --session-id copied-session --overwrite
         """
     )
 )
-def session():
+def session() -> None:
     """Export and import shareable datasight session archives."""
 
 
 @click.command(name="list")
 @_PROJECT_DIR_OPT
-def session_list(project_dir: str):
+def session_list(project_dir: str) -> None:
     """List saved sessions available for export."""
     conv_dir = _conversation_dir(project_dir)
     if not conv_dir.exists():
@@ -168,10 +124,8 @@ def session_export(
     project_dir: str,
     output_path: Path | None,
     include_data: bool,
-):
+) -> None:
     """Export SESSION_ID as a versioned datasight session archive."""
-    from datasight.session_archive import build_session_archive
-
     project_root = str(Path(project_dir).resolve())
     session_data = _load_session(project_root, session_id)
     resolved_output_path = output_path or Path(f"{session_id[:20]}.zip")
@@ -205,10 +159,8 @@ def session_import(
     project_dir: str,
     session_id: str | None,
     overwrite: bool,
-):
+) -> None:
     """Import a datasight session archive into PROJECT_DIR."""
-    from datasight.session_archive import import_session_archive
-
     try:
         result = import_session_archive(
             archive=archive_path.read_bytes(),

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Any
 
 import click
+from rich.console import Console
+from rich.table import Table
 
 from datasight.cli import _epilog, _resolve_db_path, _resolve_settings
 from datasight.session_archive import (
@@ -33,12 +35,14 @@ def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
     path = _conversation_dir(project_dir) / f"{session_id}.json"
     if not path.exists():
         raise click.ClickException(
-            f"Session not found: {session_id}. Use 'datasight session list' to see available sessions."
+            "Session not found: {}. Use 'datasight session list' to see available sessions.".format(
+                session_id
+            )
         )
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as err:
-        raise click.ClickException(f"Session JSON is invalid: {err}") from err
+        raise click.ClickException("Session JSON is invalid: {}".format(err)) from err
     if not isinstance(data, dict):
         raise click.ClickException("Session JSON must be an object.")
     return data
@@ -71,10 +75,12 @@ def session_list(project_dir: str) -> None:
         return
 
     sessions: list[dict[str, Any]] = []
+    invalid_paths: list[Path] = []
     for path in sorted(conv_dir.glob("*.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
+            invalid_paths.append(path)
             continue
         events = data.get("events", [])
         if not events and not data.get("dashboard"):
@@ -88,11 +94,10 @@ def session_list(project_dir: str) -> None:
         )
 
     if not sessions:
+        for path in invalid_paths:
+            click.echo("Warning: skipped unreadable session file {}".format(path.name), err=True)
         click.echo("No conversations found.")
         return
-
-    from rich.console import Console
-    from rich.table import Table
 
     console = Console()
     table = Table(title="Available Sessions")
@@ -102,6 +107,8 @@ def session_list(project_dir: str) -> None:
     for item in sessions:
         table.add_row(item["id"], item["title"], str(item["messages"]))
     console.print(table)
+    for path in invalid_paths:
+        click.echo("Warning: skipped unreadable session file {}".format(path.name), err=True)
 
 
 @click.command(name="export")
@@ -128,7 +135,7 @@ def session_export(
     """Export SESSION_ID as a versioned datasight session archive."""
     project_root = str(Path(project_dir).resolve())
     session_data = _load_session(project_root, session_id)
-    resolved_output_path = output_path or Path(f"{session_id[:20]}.zip")
+    resolved_output_path = output_path or Path("{}.zip".format(session_id))
 
     settings, _ = _resolve_settings(project_root)
     archive = build_session_archive(
@@ -142,7 +149,7 @@ def session_export(
     )
     resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_output_path.write_bytes(archive)
-    click.echo(f"Session archive exported to {resolved_output_path}")
+    click.echo("Session archive exported to {}".format(resolved_output_path))
 
 
 @click.command(name="import")
@@ -172,7 +179,9 @@ def session_import(
         raise click.ClickException(str(err)) from err
 
     click.echo(
-        f"Imported session {result['session_id']} into {result['conversation_path'].parent.parent}"
+        "Imported session {} into {}".format(
+            result["session_id"], result["conversation_path"].parent.parent
+        )
     )
 
 

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -35,14 +35,13 @@ def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
     path = _conversation_dir(project_dir) / f"{session_id}.json"
     if not path.exists():
         raise click.ClickException(
-            "Session not found: {}. Use 'datasight session list' to see available sessions.".format(
-                session_id
-            )
+            f"Session not found: {session_id}. "
+            "Use 'datasight session list' to see available sessions."
         )
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as err:
-        raise click.ClickException("Session JSON is invalid: {}".format(err)) from err
+        raise click.ClickException(f"Session JSON is invalid: {err}") from err
     if not isinstance(data, dict):
         raise click.ClickException("Session JSON must be an object.")
     return data
@@ -82,20 +81,26 @@ def session_list(project_dir: str) -> None:
         except (json.JSONDecodeError, OSError):
             invalid_paths.append(path)
             continue
-        events = data.get("events", [])
+        if not isinstance(data, dict):
+            invalid_paths.append(path)
+            continue
+        events = data.get("events") or []
         if not events and not data.get("dashboard"):
             continue
         sessions.append(
             {
                 "id": path.stem,
                 "title": data.get("title", "Untitled"),
-                "messages": sum(1 for event in events if event.get("event") == "user_message"),
+                "messages": sum(1 for e in events if e.get("event") == "user_message"),
             }
         )
 
+    def _warn() -> None:
+        for p in invalid_paths:
+            click.echo(f"Warning: skipped unreadable session file {p.name}", err=True)
+
     if not sessions:
-        for path in invalid_paths:
-            click.echo("Warning: skipped unreadable session file {}".format(path.name), err=True)
+        _warn()
         click.echo("No conversations found.")
         return
 
@@ -107,8 +112,7 @@ def session_list(project_dir: str) -> None:
     for item in sessions:
         table.add_row(item["id"], item["title"], str(item["messages"]))
     console.print(table)
-    for path in invalid_paths:
-        click.echo("Warning: skipped unreadable session file {}".format(path.name), err=True)
+    _warn()
 
 
 @click.command(name="export")
@@ -135,21 +139,25 @@ def session_export(
     """Export SESSION_ID as a versioned datasight session archive."""
     project_root = str(Path(project_dir).resolve())
     session_data = _load_session(project_root, session_id)
-    resolved_output_path = output_path or Path("{}.zip".format(session_id))
+    resolved_output_path = output_path or Path(f"{session_id}.zip")
 
     settings, _ = _resolve_settings(project_root)
-    archive = build_session_archive(
-        session_id=session_id,
-        conversation=session_data,
-        dashboard=session_data.get("dashboard") or {},
-        project_dir=project_root,
-        db_mode=settings.database.mode or "duckdb",
-        db_path=_resolve_db_path(settings, project_root),
-        include_data=include_data,
-    )
+    try:
+        archive = build_session_archive(
+            session_id=session_id,
+            conversation=session_data,
+            project_dir=project_root,
+            db_mode=settings.database.mode,
+            db_path=_resolve_db_path(settings, project_root),
+            include_data=include_data,
+        )
+    except ValueError as err:
+        raise click.ClickException(str(err)) from err
+
     resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_output_path.write_bytes(archive)
-    click.echo("Session archive exported to {}".format(resolved_output_path))
+    click.echo(f"Session archive exported to {resolved_output_path}")
+    click.echo("Archive does not include .env or any LLM API keys.")
 
 
 @click.command(name="import")
@@ -160,7 +168,11 @@ def session_export(
     default=None,
     help="Import under this session ID instead of the archived ID.",
 )
-@click.option("--overwrite", is_flag=True, help="Replace an existing session with the same ID.")
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Replace an existing session or restored database file.",
+)
 def session_import(
     archive_path: Path,
     project_dir: str,
@@ -168,21 +180,25 @@ def session_import(
     overwrite: bool,
 ) -> None:
     """Import a datasight session archive into PROJECT_DIR."""
+    target_root = Path(project_dir).resolve()
     try:
         result = import_session_archive(
             archive=archive_path.read_bytes(),
-            project_dir=str(Path(project_dir).resolve()),
+            project_dir=str(target_root),
             session_id=session_id,
             overwrite=overwrite,
         )
     except ValueError as err:
         raise click.ClickException(str(err)) from err
 
-    click.echo(
-        "Imported session {} into {}".format(
-            result["session_id"], result["conversation_path"].parent.parent
-        )
-    )
+    click.echo(f"Imported session {result['session_id']} into {target_root}")
+    if result["restored_db_path"] is not None:
+        click.echo(f"Restored database file to {result['restored_db_path']}")
+        if not result["env_written"]:
+            click.echo(
+                "Note: .env already exists; ensure DB_MODE and DB_PATH point to the "
+                "restored database to run this session."
+            )
 
 
 session.add_command(session_list)

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from datasight.cli import _epilog, _resolve_db_path, _resolve_settings
+from datasight.cli_helpers import _epilog, _resolve_db_path, _resolve_settings
 from datasight.session_archive import (
     import_session_archive,
     validate_session_archive_id,

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -12,9 +12,9 @@ from rich.table import Table
 
 from datasight.cli import _epilog, _resolve_db_path, _resolve_settings
 from datasight.session_archive import (
-    build_session_archive,
     import_session_archive,
     validate_session_archive_id,
+    write_session_archive,
 )
 
 _PROJECT_DIR_OPT = click.option(
@@ -34,14 +34,16 @@ def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
     validate_session_archive_id(session_id)
     path = _conversation_dir(project_dir) / f"{session_id}.json"
     if not path.exists():
-        raise click.ClickException(
+        msg = (
             f"Session not found: {session_id}. "
             "Use 'datasight session list' to see available sessions."
         )
+        raise click.ClickException(msg)
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as err:
-        raise click.ClickException(f"Session JSON is invalid: {err}") from err
+        msg = f"Session JSON is invalid: {err}"
+        raise click.ClickException(msg) from err
     if not isinstance(data, dict):
         raise click.ClickException("Session JSON must be an object.")
     return data
@@ -78,7 +80,10 @@ def session_list(project_dir: str) -> None:
     for path in sorted(conv_dir.glob("*.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+        except json.JSONDecodeError:
+            # Bad JSON is the deliberate skip case; OS-level errors
+            # (missing file, permission denied) are real problems and are
+            # allowed to propagate.
             invalid_paths.append(path)
             continue
         if not isinstance(data, dict):
@@ -115,6 +120,22 @@ def session_list(project_dir: str) -> None:
     _warn()
 
 
+def _project_db_config(project_root: str) -> tuple[str, str]:
+    """Return ``(db_mode, db_path)`` only when the project explicitly configures one.
+
+    A bare ``Settings.from_env()`` call always falls back to
+    ``DB_MODE=duckdb``/``DB_PATH=database.duckdb`` even for projects with
+    no ``.env`` and no shell-set DB env vars. Stamping those defaults into
+    the archive metadata would falsely claim a DuckDB backing file the
+    project never had, so only emit the config when the project has an
+    ``.env`` we can attribute it to.
+    """
+    if not (Path(project_root) / ".env").exists():
+        return "", ""
+    settings, _ = _resolve_settings(project_root)
+    return settings.database.mode, _resolve_db_path(settings, project_root)
+
+
 @click.command(name="export")
 @click.argument("session_id")
 @_PROJECT_DIR_OPT
@@ -141,21 +162,27 @@ def session_export(
     session_data = _load_session(project_root, session_id)
     resolved_output_path = output_path or Path(f"{session_id}.zip")
 
-    settings, _ = _resolve_settings(project_root)
+    db_mode, db_path = _project_db_config(project_root)
+    if include_data and not db_mode:
+        msg = (
+            "--include-data requires a configured database. Add DB_MODE/DB_PATH to "
+            f"{project_root}/.env or remove the flag."
+        )
+        raise click.ClickException(msg)
+
     try:
-        archive = build_session_archive(
+        write_session_archive(
+            output=resolved_output_path,
             session_id=session_id,
             conversation=session_data,
             project_dir=project_root,
-            db_mode=settings.database.mode,
-            db_path=_resolve_db_path(settings, project_root),
+            db_mode=db_mode,
+            db_path=db_path,
             include_data=include_data,
         )
     except ValueError as err:
         raise click.ClickException(str(err)) from err
 
-    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
-    resolved_output_path.write_bytes(archive)
     click.echo(f"Session archive exported to {resolved_output_path}")
     click.echo("Archive does not include .env or any LLM API keys.")
 
@@ -182,8 +209,10 @@ def session_import(
     """Import a datasight session archive into PROJECT_DIR."""
     target_root = Path(project_dir).resolve()
     try:
+        # Pass the path through so import_session_archive streams from
+        # disk instead of materializing the whole archive in memory.
         result = import_session_archive(
-            archive=archive_path.read_bytes(),
+            archive=archive_path,
             project_dir=str(target_root),
             session_id=session_id,
             overwrite=overwrite,

--- a/src/datasight/cli_commands/session.py
+++ b/src/datasight/cli_commands/session.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from datasight.cli_helpers import _epilog, _resolve_db_path, _resolve_settings
+from datasight.cli_helpers import _epilog
 from datasight.session_archive import (
     import_session_archive,
     validate_session_archive_id,
@@ -56,14 +56,18 @@ def _load_session(project_dir: str, session_id: str) -> dict[str, Any]:
 
             datasight session list
             datasight session export abc123 --output-path analysis.zip
-            datasight session export abc123 --include-data
             datasight session import analysis.zip
             datasight session import analysis.zip --session-id copied-session --overwrite
         """
     )
 )
 def session() -> None:
-    """Export and import shareable datasight session archives."""
+    """Export and import shareable datasight session archives.
+
+    Archives carry the conversation transcript and per-session dashboard
+    only — never .env or LLM credentials, and never the underlying
+    database. Recipients need to bring their own data.
+    """
 
 
 @click.command(name="list")
@@ -120,22 +124,6 @@ def session_list(project_dir: str) -> None:
     _warn()
 
 
-def _project_db_config(project_root: str) -> tuple[str, str]:
-    """Return ``(db_mode, db_path)`` only when the project explicitly configures one.
-
-    A bare ``Settings.from_env()`` call always falls back to
-    ``DB_MODE=duckdb``/``DB_PATH=database.duckdb`` even for projects with
-    no ``.env`` and no shell-set DB env vars. Stamping those defaults into
-    the archive metadata would falsely claim a DuckDB backing file the
-    project never had, so only emit the config when the project has an
-    ``.env`` we can attribute it to.
-    """
-    if not (Path(project_root) / ".env").exists():
-        return "", ""
-    settings, _ = _resolve_settings(project_root)
-    return settings.database.mode, _resolve_db_path(settings, project_root)
-
-
 @click.command(name="export")
 @click.argument("session_id")
 @_PROJECT_DIR_OPT
@@ -146,45 +134,26 @@ def _project_db_config(project_root: str) -> tuple[str, str]:
     default=None,
     help="Output archive path. Defaults to <session_id>.zip in the current directory.",
 )
-@click.option(
-    "--include-data",
-    is_flag=True,
-    help="Embed the DuckDB or SQLite database file into the archive for a runnable import.",
-)
 def session_export(
     session_id: str,
     project_dir: str,
     output_path: Path | None,
-    include_data: bool,
 ) -> None:
     """Export SESSION_ID as a versioned datasight session archive."""
     project_root = str(Path(project_dir).resolve())
     session_data = _load_session(project_root, session_id)
     resolved_output_path = output_path or Path(f"{session_id}.zip")
 
-    db_mode, db_path = _project_db_config(project_root)
-    if include_data and not db_mode:
-        msg = (
-            "--include-data requires a configured database. Add DB_MODE/DB_PATH to "
-            f"{project_root}/.env or remove the flag."
-        )
-        raise click.ClickException(msg)
-
     try:
         write_session_archive(
             output=resolved_output_path,
             session_id=session_id,
             conversation=session_data,
-            project_dir=project_root,
-            db_mode=db_mode,
-            db_path=db_path,
-            include_data=include_data,
         )
     except ValueError as err:
         raise click.ClickException(str(err)) from err
 
     click.echo(f"Session archive exported to {resolved_output_path}")
-    click.echo("Archive does not include .env or any LLM API keys.")
 
 
 @click.command(name="import")
@@ -195,11 +164,7 @@ def session_export(
     default=None,
     help="Import under this session ID instead of the archived ID.",
 )
-@click.option(
-    "--overwrite",
-    is_flag=True,
-    help="Replace an existing session or restored database file.",
-)
+@click.option("--overwrite", is_flag=True, help="Replace an existing session with the same ID.")
 def session_import(
     archive_path: Path,
     project_dir: str,
@@ -221,13 +186,6 @@ def session_import(
         raise click.ClickException(str(err)) from err
 
     click.echo(f"Imported session {result['session_id']} into {target_root}")
-    if result["restored_db_path"] is not None:
-        click.echo(f"Restored database file to {result['restored_db_path']}")
-        if not result["env_written"]:
-            click.echo(
-                "Note: .env already exists; ensure DB_MODE and DB_PATH point to the "
-                "restored database to run this session."
-            )
 
 
 session.add_command(session_list)

--- a/src/datasight/cli_helpers.py
+++ b/src/datasight/cli_helpers.py
@@ -1,0 +1,69 @@
+"""Shared helpers used by both ``datasight.cli`` and its subcommand modules.
+
+Subcommand modules under ``datasight.cli_commands`` were originally
+importing these helpers from ``datasight.cli``, which made the static
+import graph cyclic (``cli`` registers its subcommands, and the
+subcommands turned around and imported helpers from ``cli``). The
+runtime didn't care — ``_register_commands`` is lazy — but CodeQL
+flagged the cycle and any new subcommand inherits the issue.
+
+Pulling these tiny helpers into a dedicated module that imports nothing
+from the CLI package breaks the back-edge for callers that switch over.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from textwrap import dedent
+
+from datasight.settings import Settings, load_global_env
+
+
+def _epilog(text: str) -> str:
+    """Normalize Click epilog text defined in indented decorators."""
+    # Rich Click reflows epilog paragraphs. Treat each authored line as
+    # its own paragraph so examples remain scannable in terminal help.
+    return "\n\n".join(line.rstrip() for line in dedent(text).strip().splitlines())
+
+
+def _resolve_settings(
+    project_dir: str,
+    model_override: str | None = None,
+) -> tuple[Settings, str]:
+    """Load settings from a project directory and apply CLI overrides.
+
+    Parameters
+    ----------
+    project_dir:
+        Path to the project directory containing ``.env``.
+    model_override:
+        Optional model name to override the value from settings.
+
+    Returns
+    -------
+    Tuple of ``(settings, resolved_model)``.
+    """
+    from dotenv import load_dotenv
+
+    env_path = os.path.join(project_dir, ".env")
+    if os.path.exists(env_path):
+        load_dotenv(env_path, override=False)
+    load_global_env(override=False)
+    settings = Settings.from_env()
+    resolved_model = model_override if model_override else settings.llm.model
+    return settings, resolved_model
+
+
+def _resolve_db_path(settings: Settings, project_dir: str) -> str:
+    """Resolve the configured database path, making relative paths absolute.
+
+    Returns an empty string for non-file backends so callers can pass
+    the result straight through to APIs that accept ``""`` as "no path."
+    """
+    if settings.database.mode not in ("duckdb", "sqlite"):
+        return ""
+    raw_path = settings.database.path
+    if os.path.isabs(raw_path):
+        return raw_path
+    return str(Path(project_dir) / raw_path)

--- a/src/datasight/session_archive.py
+++ b/src/datasight/session_archive.py
@@ -14,7 +14,7 @@ from datasight import __version__
 
 SESSION_ARCHIVE_FORMAT = "datasight-session-archive"
 SESSION_ARCHIVE_VERSION = 1
-_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def validate_session_archive_id(session_id: str) -> str:
@@ -41,6 +41,34 @@ def _relative_or_absolute_path(path: str, project_dir: str) -> dict[str, Any] | 
     except ValueError:
         return {"path": str(target), "path_kind": "absolute"}
     return {"path": str(rel_path), "path_kind": "relative"}
+
+
+def _resolve_db_file_path(path: str, project_dir: str) -> Path:
+    raw_path = str(path or "").strip()
+    if not raw_path:
+        return Path(project_dir).resolve()
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = Path(project_dir) / candidate
+    return candidate.resolve()
+
+
+def _safe_project_relative_path(path: str) -> Path:
+    candidate = Path(str(path))
+    if candidate.is_absolute():
+        raise ValueError(f"Archive restore path must be relative: {path!r}")
+
+    clean_parts: list[str] = []
+    for part in candidate.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            raise ValueError(f"Archive restore path cannot traverse upward: {path!r}")
+        clean_parts.append(part)
+
+    if not clean_parts:
+        raise ValueError(f"Archive restore path is empty: {path!r}")
+    return Path(*clean_parts)
 
 
 def build_session_archive(
@@ -73,7 +101,7 @@ def build_session_archive(
                 raise ValueError(
                     "--include-data is only supported for DuckDB and SQLite projects."
                 )
-            resolved_db_path = Path(db_path).resolve()
+            resolved_db_path = _resolve_db_file_path(db_path, project_dir)
             if not resolved_db_path.exists() or not resolved_db_path.is_file():
                 raise ValueError(f"Database file not found for --include-data: {resolved_db_path}")
             archive_name = (
@@ -209,8 +237,13 @@ def import_session_archive(
         archive_path = database.get("archive_path")
         if not isinstance(archive_path, str) or not archive_path:
             raise ValueError("Archive metadata for embedded database is incomplete.")
-        restore_rel_path = database.get("path") or Path(archive_path).name
-        restore_path = (project_root / str(restore_rel_path)).resolve()
+        restore_rel_path_raw = (
+            database.get("path")
+            if database.get("path_kind") == "relative" and isinstance(database.get("path"), str)
+            else Path(archive_path).name
+        )
+        restore_rel_path = _safe_project_relative_path(str(restore_rel_path_raw))
+        restore_path = project_root / restore_rel_path
         restore_path.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(BytesIO(archive)) as zf:
             try:
@@ -222,9 +255,8 @@ def import_session_archive(
         db_mode = str(database.get("mode") or "").strip()
         if db_mode in {"duckdb", "sqlite"}:
             env_path = project_root / ".env"
-            rel_db_path = restore_path.relative_to(project_root)
             env_path.write_text(
-                f"DB_MODE={db_mode}\nDB_PATH={rel_db_path.as_posix()}\n",
+                f"DB_MODE={db_mode}\nDB_PATH={restore_rel_path.as_posix()}\n",
                 encoding="utf-8",
             )
 

--- a/src/datasight/session_archive.py
+++ b/src/datasight/session_archive.py
@@ -1,0 +1,237 @@
+"""Versioned session archive helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from io import BytesIO
+import json
+from pathlib import Path
+import re
+from typing import Any
+import zipfile
+
+from datasight import __version__
+
+SESSION_ARCHIVE_FORMAT = "datasight-session-archive"
+SESSION_ARCHIVE_VERSION = 1
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def validate_session_archive_id(session_id: str) -> str:
+    """Validate a session ID used in archive export/import."""
+    if not _SESSION_ID_RE.match(session_id) or len(session_id) > 128:
+        raise ValueError(f"Invalid session ID: {session_id!r}")
+    return session_id
+
+
+def _relative_or_absolute_path(path: str, project_dir: str) -> dict[str, Any] | None:
+    raw_path = str(path or "").strip()
+    if not raw_path:
+        return None
+
+    target = Path(raw_path)
+    if not target.is_absolute():
+        target = (Path(project_dir) / target).resolve()
+    else:
+        target = target.resolve()
+
+    project_root = Path(project_dir).resolve()
+    try:
+        rel_path = target.relative_to(project_root)
+    except ValueError:
+        return {"path": str(target), "path_kind": "absolute"}
+    return {"path": str(rel_path), "path_kind": "relative"}
+
+
+def build_session_archive(
+    *,
+    session_id: str,
+    conversation: dict[str, Any],
+    dashboard: dict[str, Any] | None,
+    project_dir: str,
+    db_mode: str = "",
+    db_path: str = "",
+    include_data: bool = False,
+) -> bytes:
+    """Build a portable zip archive for a saved datasight session."""
+    session_id = validate_session_archive_id(session_id)
+
+    conversation_payload = dict(conversation)
+    dashboard_payload = dashboard if isinstance(dashboard, dict) else {}
+    conversation_payload["dashboard"] = dashboard_payload
+
+    source_data: dict[str, Any] = {}
+    normalized_db_mode = str(db_mode or "").strip()
+    embedded_files: list[tuple[Path, str]] = []
+    if normalized_db_mode:
+        db_ref = {"mode": normalized_db_mode, "embedded": False}
+        path_ref = _relative_or_absolute_path(db_path, project_dir)
+        if path_ref is not None:
+            db_ref.update(path_ref)
+        if include_data:
+            if normalized_db_mode not in {"duckdb", "sqlite"}:
+                raise ValueError(
+                    "--include-data is only supported for DuckDB and SQLite projects."
+                )
+            resolved_db_path = Path(db_path).resolve()
+            if not resolved_db_path.exists() or not resolved_db_path.is_file():
+                raise ValueError(f"Database file not found for --include-data: {resolved_db_path}")
+            archive_name = (
+                path_ref["path"]
+                if path_ref and path_ref.get("path_kind") == "relative"
+                else resolved_db_path.name
+            )
+            archive_member = f"data/{archive_name}"
+            db_ref["embedded"] = True
+            db_ref["archive_path"] = archive_member
+            embedded_files.append((resolved_db_path, archive_member))
+        source_data["database"] = db_ref
+
+    manifest = {
+        "format": SESSION_ARCHIVE_FORMAT,
+        "archive_version": SESSION_ARCHIVE_VERSION,
+        "datasight_version": __version__,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "title": conversation_payload.get("title", "Untitled"),
+        "artifacts": [
+            "manifest.json",
+            "session/conversation.json",
+            "session/dashboard.json",
+            "metadata/source_data.json",
+        ],
+    }
+    manifest["includes_data"] = bool(embedded_files)
+    manifest["artifacts"].extend(archive_path for _, archive_path in embedded_files)
+
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+        zf.writestr(
+            "session/conversation.json",
+            json.dumps(conversation_payload, indent=2, sort_keys=True),
+        )
+        zf.writestr(
+            "session/dashboard.json",
+            json.dumps(dashboard_payload, indent=2, sort_keys=True),
+        )
+        zf.writestr(
+            "metadata/source_data.json",
+            json.dumps(source_data, indent=2, sort_keys=True),
+        )
+        for file_path, archive_path in embedded_files:
+            zf.write(file_path, archive_path)
+    return buf.getvalue()
+
+
+def read_session_archive(archive: bytes) -> dict[str, Any]:
+    """Read and validate a datasight session archive."""
+    with zipfile.ZipFile(BytesIO(archive)) as zf:
+        try:
+            manifest = json.loads(zf.read("manifest.json"))
+            conversation = json.loads(zf.read("session/conversation.json"))
+            dashboard = json.loads(zf.read("session/dashboard.json"))
+            source_data = json.loads(zf.read("metadata/source_data.json"))
+        except KeyError as err:
+            raise ValueError(f"Archive is missing required entry: {err.args[0]}") from err
+        except json.JSONDecodeError as err:
+            raise ValueError(f"Archive JSON is invalid: {err}") from err
+
+        if manifest.get("format") != SESSION_ARCHIVE_FORMAT:
+            raise ValueError("Not a datasight session archive.")
+        version = manifest.get("archive_version")
+        if version != SESSION_ARCHIVE_VERSION:
+            raise ValueError(
+                f"Unsupported session archive version {version!r}. "
+                f"Expected {SESSION_ARCHIVE_VERSION}."
+            )
+
+        if not isinstance(conversation, dict):
+            raise ValueError("Archive conversation payload must be an object.")
+        if not isinstance(dashboard, dict):
+            raise ValueError("Archive dashboard payload must be an object.")
+        if not isinstance(source_data, dict):
+            raise ValueError("Archive source_data payload must be an object.")
+
+        session_id = validate_session_archive_id(str(manifest.get("session_id") or ""))
+        conversation["dashboard"] = dashboard
+        return {
+            "manifest": manifest,
+            "session_id": session_id,
+            "conversation": conversation,
+            "dashboard": dashboard,
+            "source_data": source_data,
+        }
+
+
+def import_session_archive(
+    *,
+    archive: bytes,
+    project_dir: str,
+    session_id: str | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Import a session archive into a datasight project directory."""
+    payload = read_session_archive(archive)
+    imported_session_id = validate_session_archive_id(
+        session_id if session_id is not None else payload["session_id"]
+    )
+
+    project_root = Path(project_dir).resolve()
+    datasight_dir = project_root / ".datasight"
+    conversations_dir = datasight_dir / "conversations"
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+
+    conversation_path = conversations_dir / f"{imported_session_id}.json"
+    if conversation_path.exists() and not overwrite:
+        raise ValueError(
+            f"Session {imported_session_id!r} already exists in {project_root}. "
+            "Pass --overwrite to replace it."
+        )
+
+    conversation = dict(payload["conversation"])
+    dashboard = payload["dashboard"]
+    conversation["dashboard"] = dashboard
+
+    conversation_path.write_text(
+        json.dumps(conversation, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    (datasight_dir / "dashboard.json").write_text(
+        json.dumps(dashboard, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    restored_paths: list[Path] = []
+    source_data = payload["source_data"]
+    database = source_data.get("database") if isinstance(source_data, dict) else None
+    if isinstance(database, dict) and database.get("embedded"):
+        archive_path = database.get("archive_path")
+        if not isinstance(archive_path, str) or not archive_path:
+            raise ValueError("Archive metadata for embedded database is incomplete.")
+        restore_rel_path = database.get("path") or Path(archive_path).name
+        restore_path = (project_root / str(restore_rel_path)).resolve()
+        restore_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(BytesIO(archive)) as zf:
+            try:
+                restore_path.write_bytes(zf.read(archive_path))
+            except KeyError as err:
+                raise ValueError(f"Archive is missing embedded data file: {archive_path}") from err
+        restored_paths.append(restore_path)
+
+        db_mode = str(database.get("mode") or "").strip()
+        if db_mode in {"duckdb", "sqlite"}:
+            env_path = project_root / ".env"
+            rel_db_path = restore_path.relative_to(project_root)
+            env_path.write_text(
+                f"DB_MODE={db_mode}\nDB_PATH={rel_db_path.as_posix()}\n",
+                encoding="utf-8",
+            )
+
+    return {
+        "session_id": imported_session_id,
+        "conversation_path": conversation_path,
+        "dashboard_path": datasight_dir / "dashboard.json",
+        "manifest": payload["manifest"],
+        "restored_paths": restored_paths,
+    }

--- a/src/datasight/session_archive.py
+++ b/src/datasight/session_archive.py
@@ -1,198 +1,230 @@
-"""Versioned session archive helpers."""
+"""Versioned session archive helpers.
+
+A session archive is a zip file with this layout::
+
+    manifest.json              # format/version/exported_at/session_id/title
+    session/conversation.json  # the .datasight/conversations/<id>.json file,
+                               # which already embeds the per-session dashboard
+                               # under conversation["dashboard"]
+    metadata/source_data.json  # database mode + path the session was authored
+                               # against, plus an "archive_path" pointer if a
+                               # data file was embedded
+    data/<basename>            # only present when --include-data was passed
+
+The on-disk shape of conversations and per-session dashboards is the
+authoritative source of truth (see ``ConversationStore`` and
+``DashboardStore`` in ``datasight.web.app``). This module just hands those
+files in and out of a zip with a manifest.
+
+Privacy
+-------
+Archives are intended to be shared with collaborators. They deliberately
+do **not** include ``.env`` and never read LLM credentials. Database paths
+that fall outside the project directory are recorded as basenames only so
+the exporter's filesystem layout is not leaked.
+"""
 
 from __future__ import annotations
 
+import json
+import re
+import shutil
+import zipfile
 from datetime import datetime, timezone
 from io import BytesIO
-import json
 from pathlib import Path
-import re
 from typing import Any
-import zipfile
 
 from datasight import __version__
 
-SESSION_ARCHIVE_FORMAT = "datasight-session-archive"
-SESSION_ARCHIVE_VERSION = 1
+ARCHIVE_FORMAT = "datasight-session-archive"
+ARCHIVE_VERSION = 1
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_FILE_DB_MODES = frozenset({"duckdb", "sqlite"})
+
+# Backwards-compatible aliases for callers/tests that import the older names.
+SESSION_ARCHIVE_FORMAT = ARCHIVE_FORMAT
+SESSION_ARCHIVE_VERSION = ARCHIVE_VERSION
 
 
 def validate_session_archive_id(session_id: str) -> str:
-    """Validate a session ID used in archive export/import."""
+    """Validate a session ID for archive export/import.
+
+    Mirrors the regex used by ``datasight.web.app.validate_session_id`` so
+    archives can round-trip in and out of the web app's conversation store.
+    """
     if not _SESSION_ID_RE.match(session_id) or len(session_id) > 128:
-        raise ValueError("Invalid session ID: {!r}".format(session_id))
+        raise ValueError(f"Invalid session ID: {session_id!r}")
     return session_id
 
 
-def _relative_or_absolute_path(path: str, project_dir: str) -> dict[str, Any] | None:
-    raw_path = str(path or "").strip()
-    if not raw_path:
-        return None
-
-    target = Path(raw_path)
-    if not target.is_absolute():
-        target = (Path(project_dir) / target).resolve()
-    else:
-        target = target.resolve()
-
-    project_root = Path(project_dir).resolve()
-    try:
-        rel_path = target.relative_to(project_root)
-    except ValueError:
-        return {"path": str(target), "path_kind": "absolute"}
-    return {"path": str(rel_path), "path_kind": "relative"}
-
-
-def _resolve_db_file_path(path: str, project_dir: str) -> Path:
-    raw_path = str(path or "").strip()
-    if not raw_path:
-        return Path(project_dir).resolve()
-    candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = Path(project_dir) / candidate
-    return candidate.resolve()
-
-
-def _safe_project_relative_path(path: str) -> Path:
-    candidate = Path(str(path))
+def _safe_relative_member(name: str) -> Path:
+    """Reject absolute paths or anything that escapes via ``..``."""
+    candidate = Path(name)
     if candidate.is_absolute():
-        raise ValueError("Archive restore path must be relative: {!r}".format(path))
-
-    clean_parts: list[str] = []
+        raise ValueError(f"Archive restore path must be relative: {name!r}")
+    parts: list[str] = []
     for part in candidate.parts:
         if part in ("", "."):
             continue
         if part == "..":
-            raise ValueError("Archive restore path cannot traverse upward: {!r}".format(path))
-        clean_parts.append(part)
+            raise ValueError(f"Archive restore path cannot traverse upward: {name!r}")
+        parts.append(part)
+    if not parts:
+        raise ValueError(f"Archive restore path is empty: {name!r}")
+    return Path(*parts)
 
-    if not clean_parts:
-        raise ValueError("Archive restore path is empty: {!r}".format(path))
-    return Path(*clean_parts)
+
+def _resolve_db_source(db_path: str, project_root: Path) -> Path:
+    candidate = Path(db_path)
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    return candidate.resolve()
+
+
+def _archive_db_reference(
+    db_mode: str,
+    db_path: str,
+    project_root: Path,
+) -> dict[str, Any] | None:
+    mode = (db_mode or "").strip()
+    if not mode:
+        return None
+    ref: dict[str, Any] = {"mode": mode, "embedded": False}
+    raw = (db_path or "").strip()
+    if not raw:
+        return ref
+    target = _resolve_db_source(raw, project_root)
+    try:
+        rel = target.relative_to(project_root)
+        ref["path"] = rel.as_posix()
+        ref["path_kind"] = "relative"
+    except ValueError:
+        # Don't leak the exporter's absolute filesystem layout. Record
+        # only the basename so the importer can still pick a sensible
+        # destination without learning where the source lived.
+        ref["path"] = target.name
+        ref["path_kind"] = "external"
+    return ref
 
 
 def build_session_archive(
     *,
     session_id: str,
     conversation: dict[str, Any],
-    dashboard: dict[str, Any] | None,
+    dashboard: dict[str, Any] | None = None,
     project_dir: str,
     db_mode: str = "",
     db_path: str = "",
     include_data: bool = False,
 ) -> bytes:
-    """Build a portable zip archive for a saved datasight session."""
-    session_id = validate_session_archive_id(session_id)
+    """Build a portable zip archive for a saved datasight session.
 
-    conversation_payload = dict(conversation)
-    dashboard_payload = dashboard if isinstance(dashboard, dict) else {}
-    conversation_payload["dashboard"] = dashboard_payload
+    ``conversation`` is the on-disk conversation JSON, which already
+    embeds the per-session dashboard under ``conversation["dashboard"]``.
+    ``dashboard`` is an optional override for callers that want to attach
+    a dashboard explicitly.
+    """
+    validate_session_archive_id(session_id)
+    project_root = Path(project_dir).resolve()
+
+    payload = dict(conversation)
+    if dashboard is not None:
+        payload["dashboard"] = dashboard
+
+    db_ref = _archive_db_reference(db_mode, db_path, project_root)
+    embedded_db: tuple[Path, str] | None = None
+    if include_data:
+        if db_ref is None or db_ref.get("mode") not in _FILE_DB_MODES:
+            raise ValueError("--include-data is only supported for DuckDB and SQLite projects.")
+        if not (db_path or "").strip():
+            raise ValueError("--include-data requires a configured database path.")
+        source = _resolve_db_source(db_path, project_root)
+        if not source.is_file():
+            raise ValueError(f"Database file not found for --include-data: {source}")
+        member = f"data/{source.name}"
+        db_ref["embedded"] = True
+        db_ref["archive_path"] = member
+        embedded_db = (source, member)
 
     source_data: dict[str, Any] = {}
-    normalized_db_mode = str(db_mode or "").strip()
-    embedded_files: list[tuple[Path, str]] = []
-    if normalized_db_mode:
-        db_ref = {"mode": normalized_db_mode, "embedded": False}
-        path_ref = _relative_or_absolute_path(db_path, project_dir)
-        if path_ref is not None:
-            db_ref.update(path_ref)
-        if include_data:
-            if normalized_db_mode not in {"duckdb", "sqlite"}:
-                raise ValueError(
-                    "--include-data is only supported for DuckDB and SQLite projects."
-                )
-            resolved_db_path = _resolve_db_file_path(db_path, project_dir)
-            if not resolved_db_path.exists() or not resolved_db_path.is_file():
-                raise ValueError(
-                    "Database file not found for --include-data: {}".format(resolved_db_path)
-                )
-            archive_name = (
-                path_ref["path"]
-                if path_ref and path_ref.get("path_kind") == "relative"
-                else resolved_db_path.name
-            )
-            archive_member = f"data/{archive_name}"
-            db_ref["embedded"] = True
-            db_ref["archive_path"] = archive_member
-            embedded_files.append((resolved_db_path, archive_member))
+    if db_ref is not None:
         source_data["database"] = db_ref
 
     manifest = {
-        "format": SESSION_ARCHIVE_FORMAT,
-        "archive_version": SESSION_ARCHIVE_VERSION,
+        "format": ARCHIVE_FORMAT,
+        "archive_version": ARCHIVE_VERSION,
         "datasight_version": __version__,
         "exported_at": datetime.now(timezone.utc).isoformat(),
         "session_id": session_id,
-        "title": conversation_payload.get("title", "Untitled"),
-        "artifacts": [
-            "manifest.json",
-            "session/conversation.json",
-            "session/dashboard.json",
-            "metadata/source_data.json",
-        ],
+        "title": payload.get("title", "Untitled"),
+        "includes_data": embedded_db is not None,
     }
-    manifest["includes_data"] = bool(embedded_files)
-    manifest["artifacts"].extend(archive_path for _, archive_path in embedded_files)
 
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
         zf.writestr(
             "session/conversation.json",
-            json.dumps(conversation_payload, indent=2, sort_keys=True),
-        )
-        zf.writestr(
-            "session/dashboard.json",
-            json.dumps(dashboard_payload, indent=2, sort_keys=True),
+            json.dumps(payload, indent=2, sort_keys=True),
         )
         zf.writestr(
             "metadata/source_data.json",
             json.dumps(source_data, indent=2, sort_keys=True),
         )
-        for file_path, archive_path in embedded_files:
-            zf.write(file_path, archive_path)
+        if embedded_db is not None:
+            source, member = embedded_db
+            zf.write(source, member)
     return buf.getvalue()
 
 
 def read_session_archive(archive: bytes) -> dict[str, Any]:
-    """Read and validate a datasight session archive."""
+    """Read and validate a datasight session archive without extracting it."""
     with zipfile.ZipFile(BytesIO(archive)) as zf:
         try:
             manifest = json.loads(zf.read("manifest.json"))
-            conversation = json.loads(zf.read("session/conversation.json"))
-            dashboard = json.loads(zf.read("session/dashboard.json"))
-            source_data = json.loads(zf.read("metadata/source_data.json"))
-        except KeyError as err:
-            raise ValueError("Archive is missing required entry: {}".format(err.args[0])) from err
+        except KeyError:
+            raise ValueError("Archive is missing manifest.json.") from None
         except json.JSONDecodeError as err:
-            raise ValueError("Archive JSON is invalid: {}".format(err)) from err
+            raise ValueError(f"Archive manifest.json is invalid: {err}") from err
 
-        if manifest.get("format") != SESSION_ARCHIVE_FORMAT:
+        if manifest.get("format") != ARCHIVE_FORMAT:
             raise ValueError("Not a datasight session archive.")
         version = manifest.get("archive_version")
-        if version != SESSION_ARCHIVE_VERSION:
+        # Archive versions are integers; equal majors are read, greater
+        # majors are rejected with a clear message so future writers can
+        # extend the schema additively without retroactively breaking
+        # older readers.
+        if not isinstance(version, int) or version > ARCHIVE_VERSION:
             raise ValueError(
-                "Unsupported session archive version {!r}. Expected {}.".format(
-                    version, SESSION_ARCHIVE_VERSION
-                )
+                f"Unsupported session archive version {version!r} "
+                f"(this build reads up to version {ARCHIVE_VERSION})."
             )
 
-        if not isinstance(conversation, dict):
-            raise ValueError("Archive conversation payload must be an object.")
-        if not isinstance(dashboard, dict):
-            raise ValueError("Archive dashboard payload must be an object.")
-        if not isinstance(source_data, dict):
-            raise ValueError("Archive source_data payload must be an object.")
+        try:
+            conversation = json.loads(zf.read("session/conversation.json"))
+            source_data = json.loads(zf.read("metadata/source_data.json"))
+        except KeyError as err:
+            raise ValueError(f"Archive is missing required entry: {err.args[0]}") from err
+        except json.JSONDecodeError as err:
+            raise ValueError(f"Archive JSON is invalid: {err}") from err
 
-        session_id = validate_session_archive_id(str(manifest.get("session_id") or ""))
-        conversation["dashboard"] = dashboard
-        return {
-            "manifest": manifest,
-            "session_id": session_id,
-            "conversation": conversation,
-            "dashboard": dashboard,
-            "source_data": source_data,
-        }
+    if not isinstance(conversation, dict):
+        raise ValueError("Archive conversation payload must be an object.")
+    if not isinstance(source_data, dict):
+        raise ValueError("Archive source_data payload must be an object.")
+
+    session_id = validate_session_archive_id(str(manifest.get("session_id") or ""))
+    dashboard = conversation.get("dashboard")
+    if not isinstance(dashboard, dict):
+        dashboard = {}
+    return {
+        "manifest": manifest,
+        "session_id": session_id,
+        "conversation": conversation,
+        "dashboard": dashboard,
+        "source_data": source_data,
+    }
 
 
 def import_session_archive(
@@ -202,74 +234,90 @@ def import_session_archive(
     session_id: str | None = None,
     overwrite: bool = False,
 ) -> dict[str, Any]:
-    """Import a session archive into a datasight project directory."""
+    """Import a session archive into a datasight project directory.
+
+    Writes the conversation file under ``.datasight/conversations/`` and,
+    if the archive embeds a database file, restores it alongside the
+    project. The active project-wide ``.datasight/dashboard.json`` and
+    existing ``.env`` are deliberately left untouched — the per-session
+    dashboard travels inside the conversation JSON, and the web app reads
+    it from there via ``?session_id=...``.
+
+    A minimal ``.env`` is only written when the archive includes data and
+    the project has no ``.env`` yet, so a fresh-project import is
+    immediately runnable.
+    """
+    project_root = Path(project_dir).resolve()
     payload = read_session_archive(archive)
-    imported_session_id = validate_session_archive_id(
+    target_session_id = validate_session_archive_id(
         session_id if session_id is not None else payload["session_id"]
     )
 
-    project_root = Path(project_dir).resolve()
-    datasight_dir = project_root / ".datasight"
-    conversations_dir = datasight_dir / "conversations"
-    conversations_dir.mkdir(parents=True, exist_ok=True)
-
-    conversation_path = conversations_dir / f"{imported_session_id}.json"
+    conversations_dir = project_root / ".datasight" / "conversations"
+    conversation_path = conversations_dir / f"{target_session_id}.json"
     if conversation_path.exists() and not overwrite:
         raise ValueError(
-            "Session {!r} already exists in {}. Pass --overwrite to replace it.".format(
-                imported_session_id, project_root
-            )
+            f"Session {target_session_id!r} already exists in {project_root}. "
+            "Pass --overwrite to replace it."
         )
 
-    conversation = dict(payload["conversation"])
-    dashboard = payload["dashboard"]
-    conversation["dashboard"] = dashboard
-
-    conversation_path.write_text(
-        json.dumps(conversation, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    (datasight_dir / "dashboard.json").write_text(
-        json.dumps(dashboard, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-
-    restored_paths: list[Path] = []
-    source_data = payload["source_data"]
-    database = source_data.get("database") if isinstance(source_data, dict) else None
+    database = payload["source_data"].get("database")
+    restore_plan: tuple[Path, str, str] | None = None
     if isinstance(database, dict) and database.get("embedded"):
-        archive_path = database.get("archive_path")
-        if not isinstance(archive_path, str) or not archive_path:
+        member = database.get("archive_path")
+        if not isinstance(member, str) or not member:
             raise ValueError("Archive metadata for embedded database is incomplete.")
-        restore_rel_path_raw = (
-            database.get("path")
-            if database.get("path_kind") == "relative" and isinstance(database.get("path"), str)
-            else Path(archive_path).name
-        )
-        restore_rel_path = _safe_project_relative_path(str(restore_rel_path_raw))
-        restore_path = project_root / restore_rel_path
-        restore_path.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(BytesIO(archive)) as zf:
-            try:
-                restore_path.write_bytes(zf.read(archive_path))
-            except KeyError as err:
-                raise ValueError(
-                    "Archive is missing embedded data file: {}".format(archive_path)
-                ) from err
-        restored_paths.append(restore_path)
+        mode = str(database.get("mode") or "").strip()
+        if mode not in _FILE_DB_MODES:
+            raise ValueError(f"Cannot restore embedded data for db mode {mode!r}.")
 
-        db_mode = str(database.get("mode") or "").strip()
-        if db_mode in {"duckdb", "sqlite"}:
-            env_path = project_root / ".env"
+        # Pick the restore location. Honor the recorded relative path so a
+        # within-project DB lands at the same place; for absolute or
+        # missing paths, drop it next to the project under the archive
+        # member's basename so the exporter can never dictate an absolute
+        # filesystem location on the importer.
+        recorded = database.get("path") if isinstance(database.get("path"), str) else None
+        if database.get("path_kind") == "relative" and recorded:
+            rel = _safe_relative_member(recorded)
+        else:
+            rel = Path(Path(member).name)
+        target = project_root / rel
+        if target.exists() and not overwrite:
+            raise ValueError(
+                f"Database file {target} already exists. Pass --overwrite to replace it."
+            )
+        restore_plan = (target, member, mode)
+
+    # Only mutate the project once every safety check has passed.
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+    conversation_path.write_text(
+        json.dumps(payload["conversation"], indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    restored_db_path: Path | None = None
+    env_written = False
+    if restore_plan is not None:
+        target, member, mode = restore_plan
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(BytesIO(archive)) as zf:
+            with zf.open(member) as src, target.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+        restored_db_path = target
+
+        env_path = project_root / ".env"
+        if not env_path.exists():
+            rel_db = target.relative_to(project_root).as_posix()
             env_path.write_text(
-                f"DB_MODE={db_mode}\nDB_PATH={restore_rel_path.as_posix()}\n",
+                f"DB_MODE={mode}\nDB_PATH={rel_db}\n",
                 encoding="utf-8",
             )
+            env_written = True
 
     return {
-        "session_id": imported_session_id,
+        "session_id": target_session_id,
         "conversation_path": conversation_path,
-        "dashboard_path": datasight_dir / "dashboard.json",
         "manifest": payload["manifest"],
-        "restored_paths": restored_paths,
+        "restored_db_path": restored_db_path,
+        "env_written": env_written,
     }

--- a/src/datasight/session_archive.py
+++ b/src/datasight/session_archive.py
@@ -6,10 +6,6 @@ A session archive is a zip file with this layout::
     session/conversation.json  # the .datasight/conversations/<id>.json file,
                                # which already embeds the per-session dashboard
                                # under conversation["dashboard"]
-    metadata/source_data.json  # database mode + path the session was authored
-                               # against, plus an "archive_path" pointer if a
-                               # data file was embedded
-    data/<basename>            # only present when --include-data was passed
 
 The on-disk shape of conversations and per-session dashboards is the
 authoritative source of truth (see ``ConversationStore`` and
@@ -18,10 +14,10 @@ files in and out of a zip with a manifest.
 
 Privacy
 -------
-Archives are intended to be shared with collaborators. They deliberately
-do **not** include ``.env`` and never read LLM credentials. Database paths
-that fall outside the project directory are recorded as basenames only so
-the exporter's filesystem layout is not leaked.
+Archives are intended to be shared with collaborators. They never include
+``.env`` and never read LLM credentials. Sharing the underlying database
+is out of scope — wrap the project directory yourself if a recipient
+needs runnable data.
 """
 
 from __future__ import annotations
@@ -30,20 +26,19 @@ import contextlib
 import json
 import os
 import re
-import shutil
 import uuid
 import zipfile
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import IO, Any, ContextManager
+from typing import IO, Any
 
 from datasight import __version__
 
 ARCHIVE_FORMAT = "datasight-session-archive"
 ARCHIVE_VERSION = 1
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-_FILE_DB_MODES = frozenset({"duckdb", "sqlite"})
 
 # Backwards-compatible aliases for callers/tests that import the older names.
 SESSION_ARCHIVE_FORMAT = ARCHIVE_FORMAT
@@ -64,81 +59,7 @@ def validate_session_archive_id(session_id: str) -> str:
     return session_id
 
 
-def _safe_relative_member(name: str) -> Path:
-    """Reject absolute paths or anything that escapes via ``..``."""
-    candidate = Path(name)
-    if candidate.is_absolute():
-        msg = f"Archive restore path must be relative: {name!r}"
-        raise ValueError(msg)
-    parts: list[str] = []
-    for part in candidate.parts:
-        if part in ("", "."):
-            continue
-        if part == "..":
-            msg = f"Archive restore path cannot traverse upward: {name!r}"
-            raise ValueError(msg)
-        parts.append(part)
-    if not parts:
-        msg = f"Archive restore path is empty: {name!r}"
-        raise ValueError(msg)
-    return Path(*parts)
-
-
-def _ensure_within_project(target: Path, project_root: Path) -> None:
-    """Refuse to write to a path that resolves outside ``project_root``.
-
-    ``target`` may not exist yet; resolve it relative to a real ancestor so
-    a parent symlink that escapes the project tree still gets caught.
-    """
-    probe = target
-    while not probe.exists() and probe != probe.parent:
-        probe = probe.parent
-    resolved_anchor = probe.resolve()
-    resolved_target = resolved_anchor / target.relative_to(probe)
-    if not resolved_target.is_relative_to(project_root.resolve()):
-        msg = f"Archive restore path escapes the project directory: {target}"
-        raise ValueError(msg)
-
-
-def _resolve_db_source(db_path: str, project_root: Path) -> Path:
-    candidate = Path(db_path)
-    if not candidate.is_absolute():
-        candidate = project_root / candidate
-    return candidate.resolve()
-
-
-def _archive_db_reference(
-    db_mode: str,
-    db_path: str,
-    project_root: Path,
-) -> dict[str, Any] | None:
-    mode = (db_mode or "").strip()
-    if not mode:
-        return None
-    ref: dict[str, Any] = {"mode": mode, "embedded": False}
-    raw = (db_path or "").strip()
-    if not raw:
-        return ref
-    target = _resolve_db_source(raw, project_root)
-    try:
-        rel = target.relative_to(project_root)
-        ref["path"] = rel.as_posix()
-        ref["path_kind"] = "relative"
-    except ValueError:
-        # Don't leak the exporter's absolute filesystem layout. Record
-        # only the basename so the importer can still pick a sensible
-        # destination without learning where the source lived.
-        ref["path"] = target.name
-        ref["path_kind"] = "external"
-    return ref
-
-
-def _build_manifest(
-    *,
-    session_id: str,
-    title: str,
-    includes_data: bool,
-) -> dict[str, Any]:
+def _build_manifest(*, session_id: str, title: str) -> dict[str, Any]:
     return {
         "format": ARCHIVE_FORMAT,
         "archive_version": ARCHIVE_VERSION,
@@ -146,7 +67,6 @@ def _build_manifest(
         "exported_at": datetime.now(timezone.utc).isoformat(),
         "session_id": session_id,
         "title": title,
-        "includes_data": includes_data,
     }
 
 
@@ -156,44 +76,16 @@ def _write_archive_to(
     session_id: str,
     conversation: dict[str, Any],
     dashboard: dict[str, Any] | None,
-    project_dir: str,
-    db_mode: str,
-    db_path: str,
-    include_data: bool,
 ) -> None:
     validate_session_archive_id(session_id)
-    project_root = Path(project_dir).resolve()
 
     payload = dict(conversation)
     if dashboard is not None:
         payload["dashboard"] = dashboard
 
-    db_ref = _archive_db_reference(db_mode, db_path, project_root)
-    embedded_db: tuple[Path, str] | None = None
-    if include_data:
-        if db_ref is None or db_ref.get("mode") not in _FILE_DB_MODES:
-            msg = "--include-data is only supported for DuckDB and SQLite projects."
-            raise ValueError(msg)
-        if not (db_path or "").strip():
-            msg = "--include-data requires a configured database path."
-            raise ValueError(msg)
-        source = _resolve_db_source(db_path, project_root)
-        if not source.is_file():
-            msg = f"Database file not found for --include-data: {source}"
-            raise ValueError(msg)
-        member = f"data/{source.name}"
-        db_ref["embedded"] = True
-        db_ref["archive_path"] = member
-        embedded_db = (source, member)
-
-    source_data: dict[str, Any] = {}
-    if db_ref is not None:
-        source_data["database"] = db_ref
-
     manifest = _build_manifest(
         session_id=session_id,
         title=str(payload.get("title", "Untitled")),
-        includes_data=embedded_db is not None,
     )
 
     with zipfile.ZipFile(sink, "w", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -202,14 +94,6 @@ def _write_archive_to(
             "session/conversation.json",
             json.dumps(payload, indent=2, sort_keys=True),
         )
-        zf.writestr(
-            "metadata/source_data.json",
-            json.dumps(source_data, indent=2, sort_keys=True),
-        )
-        if embedded_db is not None:
-            source, member = embedded_db
-            # zf.write streams the file from disk; no full buffer in memory.
-            zf.write(source, member)
 
 
 def build_session_archive(
@@ -217,17 +101,12 @@ def build_session_archive(
     session_id: str,
     conversation: dict[str, Any],
     dashboard: dict[str, Any] | None = None,
-    project_dir: str,
-    db_mode: str = "",
-    db_path: str = "",
-    include_data: bool = False,
 ) -> bytes:
     """Build a portable zip archive for a saved datasight session.
 
     Buffers the archive in memory and returns its bytes — convenient for
-    callers that don't have an output path. For ``--include-data`` exports
-    of large databases prefer :func:`write_session_archive`, which streams
-    directly to disk and avoids materializing the whole archive in RAM.
+    callers that don't have an output path. Use
+    :func:`write_session_archive` when streaming straight to disk.
     """
     buf = BytesIO()
     _write_archive_to(
@@ -235,10 +114,6 @@ def build_session_archive(
         session_id=session_id,
         conversation=conversation,
         dashboard=dashboard,
-        project_dir=project_dir,
-        db_mode=db_mode,
-        db_path=db_path,
-        include_data=include_data,
     )
     return buf.getvalue()
 
@@ -249,10 +124,6 @@ def write_session_archive(
     session_id: str,
     conversation: dict[str, Any],
     dashboard: dict[str, Any] | None = None,
-    project_dir: str,
-    db_mode: str = "",
-    db_path: str = "",
-    include_data: bool = False,
 ) -> Path:
     """Stream a session archive to ``output``.
 
@@ -270,10 +141,6 @@ def write_session_archive(
                 session_id=session_id,
                 conversation=conversation,
                 dashboard=dashboard,
-                project_dir=project_dir,
-                db_mode=db_mode,
-                db_path=db_path,
-                include_data=include_data,
             )
         os.replace(tmp_path, final_path)
     except BaseException:
@@ -283,33 +150,26 @@ def write_session_archive(
     return final_path
 
 
-def _open_archive(archive: ArchiveSource) -> ContextManager[zipfile.ZipFile]:
-    """Return a ZipFile context manager for ``archive`` (bytes or path).
+@contextlib.contextmanager
+def _open_archive(archive: ArchiveSource) -> Iterator[zipfile.ZipFile]:
+    """Open ``archive`` (bytes or path) as a ``ZipFile``.
 
-    Path-based archives stream from disk; bytes-based archives wrap
-    in BytesIO. ``BadZipFile`` is normalized to ``ValueError`` so the
-    CLI surfaces a clean error.
+    ``BadZipFile`` is normalized to ``ValueError`` so the CLI surfaces
+    a clean error.
     """
-
-    @contextlib.contextmanager
-    def _opener():  # type: ignore[no-untyped-def]
-        try:
-            if isinstance(archive, (bytes, bytearray)):
-                with zipfile.ZipFile(BytesIO(archive), "r") as zf:
-                    yield zf
-            else:
-                with zipfile.ZipFile(os.fspath(archive), "r") as zf:
-                    yield zf
-        except zipfile.BadZipFile as err:
-            msg = f"Not a valid zip archive: {err}"
-            raise ValueError(msg) from err
-
-    return _opener()
+    try:
+        if isinstance(archive, (bytes, bytearray)):
+            with zipfile.ZipFile(BytesIO(archive), "r") as zf:
+                yield zf
+        else:
+            with zipfile.ZipFile(os.fspath(archive), "r") as zf:
+                yield zf
+    except zipfile.BadZipFile as err:
+        msg = f"Not a valid zip archive: {err}"
+        raise ValueError(msg) from err
 
 
-def _read_manifest_payload(
-    zf: zipfile.ZipFile,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+def _read_manifest_payload(zf: zipfile.ZipFile) -> tuple[dict[str, Any], dict[str, Any]]:
     try:
         manifest = json.loads(zf.read("manifest.json"))
     except KeyError:
@@ -338,7 +198,6 @@ def _read_manifest_payload(
 
     try:
         conversation = json.loads(zf.read("session/conversation.json"))
-        source_data = json.loads(zf.read("metadata/source_data.json"))
     except KeyError as err:
         missing = err.args[0] if err.args else "archive entry"
         msg = f"Archive is missing required entry: {missing}"
@@ -350,11 +209,8 @@ def _read_manifest_payload(
     if not isinstance(conversation, dict):
         msg = "Archive conversation payload must be an object."
         raise ValueError(msg)
-    if not isinstance(source_data, dict):
-        msg = "Archive source_data payload must be an object."
-        raise ValueError(msg)
 
-    return manifest, conversation, source_data
+    return manifest, conversation
 
 
 def read_session_archive(archive: ArchiveSource) -> dict[str, Any]:
@@ -363,7 +219,7 @@ def read_session_archive(archive: ArchiveSource) -> dict[str, Any]:
     ``archive`` may be raw bytes or a path; path inputs stream from disk.
     """
     with _open_archive(archive) as zf:
-        manifest, conversation, source_data = _read_manifest_payload(zf)
+        manifest, conversation = _read_manifest_payload(zf)
 
     session_id = validate_session_archive_id(str(manifest.get("session_id") or ""))
     dashboard = conversation.get("dashboard")
@@ -374,40 +230,7 @@ def read_session_archive(archive: ArchiveSource) -> dict[str, Any]:
         "session_id": session_id,
         "conversation": conversation,
         "dashboard": dashboard,
-        "source_data": source_data,
     }
-
-
-def _plan_db_restore(
-    database: dict[str, Any],
-    project_root: Path,
-    *,
-    overwrite: bool,
-) -> tuple[Path, str, str]:
-    member = database.get("archive_path")
-    if not isinstance(member, str) or not member:
-        msg = "Archive metadata for embedded database is incomplete."
-        raise ValueError(msg)
-    mode = str(database.get("mode") or "").strip()
-    if mode not in _FILE_DB_MODES:
-        msg = f"Cannot restore embedded data for db mode {mode!r}."
-        raise ValueError(msg)
-
-    # Honor the recorded relative path so a within-project DB lands at
-    # the same place; for "external" or missing paths, drop the file
-    # next to the project under the archive member's basename so the
-    # exporter can never dictate an absolute layout on the importer.
-    recorded = database.get("path") if isinstance(database.get("path"), str) else None
-    if database.get("path_kind") == "relative" and recorded:
-        rel = _safe_relative_member(recorded)
-    else:
-        rel = Path(Path(member).name)
-    target = project_root / rel
-    _ensure_within_project(target, project_root)
-    if target.exists() and not overwrite:
-        msg = f"Database file {target} already exists. Pass --overwrite to replace it."
-        raise ValueError(msg)
-    return target, member, mode
 
 
 def import_session_archive(
@@ -419,105 +242,38 @@ def import_session_archive(
 ) -> dict[str, Any]:
     """Import a session archive into a datasight project directory.
 
-    Writes the conversation file under ``.datasight/conversations/`` and,
-    if the archive embeds a database file, restores it alongside the
-    project. The active project-wide ``.datasight/dashboard.json`` and
-    existing ``.env`` are deliberately left untouched — the per-session
-    dashboard travels inside the conversation JSON, and the web app reads
-    it from there via ``?session_id=...``.
-
-    A minimal ``.env`` is only written when the archive includes data and
-    the project has no ``.env`` yet, so a fresh-project import is
-    immediately runnable.
-
-    The import is staged via ``.part-<rand>`` files and renamed into
-    place on success, so a failure mid-extraction does not leave a
-    half-imported session on disk.
+    Writes ``.datasight/conversations/<session_id>.json``. The
+    project-wide ``.datasight/dashboard.json`` and any existing ``.env``
+    are deliberately left untouched — the per-session dashboard travels
+    inside the conversation JSON, and the web app reads it from there
+    via ``?session_id=...``.
     """
     project_root = Path(project_dir).resolve()
 
     with _open_archive(archive) as zf:
-        manifest, conversation, source_data = _read_manifest_payload(zf)
+        manifest, conversation = _read_manifest_payload(zf)
 
-        target_session_id = validate_session_archive_id(
-            session_id if session_id is not None else str(manifest.get("session_id") or "")
+    target_session_id = validate_session_archive_id(
+        session_id if session_id is not None else str(manifest.get("session_id") or "")
+    )
+
+    conversations_dir = project_root / ".datasight" / "conversations"
+    conversation_path = conversations_dir / f"{target_session_id}.json"
+    if conversation_path.exists() and not overwrite:
+        msg = (
+            f"Session {target_session_id!r} already exists in {project_root}. "
+            "Pass --overwrite to replace it."
         )
+        raise ValueError(msg)
 
-        conversations_dir = project_root / ".datasight" / "conversations"
-        conversation_path = conversations_dir / f"{target_session_id}.json"
-        if conversation_path.exists() and not overwrite:
-            msg = (
-                f"Session {target_session_id!r} already exists in {project_root}. "
-                "Pass --overwrite to replace it."
-            )
-            raise ValueError(msg)
-
-        database = source_data.get("database")
-        restore_plan: tuple[Path, str, str] | None = None
-        if isinstance(database, dict) and database.get("embedded"):
-            restore_plan = _plan_db_restore(database, project_root, overwrite=overwrite)
-            # Fail fast if the metadata points at a member that's not
-            # actually in the zip — better than crashing mid-extract.
-            try:
-                zf.getinfo(restore_plan[1])
-            except KeyError as err:
-                msg = f"Archive is missing embedded data file: {restore_plan[1]}"
-                raise ValueError(msg) from err
-
-        conversations_dir.mkdir(parents=True, exist_ok=True)
-        suffix = f".part-{uuid.uuid4().hex[:8]}"
-        conv_tmp = conversation_path.with_name(conversation_path.name + suffix)
-
-        db_tmp: Path | None = None
-        if restore_plan is not None:
-            target, _, _ = restore_plan
-            target.parent.mkdir(parents=True, exist_ok=True)
-            db_tmp = target.with_name(target.name + suffix)
-
-        try:
-            # Stage: write both files to .part siblings.
-            conv_tmp.write_text(
-                json.dumps(conversation, indent=2, sort_keys=True),
-                encoding="utf-8",
-            )
-            if restore_plan is not None and db_tmp is not None:
-                _, member, _ = restore_plan
-                with zf.open(member) as src, db_tmp.open("wb") as dst:
-                    shutil.copyfileobj(src, dst)
-
-            # Commit: atomic renames. DB first so the conversation only
-            # appears once its referenced data is in place.
-            if restore_plan is not None and db_tmp is not None:
-                target, _, _ = restore_plan
-                os.replace(db_tmp, target)
-                db_tmp = None
-            os.replace(conv_tmp, conversation_path)
-        except BaseException:
-            for tmp in (conv_tmp, db_tmp):
-                if tmp is None:
-                    continue
-                with contextlib.suppress(FileNotFoundError):
-                    tmp.unlink()
-            raise
-
-    restored_db_path: Path | None = None
-    env_written = False
-    if restore_plan is not None:
-        target, _, mode = restore_plan
-        restored_db_path = target
-        env_path = project_root / ".env"
-        if not env_path.exists():
-            rel_db = target.relative_to(project_root).as_posix()
-            env_path.write_text(
-                f"DB_MODE={mode}\nDB_PATH={rel_db}\n",
-                encoding="utf-8",
-            )
-            env_written = True
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+    conversation_path.write_text(
+        json.dumps(conversation, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
 
     return {
         "session_id": target_session_id,
         "conversation_path": conversation_path,
         "manifest": manifest,
-        "restored_db_path": restored_db_path,
-        "env_written": env_written,
     }

--- a/src/datasight/session_archive.py
+++ b/src/datasight/session_archive.py
@@ -20,7 +20,7 @@ _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 def validate_session_archive_id(session_id: str) -> str:
     """Validate a session ID used in archive export/import."""
     if not _SESSION_ID_RE.match(session_id) or len(session_id) > 128:
-        raise ValueError(f"Invalid session ID: {session_id!r}")
+        raise ValueError("Invalid session ID: {!r}".format(session_id))
     return session_id
 
 
@@ -56,18 +56,18 @@ def _resolve_db_file_path(path: str, project_dir: str) -> Path:
 def _safe_project_relative_path(path: str) -> Path:
     candidate = Path(str(path))
     if candidate.is_absolute():
-        raise ValueError(f"Archive restore path must be relative: {path!r}")
+        raise ValueError("Archive restore path must be relative: {!r}".format(path))
 
     clean_parts: list[str] = []
     for part in candidate.parts:
         if part in ("", "."):
             continue
         if part == "..":
-            raise ValueError(f"Archive restore path cannot traverse upward: {path!r}")
+            raise ValueError("Archive restore path cannot traverse upward: {!r}".format(path))
         clean_parts.append(part)
 
     if not clean_parts:
-        raise ValueError(f"Archive restore path is empty: {path!r}")
+        raise ValueError("Archive restore path is empty: {!r}".format(path))
     return Path(*clean_parts)
 
 
@@ -103,7 +103,9 @@ def build_session_archive(
                 )
             resolved_db_path = _resolve_db_file_path(db_path, project_dir)
             if not resolved_db_path.exists() or not resolved_db_path.is_file():
-                raise ValueError(f"Database file not found for --include-data: {resolved_db_path}")
+                raise ValueError(
+                    "Database file not found for --include-data: {}".format(resolved_db_path)
+                )
             archive_name = (
                 path_ref["path"]
                 if path_ref and path_ref.get("path_kind") == "relative"
@@ -161,17 +163,18 @@ def read_session_archive(archive: bytes) -> dict[str, Any]:
             dashboard = json.loads(zf.read("session/dashboard.json"))
             source_data = json.loads(zf.read("metadata/source_data.json"))
         except KeyError as err:
-            raise ValueError(f"Archive is missing required entry: {err.args[0]}") from err
+            raise ValueError("Archive is missing required entry: {}".format(err.args[0])) from err
         except json.JSONDecodeError as err:
-            raise ValueError(f"Archive JSON is invalid: {err}") from err
+            raise ValueError("Archive JSON is invalid: {}".format(err)) from err
 
         if manifest.get("format") != SESSION_ARCHIVE_FORMAT:
             raise ValueError("Not a datasight session archive.")
         version = manifest.get("archive_version")
         if version != SESSION_ARCHIVE_VERSION:
             raise ValueError(
-                f"Unsupported session archive version {version!r}. "
-                f"Expected {SESSION_ARCHIVE_VERSION}."
+                "Unsupported session archive version {!r}. Expected {}.".format(
+                    version, SESSION_ARCHIVE_VERSION
+                )
             )
 
         if not isinstance(conversation, dict):
@@ -213,8 +216,9 @@ def import_session_archive(
     conversation_path = conversations_dir / f"{imported_session_id}.json"
     if conversation_path.exists() and not overwrite:
         raise ValueError(
-            f"Session {imported_session_id!r} already exists in {project_root}. "
-            "Pass --overwrite to replace it."
+            "Session {!r} already exists in {}. Pass --overwrite to replace it.".format(
+                imported_session_id, project_root
+            )
         )
 
     conversation = dict(payload["conversation"])
@@ -249,7 +253,9 @@ def import_session_archive(
             try:
                 restore_path.write_bytes(zf.read(archive_path))
             except KeyError as err:
-                raise ValueError(f"Archive is missing embedded data file: {archive_path}") from err
+                raise ValueError(
+                    "Archive is missing embedded data file: {}".format(archive_path)
+                ) from err
         restored_paths.append(restore_path)
 
         db_mode = str(database.get("mode") or "").strip()

--- a/src/datasight/session_archive.py
+++ b/src/datasight/session_archive.py
@@ -26,14 +26,17 @@ the exporter's filesystem layout is not leaked.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import re
 import shutil
+import uuid
 import zipfile
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import IO, Any, ContextManager
 
 from datasight import __version__
 
@@ -46,6 +49,8 @@ _FILE_DB_MODES = frozenset({"duckdb", "sqlite"})
 SESSION_ARCHIVE_FORMAT = ARCHIVE_FORMAT
 SESSION_ARCHIVE_VERSION = ARCHIVE_VERSION
 
+ArchiveSource = bytes | bytearray | str | os.PathLike[str]
+
 
 def validate_session_archive_id(session_id: str) -> str:
     """Validate a session ID for archive export/import.
@@ -54,7 +59,8 @@ def validate_session_archive_id(session_id: str) -> str:
     archives can round-trip in and out of the web app's conversation store.
     """
     if not _SESSION_ID_RE.match(session_id) or len(session_id) > 128:
-        raise ValueError(f"Invalid session ID: {session_id!r}")
+        msg = f"Invalid session ID: {session_id!r}"
+        raise ValueError(msg)
     return session_id
 
 
@@ -62,17 +68,36 @@ def _safe_relative_member(name: str) -> Path:
     """Reject absolute paths or anything that escapes via ``..``."""
     candidate = Path(name)
     if candidate.is_absolute():
-        raise ValueError(f"Archive restore path must be relative: {name!r}")
+        msg = f"Archive restore path must be relative: {name!r}"
+        raise ValueError(msg)
     parts: list[str] = []
     for part in candidate.parts:
         if part in ("", "."):
             continue
         if part == "..":
-            raise ValueError(f"Archive restore path cannot traverse upward: {name!r}")
+            msg = f"Archive restore path cannot traverse upward: {name!r}"
+            raise ValueError(msg)
         parts.append(part)
     if not parts:
-        raise ValueError(f"Archive restore path is empty: {name!r}")
+        msg = f"Archive restore path is empty: {name!r}"
+        raise ValueError(msg)
     return Path(*parts)
+
+
+def _ensure_within_project(target: Path, project_root: Path) -> None:
+    """Refuse to write to a path that resolves outside ``project_root``.
+
+    ``target`` may not exist yet; resolve it relative to a real ancestor so
+    a parent symlink that escapes the project tree still gets caught.
+    """
+    probe = target
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    resolved_anchor = probe.resolve()
+    resolved_target = resolved_anchor / target.relative_to(probe)
+    if not resolved_target.is_relative_to(project_root.resolve()):
+        msg = f"Archive restore path escapes the project directory: {target}"
+        raise ValueError(msg)
 
 
 def _resolve_db_source(db_path: str, project_root: Path) -> Path:
@@ -108,6 +133,85 @@ def _archive_db_reference(
     return ref
 
 
+def _build_manifest(
+    *,
+    session_id: str,
+    title: str,
+    includes_data: bool,
+) -> dict[str, Any]:
+    return {
+        "format": ARCHIVE_FORMAT,
+        "archive_version": ARCHIVE_VERSION,
+        "datasight_version": __version__,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "title": title,
+        "includes_data": includes_data,
+    }
+
+
+def _write_archive_to(
+    sink: IO[bytes],
+    *,
+    session_id: str,
+    conversation: dict[str, Any],
+    dashboard: dict[str, Any] | None,
+    project_dir: str,
+    db_mode: str,
+    db_path: str,
+    include_data: bool,
+) -> None:
+    validate_session_archive_id(session_id)
+    project_root = Path(project_dir).resolve()
+
+    payload = dict(conversation)
+    if dashboard is not None:
+        payload["dashboard"] = dashboard
+
+    db_ref = _archive_db_reference(db_mode, db_path, project_root)
+    embedded_db: tuple[Path, str] | None = None
+    if include_data:
+        if db_ref is None or db_ref.get("mode") not in _FILE_DB_MODES:
+            msg = "--include-data is only supported for DuckDB and SQLite projects."
+            raise ValueError(msg)
+        if not (db_path or "").strip():
+            msg = "--include-data requires a configured database path."
+            raise ValueError(msg)
+        source = _resolve_db_source(db_path, project_root)
+        if not source.is_file():
+            msg = f"Database file not found for --include-data: {source}"
+            raise ValueError(msg)
+        member = f"data/{source.name}"
+        db_ref["embedded"] = True
+        db_ref["archive_path"] = member
+        embedded_db = (source, member)
+
+    source_data: dict[str, Any] = {}
+    if db_ref is not None:
+        source_data["database"] = db_ref
+
+    manifest = _build_manifest(
+        session_id=session_id,
+        title=str(payload.get("title", "Untitled")),
+        includes_data=embedded_db is not None,
+    )
+
+    with zipfile.ZipFile(sink, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+        zf.writestr(
+            "session/conversation.json",
+            json.dumps(payload, indent=2, sort_keys=True),
+        )
+        zf.writestr(
+            "metadata/source_data.json",
+            json.dumps(source_data, indent=2, sort_keys=True),
+        )
+        if embedded_db is not None:
+            source, member = embedded_db
+            # zf.write streams the file from disk; no full buffer in memory.
+            zf.write(source, member)
+
+
 def build_session_archive(
     *,
     session_id: str,
@@ -120,99 +224,146 @@ def build_session_archive(
 ) -> bytes:
     """Build a portable zip archive for a saved datasight session.
 
-    ``conversation`` is the on-disk conversation JSON, which already
-    embeds the per-session dashboard under ``conversation["dashboard"]``.
-    ``dashboard`` is an optional override for callers that want to attach
-    a dashboard explicitly.
+    Buffers the archive in memory and returns its bytes — convenient for
+    callers that don't have an output path. For ``--include-data`` exports
+    of large databases prefer :func:`write_session_archive`, which streams
+    directly to disk and avoids materializing the whole archive in RAM.
     """
-    validate_session_archive_id(session_id)
-    project_root = Path(project_dir).resolve()
-
-    payload = dict(conversation)
-    if dashboard is not None:
-        payload["dashboard"] = dashboard
-
-    db_ref = _archive_db_reference(db_mode, db_path, project_root)
-    embedded_db: tuple[Path, str] | None = None
-    if include_data:
-        if db_ref is None or db_ref.get("mode") not in _FILE_DB_MODES:
-            raise ValueError("--include-data is only supported for DuckDB and SQLite projects.")
-        if not (db_path or "").strip():
-            raise ValueError("--include-data requires a configured database path.")
-        source = _resolve_db_source(db_path, project_root)
-        if not source.is_file():
-            raise ValueError(f"Database file not found for --include-data: {source}")
-        member = f"data/{source.name}"
-        db_ref["embedded"] = True
-        db_ref["archive_path"] = member
-        embedded_db = (source, member)
-
-    source_data: dict[str, Any] = {}
-    if db_ref is not None:
-        source_data["database"] = db_ref
-
-    manifest = {
-        "format": ARCHIVE_FORMAT,
-        "archive_version": ARCHIVE_VERSION,
-        "datasight_version": __version__,
-        "exported_at": datetime.now(timezone.utc).isoformat(),
-        "session_id": session_id,
-        "title": payload.get("title", "Untitled"),
-        "includes_data": embedded_db is not None,
-    }
-
     buf = BytesIO()
-    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
-        zf.writestr(
-            "session/conversation.json",
-            json.dumps(payload, indent=2, sort_keys=True),
-        )
-        zf.writestr(
-            "metadata/source_data.json",
-            json.dumps(source_data, indent=2, sort_keys=True),
-        )
-        if embedded_db is not None:
-            source, member = embedded_db
-            zf.write(source, member)
+    _write_archive_to(
+        buf,
+        session_id=session_id,
+        conversation=conversation,
+        dashboard=dashboard,
+        project_dir=project_dir,
+        db_mode=db_mode,
+        db_path=db_path,
+        include_data=include_data,
+    )
     return buf.getvalue()
 
 
-def read_session_archive(archive: bytes) -> dict[str, Any]:
-    """Read and validate a datasight session archive without extracting it."""
-    with zipfile.ZipFile(BytesIO(archive)) as zf:
-        try:
-            manifest = json.loads(zf.read("manifest.json"))
-        except KeyError:
-            raise ValueError("Archive is missing manifest.json.") from None
-        except json.JSONDecodeError as err:
-            raise ValueError(f"Archive manifest.json is invalid: {err}") from err
+def write_session_archive(
+    *,
+    output: str | os.PathLike[str],
+    session_id: str,
+    conversation: dict[str, Any],
+    dashboard: dict[str, Any] | None = None,
+    project_dir: str,
+    db_mode: str = "",
+    db_path: str = "",
+    include_data: bool = False,
+) -> Path:
+    """Stream a session archive to ``output``.
 
-        if manifest.get("format") != ARCHIVE_FORMAT:
-            raise ValueError("Not a datasight session archive.")
-        version = manifest.get("archive_version")
-        # Archive versions are integers; equal majors are read, greater
-        # majors are rejected with a clear message so future writers can
-        # extend the schema additively without retroactively breaking
-        # older readers.
-        if not isinstance(version, int) or version > ARCHIVE_VERSION:
-            raise ValueError(
-                f"Unsupported session archive version {version!r} "
-                f"(this build reads up to version {ARCHIVE_VERSION})."
+    Writes to a sibling ``.part-<rand>`` file and renames into place on
+    success so a partial archive doesn't leave a misleading file behind
+    on failure. Returns the final path.
+    """
+    final_path = Path(output)
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = final_path.with_name(f"{final_path.name}.part-{uuid.uuid4().hex[:8]}")
+    try:
+        with tmp_path.open("wb") as fh:
+            _write_archive_to(
+                fh,
+                session_id=session_id,
+                conversation=conversation,
+                dashboard=dashboard,
+                project_dir=project_dir,
+                db_mode=db_mode,
+                db_path=db_path,
+                include_data=include_data,
             )
+        os.replace(tmp_path, final_path)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise
+    return final_path
 
+
+def _open_archive(archive: ArchiveSource) -> ContextManager[zipfile.ZipFile]:
+    """Return a ZipFile context manager for ``archive`` (bytes or path).
+
+    Path-based archives stream from disk; bytes-based archives wrap
+    in BytesIO. ``BadZipFile`` is normalized to ``ValueError`` so the
+    CLI surfaces a clean error.
+    """
+
+    @contextlib.contextmanager
+    def _opener():  # type: ignore[no-untyped-def]
         try:
-            conversation = json.loads(zf.read("session/conversation.json"))
-            source_data = json.loads(zf.read("metadata/source_data.json"))
-        except KeyError as err:
-            raise ValueError(f"Archive is missing required entry: {err.args[0]}") from err
-        except json.JSONDecodeError as err:
-            raise ValueError(f"Archive JSON is invalid: {err}") from err
+            if isinstance(archive, (bytes, bytearray)):
+                with zipfile.ZipFile(BytesIO(archive), "r") as zf:
+                    yield zf
+            else:
+                with zipfile.ZipFile(os.fspath(archive), "r") as zf:
+                    yield zf
+        except zipfile.BadZipFile as err:
+            msg = f"Not a valid zip archive: {err}"
+            raise ValueError(msg) from err
+
+    return _opener()
+
+
+def _read_manifest_payload(
+    zf: zipfile.ZipFile,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    try:
+        manifest = json.loads(zf.read("manifest.json"))
+    except KeyError:
+        msg = "Archive is missing manifest.json."
+        raise ValueError(msg) from None
+    except json.JSONDecodeError as err:
+        msg = f"Archive manifest.json is invalid: {err}"
+        raise ValueError(msg) from err
+
+    if not isinstance(manifest, dict):
+        msg = "Archive manifest.json must be a JSON object."
+        raise ValueError(msg)
+    if manifest.get("format") != ARCHIVE_FORMAT:
+        msg = "Not a datasight session archive."
+        raise ValueError(msg)
+    version = manifest.get("archive_version")
+    # Same-major archives are read; greater majors are rejected so future
+    # writers can extend the schema additively without breaking older
+    # readers retroactively.
+    if not isinstance(version, int) or version > ARCHIVE_VERSION:
+        msg = (
+            f"Unsupported session archive version {version!r} "
+            f"(this build reads up to version {ARCHIVE_VERSION})."
+        )
+        raise ValueError(msg)
+
+    try:
+        conversation = json.loads(zf.read("session/conversation.json"))
+        source_data = json.loads(zf.read("metadata/source_data.json"))
+    except KeyError as err:
+        missing = err.args[0] if err.args else "archive entry"
+        msg = f"Archive is missing required entry: {missing}"
+        raise ValueError(msg) from err
+    except json.JSONDecodeError as err:
+        msg = f"Archive JSON is invalid: {err}"
+        raise ValueError(msg) from err
 
     if not isinstance(conversation, dict):
-        raise ValueError("Archive conversation payload must be an object.")
+        msg = "Archive conversation payload must be an object."
+        raise ValueError(msg)
     if not isinstance(source_data, dict):
-        raise ValueError("Archive source_data payload must be an object.")
+        msg = "Archive source_data payload must be an object."
+        raise ValueError(msg)
+
+    return manifest, conversation, source_data
+
+
+def read_session_archive(archive: ArchiveSource) -> dict[str, Any]:
+    """Read and validate a datasight session archive without extracting it.
+
+    ``archive`` may be raw bytes or a path; path inputs stream from disk.
+    """
+    with _open_archive(archive) as zf:
+        manifest, conversation, source_data = _read_manifest_payload(zf)
 
     session_id = validate_session_archive_id(str(manifest.get("session_id") or ""))
     dashboard = conversation.get("dashboard")
@@ -227,9 +378,41 @@ def read_session_archive(archive: bytes) -> dict[str, Any]:
     }
 
 
+def _plan_db_restore(
+    database: dict[str, Any],
+    project_root: Path,
+    *,
+    overwrite: bool,
+) -> tuple[Path, str, str]:
+    member = database.get("archive_path")
+    if not isinstance(member, str) or not member:
+        msg = "Archive metadata for embedded database is incomplete."
+        raise ValueError(msg)
+    mode = str(database.get("mode") or "").strip()
+    if mode not in _FILE_DB_MODES:
+        msg = f"Cannot restore embedded data for db mode {mode!r}."
+        raise ValueError(msg)
+
+    # Honor the recorded relative path so a within-project DB lands at
+    # the same place; for "external" or missing paths, drop the file
+    # next to the project under the archive member's basename so the
+    # exporter can never dictate an absolute layout on the importer.
+    recorded = database.get("path") if isinstance(database.get("path"), str) else None
+    if database.get("path_kind") == "relative" and recorded:
+        rel = _safe_relative_member(recorded)
+    else:
+        rel = Path(Path(member).name)
+    target = project_root / rel
+    _ensure_within_project(target, project_root)
+    if target.exists() and not overwrite:
+        msg = f"Database file {target} already exists. Pass --overwrite to replace it."
+        raise ValueError(msg)
+    return target, member, mode
+
+
 def import_session_archive(
     *,
-    archive: bytes,
+    archive: ArchiveSource,
     project_dir: str,
     session_id: str | None = None,
     overwrite: bool = False,
@@ -246,65 +429,82 @@ def import_session_archive(
     A minimal ``.env`` is only written when the archive includes data and
     the project has no ``.env`` yet, so a fresh-project import is
     immediately runnable.
+
+    The import is staged via ``.part-<rand>`` files and renamed into
+    place on success, so a failure mid-extraction does not leave a
+    half-imported session on disk.
     """
     project_root = Path(project_dir).resolve()
-    payload = read_session_archive(archive)
-    target_session_id = validate_session_archive_id(
-        session_id if session_id is not None else payload["session_id"]
-    )
 
-    conversations_dir = project_root / ".datasight" / "conversations"
-    conversation_path = conversations_dir / f"{target_session_id}.json"
-    if conversation_path.exists() and not overwrite:
-        raise ValueError(
-            f"Session {target_session_id!r} already exists in {project_root}. "
-            "Pass --overwrite to replace it."
+    with _open_archive(archive) as zf:
+        manifest, conversation, source_data = _read_manifest_payload(zf)
+
+        target_session_id = validate_session_archive_id(
+            session_id if session_id is not None else str(manifest.get("session_id") or "")
         )
 
-    database = payload["source_data"].get("database")
-    restore_plan: tuple[Path, str, str] | None = None
-    if isinstance(database, dict) and database.get("embedded"):
-        member = database.get("archive_path")
-        if not isinstance(member, str) or not member:
-            raise ValueError("Archive metadata for embedded database is incomplete.")
-        mode = str(database.get("mode") or "").strip()
-        if mode not in _FILE_DB_MODES:
-            raise ValueError(f"Cannot restore embedded data for db mode {mode!r}.")
-
-        # Pick the restore location. Honor the recorded relative path so a
-        # within-project DB lands at the same place; for absolute or
-        # missing paths, drop it next to the project under the archive
-        # member's basename so the exporter can never dictate an absolute
-        # filesystem location on the importer.
-        recorded = database.get("path") if isinstance(database.get("path"), str) else None
-        if database.get("path_kind") == "relative" and recorded:
-            rel = _safe_relative_member(recorded)
-        else:
-            rel = Path(Path(member).name)
-        target = project_root / rel
-        if target.exists() and not overwrite:
-            raise ValueError(
-                f"Database file {target} already exists. Pass --overwrite to replace it."
+        conversations_dir = project_root / ".datasight" / "conversations"
+        conversation_path = conversations_dir / f"{target_session_id}.json"
+        if conversation_path.exists() and not overwrite:
+            msg = (
+                f"Session {target_session_id!r} already exists in {project_root}. "
+                "Pass --overwrite to replace it."
             )
-        restore_plan = (target, member, mode)
+            raise ValueError(msg)
 
-    # Only mutate the project once every safety check has passed.
-    conversations_dir.mkdir(parents=True, exist_ok=True)
-    conversation_path.write_text(
-        json.dumps(payload["conversation"], indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
+        database = source_data.get("database")
+        restore_plan: tuple[Path, str, str] | None = None
+        if isinstance(database, dict) and database.get("embedded"):
+            restore_plan = _plan_db_restore(database, project_root, overwrite=overwrite)
+            # Fail fast if the metadata points at a member that's not
+            # actually in the zip — better than crashing mid-extract.
+            try:
+                zf.getinfo(restore_plan[1])
+            except KeyError as err:
+                msg = f"Archive is missing embedded data file: {restore_plan[1]}"
+                raise ValueError(msg) from err
+
+        conversations_dir.mkdir(parents=True, exist_ok=True)
+        suffix = f".part-{uuid.uuid4().hex[:8]}"
+        conv_tmp = conversation_path.with_name(conversation_path.name + suffix)
+
+        db_tmp: Path | None = None
+        if restore_plan is not None:
+            target, _, _ = restore_plan
+            target.parent.mkdir(parents=True, exist_ok=True)
+            db_tmp = target.with_name(target.name + suffix)
+
+        try:
+            # Stage: write both files to .part siblings.
+            conv_tmp.write_text(
+                json.dumps(conversation, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            if restore_plan is not None and db_tmp is not None:
+                _, member, _ = restore_plan
+                with zf.open(member) as src, db_tmp.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+
+            # Commit: atomic renames. DB first so the conversation only
+            # appears once its referenced data is in place.
+            if restore_plan is not None and db_tmp is not None:
+                target, _, _ = restore_plan
+                os.replace(db_tmp, target)
+                db_tmp = None
+            os.replace(conv_tmp, conversation_path)
+        except BaseException:
+            for tmp in (conv_tmp, db_tmp):
+                if tmp is None:
+                    continue
+                with contextlib.suppress(FileNotFoundError):
+                    tmp.unlink()
+            raise
 
     restored_db_path: Path | None = None
     env_written = False
     if restore_plan is not None:
-        target, member, mode = restore_plan
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(BytesIO(archive)) as zf:
-            with zf.open(member) as src, target.open("wb") as dst:
-                shutil.copyfileobj(src, dst)
+        target, _, mode = restore_plan
         restored_db_path = target
-
         env_path = project_root / ".env"
         if not env_path.exists():
             rel_db = target.relative_to(project_root).as_posix()
@@ -317,7 +517,7 @@ def import_session_archive(
     return {
         "session_id": target_session_id,
         "conversation_path": conversation_path,
-        "manifest": payload["manifest"],
+        "manifest": manifest,
         "restored_db_path": restored_db_path,
         "env_written": env_written,
     }

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from io import BytesIO
 from pathlib import Path
 import zipfile
 
@@ -15,6 +16,7 @@ from datasight.session_archive import (
     build_session_archive,
     import_session_archive,
     read_session_archive,
+    validate_session_archive_id,
 )
 
 
@@ -145,6 +147,30 @@ def test_archive_include_data_embeds_database_file(tmp_path: Path) -> None:
         assert "data/database.duckdb" in zf.namelist()
 
 
+def test_archive_include_data_resolves_relative_db_path_from_project_dir(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    db_path = project_dir / "database.duckdb"
+    duckdb.connect(str(db_path)).close()
+
+    original_cwd = Path.cwd()
+    try:
+        archive = build_session_archive(
+            session_id="fuel-review",
+            conversation=_sample_conversation(),
+            dashboard=_sample_dashboard(),
+            project_dir=str(project_dir),
+            db_mode="duckdb",
+            db_path="database.duckdb",
+            include_data=True,
+        )
+    finally:
+        assert Path.cwd() == original_cwd
+
+    payload = read_session_archive(archive)
+    assert payload["source_data"]["database"]["embedded"] is True
+
+
 def test_import_session_archive_writes_conversation_and_dashboard(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
@@ -214,6 +240,94 @@ def test_import_session_archive_restores_embedded_database_and_env(tmp_path: Pat
     rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
     conn.close()
     assert rows == [("NG",)]
+
+
+def test_import_session_archive_restores_absolute_source_db_inside_project(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    db_path = external_dir / "shared.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.close()
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(source_dir),
+        db_mode="duckdb",
+        db_path=str(db_path),
+        include_data=True,
+    )
+
+    import_session_archive(
+        archive=archive,
+        project_dir=str(target_dir),
+    )
+
+    assert (target_dir / "shared.duckdb").exists()
+    assert not (external_dir / "shared.duckdb").samefile(target_dir / "shared.duckdb")
+    assert (target_dir / ".env").read_text(encoding="utf-8") == (
+        "DB_MODE=duckdb\nDB_PATH=shared.duckdb\n"
+    )
+
+
+def test_import_session_archive_rejects_traversal_restore_path(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+    )
+
+    original = BytesIO(archive)
+    mutated = BytesIO()
+    with (
+        zipfile.ZipFile(original) as src,
+        zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
+    ):
+        for name in src.namelist():
+            if name == "metadata/source_data.json":
+                source_data = json.loads(src.read(name))
+                source_data["database"] = {
+                    "mode": "duckdb",
+                    "embedded": True,
+                    "path_kind": "relative",
+                    "path": "../escape.duckdb",
+                    "archive_path": "data/database.duckdb",
+                }
+                dst.writestr(name, json.dumps(source_data))
+            else:
+                dst.writestr(name, src.read(name))
+        dst.writestr("data/database.duckdb", b"not-a-real-db")
+
+    try:
+        import_session_archive(
+            archive=mutated.getvalue(),
+            project_dir=str(project_dir),
+        )
+    except ValueError as err:
+        assert "traverse upward" in str(err)
+    else:
+        raise AssertionError("Expected import to reject traversal restore path")
+
+
+def test_validate_session_archive_id_rejects_dotted_ids() -> None:
+    try:
+        validate_session_archive_id("fuel.review")
+    except ValueError as err:
+        assert "Invalid session ID" in str(err)
+    else:
+        raise AssertionError("Expected dotted session ID to be rejected")
 
 
 def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -401,4 +401,5 @@ def test_cli_session_import_requires_overwrite_for_existing_session(tmp_path: Pa
         ],
     )
     assert result.exit_code != 0
-    assert "Pass --overwrite" in result.output
+    assert "already exists" in result.output
+    assert "--overwrite" in result.output

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -1,0 +1,404 @@
+"""Tests for versioned datasight session archives."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+import duckdb
+from click.testing import CliRunner
+
+from datasight.cli import cli
+from datasight.session_archive import (
+    SESSION_ARCHIVE_VERSION,
+    build_session_archive,
+    import_session_archive,
+    read_session_archive,
+)
+
+
+def _sample_conversation() -> dict[str, object]:
+    return {
+        "title": "Monthly generation review",
+        "messages": [
+            {"role": "user", "content": "Summarize generation by fuel."},
+            {"role": "assistant", "content": "Gas led the month."},
+        ],
+        "events": [
+            {
+                "event": "user_message",
+                "data": {"text": "Summarize generation by fuel."},
+            },
+            {
+                "event": "tool_start",
+                "data": {
+                    "tool": "run_sql",
+                    "input": {
+                        "sql": "SELECT energy_source_code, SUM(net_generation_mwh) FROM generation_fuel"
+                    },
+                },
+            },
+            {
+                "event": "assistant_message",
+                "data": {"text": "Gas led the month."},
+            },
+        ],
+    }
+
+
+def _sample_dashboard() -> dict[str, object]:
+    return {
+        "items": [
+            {
+                "id": 1,
+                "type": "chart",
+                "title": "Generation by fuel",
+                "sql": "SELECT energy_source_code, SUM(net_generation_mwh) FROM generation_fuel",
+                "plotly_spec": {
+                    "data": [{"type": "bar", "x": ["NG"], "y": [1200]}],
+                    "layout": {"title": "Generation by fuel"},
+                },
+            }
+        ],
+        "columns": 2,
+        "filters": [
+            {
+                "id": 1,
+                "column": "energy_source_code",
+                "operator": "eq",
+                "value": "NG",
+            }
+        ],
+        "title": "Fuel dashboard",
+    }
+
+
+def test_build_and_read_session_archive_round_trip(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+    )
+
+    payload = read_session_archive(archive)
+    assert payload["session_id"] == "fuel-review"
+    assert payload["manifest"]["archive_version"] == SESSION_ARCHIVE_VERSION
+    assert payload["conversation"]["title"] == "Monthly generation review"
+    assert payload["dashboard"]["columns"] == 2
+    assert payload["dashboard"]["filters"][0]["value"] == "NG"
+    assert payload["source_data"]["database"]["embedded"] is False
+
+
+def test_archive_includes_relative_source_data_reference(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+    )
+
+    archive_path = tmp_path / "session.dszip"
+    archive_path.write_bytes(archive)
+    with zipfile.ZipFile(archive_path) as zf:
+        source_data = json.loads(zf.read("metadata/source_data.json"))
+    assert source_data["database"]["mode"] == "duckdb"
+    assert source_data["database"]["path"] == "database.duckdb"
+    assert source_data["database"]["path_kind"] == "relative"
+
+
+def test_archive_include_data_embeds_database_file(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    db_path = project_dir / "database.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.close()
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path=str(db_path),
+        include_data=True,
+    )
+
+    payload = read_session_archive(archive)
+    assert payload["manifest"]["includes_data"] is True
+    assert payload["source_data"]["database"]["embedded"] is True
+    assert payload["source_data"]["database"]["archive_path"] == "data/database.duckdb"
+
+    archive_path = tmp_path / "session.zip"
+    archive_path.write_bytes(archive)
+    with zipfile.ZipFile(archive_path) as zf:
+        assert "data/database.duckdb" in zf.namelist()
+
+
+def test_import_session_archive_writes_conversation_and_dashboard(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(source_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+    )
+
+    result = import_session_archive(
+        archive=archive,
+        project_dir=str(target_dir),
+    )
+    assert result["session_id"] == "fuel-review"
+
+    conversation_path = target_dir / ".datasight" / "conversations" / "fuel-review.json"
+    dashboard_path = target_dir / ".datasight" / "dashboard.json"
+    conversation = json.loads(conversation_path.read_text(encoding="utf-8"))
+    dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+
+    assert conversation["dashboard"]["title"] == "Fuel dashboard"
+    assert conversation["events"][1]["data"]["tool"] == "run_sql"
+    assert dashboard["items"][0]["title"] == "Generation by fuel"
+
+
+def test_import_session_archive_restores_embedded_database_and_env(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    db_path = source_dir / "database.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.execute("INSERT INTO generation_fuel VALUES ('NG')")
+    conn.close()
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(source_dir),
+        db_mode="duckdb",
+        db_path=str(db_path),
+        include_data=True,
+    )
+
+    result = import_session_archive(
+        archive=archive,
+        project_dir=str(target_dir),
+    )
+
+    restored_db_path = target_dir / "database.duckdb"
+    assert restored_db_path in result["restored_paths"]
+    assert restored_db_path.exists()
+    assert (target_dir / ".env").read_text(encoding="utf-8") == (
+        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n"
+    )
+
+    conn = duckdb.connect(str(restored_db_path), read_only=True)
+    rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
+    conn.close()
+    assert rows == [("NG",)]
+
+
+def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> None:
+    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    conv_dir = source_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+    target_dir.mkdir()
+
+    db_path = source_dir / "database.duckdb"
+    duckdb.connect(str(db_path)).close()
+    (source_dir / ".env").write_text("DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8")
+
+    conversation = _sample_conversation()
+    conversation["dashboard"] = _sample_dashboard()
+    (conv_dir / "fuel-review.json").write_text(json.dumps(conversation), encoding="utf-8")
+
+    archive_path = tmp_path / "fuel-review.zip"
+    runner = CliRunner()
+
+    export_result = runner.invoke(
+        cli,
+        [
+            "session",
+            "export",
+            "fuel-review",
+            "--project-dir",
+            str(source_dir),
+            "--output-path",
+            str(archive_path),
+        ],
+    )
+    assert export_result.exit_code == 0, export_result.output
+    assert archive_path.exists()
+
+    import_result = runner.invoke(
+        cli,
+        [
+            "session",
+            "import",
+            str(archive_path),
+            "--project-dir",
+            str(target_dir),
+        ],
+    )
+    assert import_result.exit_code == 0, import_result.output
+
+    imported = json.loads(
+        (target_dir / ".datasight" / "conversations" / "fuel-review.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    active_dashboard = json.loads(
+        (target_dir / ".datasight" / "dashboard.json").read_text(encoding="utf-8")
+    )
+
+    assert imported["title"] == "Monthly generation review"
+    assert imported["dashboard"]["filters"][0]["value"] == "NG"
+    assert active_dashboard["title"] == "Fuel dashboard"
+
+
+def test_cli_session_export_include_data_round_trip_restores_db(
+    tmp_path: Path, monkeypatch
+) -> None:
+    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    conv_dir = source_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+    target_dir.mkdir()
+
+    db_path = source_dir / "database.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    conn.execute("INSERT INTO generation_fuel VALUES ('NG')")
+    conn.close()
+    (source_dir / ".env").write_text("DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8")
+
+    conversation = _sample_conversation()
+    conversation["dashboard"] = _sample_dashboard()
+    (conv_dir / "fuel-review.json").write_text(json.dumps(conversation), encoding="utf-8")
+
+    archive_path = tmp_path / "fuel-review.zip"
+    runner = CliRunner()
+    export_result = runner.invoke(
+        cli,
+        [
+            "session",
+            "export",
+            "fuel-review",
+            "--project-dir",
+            str(source_dir),
+            "--output-path",
+            str(archive_path),
+            "--include-data",
+        ],
+    )
+    assert export_result.exit_code == 0, export_result.output
+
+    import_result = runner.invoke(
+        cli,
+        [
+            "session",
+            "import",
+            str(archive_path),
+            "--project-dir",
+            str(target_dir),
+        ],
+    )
+    assert import_result.exit_code == 0, import_result.output
+    assert (target_dir / ".env").read_text(encoding="utf-8") == (
+        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n"
+    )
+
+    conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
+    rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
+    conn.close()
+    assert rows == [("NG",)]
+
+
+def test_cli_session_export_defaults_to_zip_filename(tmp_path: Path, monkeypatch) -> None:
+    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+    project_dir = tmp_path / "project"
+    conv_dir = project_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+
+    db_path = project_dir / "database.duckdb"
+    duckdb.connect(str(db_path)).close()
+    (project_dir / ".env").write_text(
+        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8"
+    )
+
+    conversation = _sample_conversation()
+    conversation["dashboard"] = _sample_dashboard()
+    (conv_dir / "fuel-review.json").write_text(json.dumps(conversation), encoding="utf-8")
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "export",
+                "fuel-review",
+                "--project-dir",
+                str(project_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("fuel-review.zip").exists()
+
+
+def test_cli_session_import_requires_overwrite_for_existing_session(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=_sample_dashboard(),
+        project_dir=str(project_dir),
+    )
+    archive_path = tmp_path / "fuel-review.zip"
+    archive_path.write_bytes(archive)
+
+    existing_dir = project_dir / ".datasight" / "conversations"
+    existing_dir.mkdir(parents=True)
+    (existing_dir / "fuel-review.json").write_text("{}", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "session",
+            "import",
+            str(archive_path),
+            "--project-dir",
+            str(project_dir),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Pass --overwrite" in result.output

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -487,6 +487,67 @@ def test_cli_session_export_defaults_to_zip_filename(tmp_path: Path, monkeypatch
         assert Path("fuel-review.zip").exists()
 
 
+def test_cli_session_export_uses_full_session_id_for_default_filename(
+    tmp_path: Path, monkeypatch
+) -> None:
+    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+    project_dir = tmp_path / "project"
+    long_session_id = "fuel-review-with-a-long-session-id"
+    conv_dir = project_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+
+    db_path = project_dir / "database.duckdb"
+    duckdb.connect(str(db_path)).close()
+    (project_dir / ".env").write_text(
+        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8"
+    )
+
+    conversation = _sample_conversation()
+    conversation["dashboard"] = _sample_dashboard()
+    (conv_dir / "{}.json".format(long_session_id)).write_text(
+        json.dumps(conversation), encoding="utf-8"
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "export",
+                long_session_id,
+                "--project-dir",
+                str(project_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("{}.zip".format(long_session_id)).exists()
+
+
+def test_cli_session_list_warns_about_unreadable_session_files(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    conv_dir = project_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+    (conv_dir / "valid.json").write_text(
+        json.dumps(
+            {
+                "title": "Valid",
+                "events": [{"event": "user_message", "data": {"text": "hi"}}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (conv_dir / "broken.json").write_text("{not json", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "list", "--project-dir", str(project_dir)])
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output
+    assert "Warning: skipped unreadable session file broken.json" in result.output
+
+
 def test_cli_session_import_requires_overwrite_for_existing_session(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -8,11 +8,12 @@ from pathlib import Path
 import zipfile
 
 import duckdb
+import pytest
 from click.testing import CliRunner
 
 from datasight.cli import cli
 from datasight.session_archive import (
-    SESSION_ARCHIVE_VERSION,
+    ARCHIVE_VERSION,
     build_session_archive,
     import_session_archive,
     read_session_archive,
@@ -20,18 +21,15 @@ from datasight.session_archive import (
 )
 
 
-def _sample_conversation() -> dict[str, object]:
-    return {
+def _sample_conversation(*, with_dashboard: bool = True) -> dict[str, object]:
+    convo: dict[str, object] = {
         "title": "Monthly generation review",
         "messages": [
             {"role": "user", "content": "Summarize generation by fuel."},
             {"role": "assistant", "content": "Gas led the month."},
         ],
         "events": [
-            {
-                "event": "user_message",
-                "data": {"text": "Summarize generation by fuel."},
-            },
+            {"event": "user_message", "data": {"text": "Summarize generation by fuel."}},
             {
                 "event": "tool_start",
                 "data": {
@@ -41,12 +39,12 @@ def _sample_conversation() -> dict[str, object]:
                     },
                 },
             },
-            {
-                "event": "assistant_message",
-                "data": {"text": "Gas led the month."},
-            },
+            {"event": "assistant_message", "data": {"text": "Gas led the month."}},
         ],
     }
+    if with_dashboard:
+        convo["dashboard"] = _sample_dashboard()
+    return convo
 
 
 def _sample_dashboard() -> dict[str, object]:
@@ -64,25 +62,26 @@ def _sample_dashboard() -> dict[str, object]:
             }
         ],
         "columns": 2,
-        "filters": [
-            {
-                "id": 1,
-                "column": "energy_source_code",
-                "operator": "eq",
-                "value": "NG",
-            }
-        ],
+        "filters": [{"id": 1, "column": "energy_source_code", "operator": "eq", "value": "NG"}],
         "title": "Fuel dashboard",
     }
 
 
-def test_build_and_read_session_archive_round_trip(tmp_path: Path) -> None:
+def _make_duckdb(path: Path, *, with_row: bool = False) -> None:
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
+    if with_row:
+        conn.execute("INSERT INTO generation_fuel VALUES ('NG')")
+    conn.close()
+
+
+def test_build_and_read_round_trip(tmp_path: Path) -> None:
     project_dir = tmp_path / "source"
     project_dir.mkdir()
+
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
         project_dir=str(project_dir),
         db_mode="duckdb",
         db_path="database.duckdb",
@@ -90,75 +89,86 @@ def test_build_and_read_session_archive_round_trip(tmp_path: Path) -> None:
 
     payload = read_session_archive(archive)
     assert payload["session_id"] == "fuel-review"
-    assert payload["manifest"]["archive_version"] == SESSION_ARCHIVE_VERSION
+    assert payload["manifest"]["archive_version"] == ARCHIVE_VERSION
+    assert payload["manifest"]["includes_data"] is False
     assert payload["conversation"]["title"] == "Monthly generation review"
+    # Dashboard travels embedded in the conversation; no separate top-level entry.
     assert payload["dashboard"]["columns"] == 2
-    assert payload["dashboard"]["filters"][0]["value"] == "NG"
-    assert payload["source_data"]["database"]["embedded"] is False
+    assert payload["conversation"]["dashboard"]["filters"][0]["value"] == "NG"
+    assert payload["source_data"]["database"] == {
+        "mode": "duckdb",
+        "embedded": False,
+        "path": "database.duckdb",
+        "path_kind": "relative",
+    }
 
 
-def test_archive_includes_relative_source_data_reference(tmp_path: Path) -> None:
+def test_archive_omits_redundant_dashboard_entry(tmp_path: Path) -> None:
     project_dir = tmp_path / "source"
     project_dir.mkdir()
+
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
         project_dir=str(project_dir),
         db_mode="duckdb",
         db_path="database.duckdb",
     )
-
-    archive_path = tmp_path / "session.dszip"
-    archive_path.write_bytes(archive)
-    with zipfile.ZipFile(archive_path) as zf:
-        source_data = json.loads(zf.read("metadata/source_data.json"))
-    assert source_data["database"]["mode"] == "duckdb"
-    assert source_data["database"]["path"] == "database.duckdb"
-    assert source_data["database"]["path_kind"] == "relative"
+    with zipfile.ZipFile(BytesIO(archive)) as zf:
+        names = set(zf.namelist())
+    assert "session/conversation.json" in names
+    assert "session/dashboard.json" not in names
 
 
-def test_archive_include_data_embeds_database_file(tmp_path: Path) -> None:
+def test_dashboard_override_replaces_conversation_dashboard(tmp_path: Path) -> None:
     project_dir = tmp_path / "source"
     project_dir.mkdir()
-    db_path = project_dir / "database.duckdb"
-    conn = duckdb.connect(str(db_path))
-    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
-    conn.close()
+
+    override = {"items": [], "columns": 0, "filters": [], "title": "Override"}
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        dashboard=override,
+        project_dir=str(project_dir),
+    )
+    payload = read_session_archive(archive)
+    assert payload["conversation"]["dashboard"] == override
+
+
+def test_include_data_embeds_database_file(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    _make_duckdb(project_dir / "database.duckdb")
 
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
         project_dir=str(project_dir),
         db_mode="duckdb",
-        db_path=str(db_path),
+        db_path="database.duckdb",
         include_data=True,
     )
 
     payload = read_session_archive(archive)
     assert payload["manifest"]["includes_data"] is True
-    assert payload["source_data"]["database"]["embedded"] is True
-    assert payload["source_data"]["database"]["archive_path"] == "data/database.duckdb"
+    db_meta = payload["source_data"]["database"]
+    assert db_meta["embedded"] is True
+    assert db_meta["archive_path"] == "data/database.duckdb"
 
-    archive_path = tmp_path / "session.zip"
-    archive_path.write_bytes(archive)
-    with zipfile.ZipFile(archive_path) as zf:
+    with zipfile.ZipFile(BytesIO(archive)) as zf:
         assert "data/database.duckdb" in zf.namelist()
 
 
-def test_archive_include_data_resolves_relative_db_path_from_project_dir(tmp_path: Path) -> None:
+def test_include_data_resolves_relative_path_independent_of_cwd(tmp_path: Path) -> None:
     project_dir = tmp_path / "source"
     project_dir.mkdir()
-    db_path = project_dir / "database.duckdb"
-    duckdb.connect(str(db_path)).close()
+    _make_duckdb(project_dir / "database.duckdb")
 
     original_cwd = Path.cwd()
     try:
         archive = build_session_archive(
             session_id="fuel-review",
             conversation=_sample_conversation(),
-            dashboard=_sample_dashboard(),
             project_dir=str(project_dir),
             db_mode="duckdb",
             db_path="database.duckdb",
@@ -167,11 +177,24 @@ def test_archive_include_data_resolves_relative_db_path_from_project_dir(tmp_pat
     finally:
         assert Path.cwd() == original_cwd
 
-    payload = read_session_archive(archive)
-    assert payload["source_data"]["database"]["embedded"] is True
+    assert read_session_archive(archive)["source_data"]["database"]["embedded"] is True
 
 
-def test_import_session_archive_writes_conversation_and_dashboard(tmp_path: Path) -> None:
+def test_include_data_rejects_unsupported_db_mode(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    with pytest.raises(ValueError, match="DuckDB and SQLite"):
+        build_session_archive(
+            session_id="fuel-review",
+            conversation=_sample_conversation(),
+            project_dir=str(project_dir),
+            db_mode="postgres",
+            db_path="ignored",
+            include_data=True,
+        )
+
+
+def test_import_writes_conversation_with_embedded_dashboard(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
     source_dir.mkdir()
@@ -180,96 +203,223 @@ def test_import_session_archive_writes_conversation_and_dashboard(tmp_path: Path
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
         project_dir=str(source_dir),
         db_mode="duckdb",
         db_path="database.duckdb",
     )
 
-    result = import_session_archive(
-        archive=archive,
-        project_dir=str(target_dir),
-    )
+    result = import_session_archive(archive=archive, project_dir=str(target_dir))
     assert result["session_id"] == "fuel-review"
+    assert result["restored_db_path"] is None
+    assert result["env_written"] is False
 
     conversation_path = target_dir / ".datasight" / "conversations" / "fuel-review.json"
-    dashboard_path = target_dir / ".datasight" / "dashboard.json"
     conversation = json.loads(conversation_path.read_text(encoding="utf-8"))
-    dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
-
     assert conversation["dashboard"]["title"] == "Fuel dashboard"
     assert conversation["events"][1]["data"]["tool"] == "run_sql"
-    assert dashboard["items"][0]["title"] == "Generation by fuel"
 
 
-def test_import_session_archive_restores_embedded_database_and_env(tmp_path: Path) -> None:
+def test_import_does_not_clobber_active_dashboard(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
     source_dir.mkdir()
     target_dir.mkdir()
 
-    db_path = source_dir / "database.duckdb"
-    conn = duckdb.connect(str(db_path))
-    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
-    conn.execute("INSERT INTO generation_fuel VALUES ('NG')")
-    conn.close()
+    # Pre-existing project-wide dashboard the user is editing.
+    existing_dashboard = {
+        "items": [
+            {"id": 9, "type": "chart", "title": "Mine", "sql": "SELECT 1", "plotly_spec": {}}
+        ],
+        "columns": 3,
+        "filters": [],
+        "title": "My active dashboard",
+    }
+    (target_dir / ".datasight").mkdir()
+    (target_dir / ".datasight" / "dashboard.json").write_text(
+        json.dumps(existing_dashboard), encoding="utf-8"
+    )
 
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
+        project_dir=str(source_dir),
+    )
+    import_session_archive(archive=archive, project_dir=str(target_dir))
+
+    preserved = json.loads(
+        (target_dir / ".datasight" / "dashboard.json").read_text(encoding="utf-8")
+    )
+    assert preserved == existing_dashboard
+
+
+def test_import_does_not_clobber_existing_env(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    existing_env = (
+        "DB_MODE=duckdb\nDB_PATH=existing.duckdb\nANTHROPIC_API_KEY=secret-do-not-erase\n"
+    )
+    (target_dir / ".env").write_text(existing_env, encoding="utf-8")
+    _make_duckdb(source_dir / "database.duckdb")
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
         project_dir=str(source_dir),
         db_mode="duckdb",
-        db_path=str(db_path),
+        db_path="database.duckdb",
+        include_data=True,
+    )
+    # Allow the data file to land at database.duckdb in target (no prior file there).
+    result = import_session_archive(archive=archive, project_dir=str(target_dir))
+
+    assert (target_dir / ".env").read_text(encoding="utf-8") == existing_env
+    assert result["env_written"] is False
+    assert (target_dir / "database.duckdb").exists()
+
+
+def test_import_writes_minimal_env_in_fresh_project(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    _make_duckdb(source_dir / "database.duckdb", with_row=True)
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(source_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
         include_data=True,
     )
 
-    result = import_session_archive(
-        archive=archive,
-        project_dir=str(target_dir),
-    )
+    result = import_session_archive(archive=archive, project_dir=str(target_dir))
 
-    restored_db_path = target_dir / "database.duckdb"
-    assert restored_db_path in result["restored_paths"]
-    assert restored_db_path.exists()
+    assert result["env_written"] is True
     assert (target_dir / ".env").read_text(encoding="utf-8") == (
         "DB_MODE=duckdb\nDB_PATH=database.duckdb\n"
     )
-
-    conn = duckdb.connect(str(restored_db_path), read_only=True)
+    conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
     rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
     conn.close()
     assert rows == [("NG",)]
 
 
-def test_import_session_archive_restores_absolute_source_db_inside_project(tmp_path: Path) -> None:
+def test_import_refuses_to_overwrite_existing_db_file(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
     source_dir.mkdir()
     target_dir.mkdir()
+    _make_duckdb(source_dir / "database.duckdb")
 
-    external_dir = tmp_path / "external"
-    external_dir.mkdir()
-    db_path = external_dir / "shared.duckdb"
-    conn = duckdb.connect(str(db_path))
-    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
-    conn.close()
+    # Drop a sentinel file at the same path the importer would restore to.
+    (target_dir / "database.duckdb").write_bytes(b"existing-bytes")
 
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
+        project_dir=str(source_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+        include_data=True,
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        import_session_archive(archive=archive, project_dir=str(target_dir))
+
+    # The conversation file must not have been written either.
+    assert not (target_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
+    assert (target_dir / "database.duckdb").read_bytes() == b"existing-bytes"
+
+
+def test_import_overwrite_replaces_existing_db(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    _make_duckdb(source_dir / "database.duckdb", with_row=True)
+    (target_dir / "database.duckdb").write_bytes(b"existing-bytes")
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(source_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+        include_data=True,
+    )
+
+    import_session_archive(archive=archive, project_dir=str(target_dir), overwrite=True)
+    conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
+    rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
+    conn.close()
+    assert rows == [("NG",)]
+
+
+def test_archive_omits_env_and_scrubs_external_db_paths(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / ".env").write_text(
+        "DB_MODE=duckdb\nDB_PATH=database.duckdb\nANTHROPIC_API_KEY=top-secret\n",
+        encoding="utf-8",
+    )
+
+    external_dir = tmp_path / "private" / "datasets"
+    external_dir.mkdir(parents=True)
+    abs_db = external_dir / "shared.duckdb"
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path=str(abs_db),
+    )
+
+    with zipfile.ZipFile(BytesIO(archive)) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("manifest.json"))
+        source_data = json.loads(zf.read("metadata/source_data.json"))
+        all_bytes = b"".join(zf.read(name) for name in names)
+
+    # The archive must not bundle any .env or echo the user's secrets.
+    assert ".env" not in names
+    assert b"top-secret" not in all_bytes
+    assert b"ANTHROPIC_API_KEY" not in all_bytes
+
+    # External absolute paths get reduced to a basename so the exporter's
+    # filesystem layout doesn't leak.
+    db = source_data["database"]
+    assert db["path"] == "shared.duckdb"
+    assert db["path_kind"] == "external"
+    assert str(external_dir) not in json.dumps(manifest) + json.dumps(source_data)
+
+
+def test_import_restores_external_db_under_basename_in_project(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    external_dir = tmp_path / "external"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    external_dir.mkdir()
+    db_path = external_dir / "shared.duckdb"
+    _make_duckdb(db_path)
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
         project_dir=str(source_dir),
         db_mode="duckdb",
         db_path=str(db_path),
         include_data=True,
     )
+    import_session_archive(archive=archive, project_dir=str(target_dir))
 
-    import_session_archive(
-        archive=archive,
-        project_dir=str(target_dir),
-    )
-
+    # External absolute paths get pinned to the project root by basename so
+    # the exporter can't dictate filesystem layout on the importer.
     assert (target_dir / "shared.duckdb").exists()
     assert not (external_dir / "shared.duckdb").samefile(target_dir / "shared.duckdb")
     assert (target_dir / ".env").read_text(encoding="utf-8") == (
@@ -277,22 +427,21 @@ def test_import_session_archive_restores_absolute_source_db_inside_project(tmp_p
     )
 
 
-def test_import_session_archive_rejects_traversal_restore_path(tmp_path: Path) -> None:
+def test_import_rejects_traversal_restore_path(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-    archive = build_session_archive(
+
+    base = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
         project_dir=str(project_dir),
         db_mode="duckdb",
         db_path="database.duckdb",
     )
 
-    original = BytesIO(archive)
     mutated = BytesIO()
     with (
-        zipfile.ZipFile(original) as src,
+        zipfile.ZipFile(BytesIO(base)) as src,
         zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
     ):
         for name in src.namelist():
@@ -310,24 +459,60 @@ def test_import_session_archive_rejects_traversal_restore_path(tmp_path: Path) -
                 dst.writestr(name, src.read(name))
         dst.writestr("data/database.duckdb", b"not-a-real-db")
 
-    try:
-        import_session_archive(
-            archive=mutated.getvalue(),
-            project_dir=str(project_dir),
-        )
-    except ValueError as err:
-        assert "traverse upward" in str(err)
-    else:
-        raise AssertionError("Expected import to reject traversal restore path")
+    with pytest.raises(ValueError, match="traverse upward"):
+        import_session_archive(archive=mutated.getvalue(), project_dir=str(project_dir))
+
+    # No partial state should be left behind on rejection.
+    assert not (project_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
+
+
+def test_read_archive_rejects_unknown_format(tmp_path: Path) -> None:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"format": "something-else"}))
+    with pytest.raises(ValueError, match="datasight session archive"):
+        read_session_archive(buf.getvalue())
+
+
+def test_read_archive_rejects_future_major_version(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+    )
+    mutated = BytesIO()
+    with (
+        zipfile.ZipFile(BytesIO(archive)) as src,
+        zipfile.ZipFile(mutated, "w") as dst,
+    ):
+        for name in src.namelist():
+            if name == "manifest.json":
+                manifest = json.loads(src.read(name))
+                manifest["archive_version"] = ARCHIVE_VERSION + 1
+                dst.writestr(name, json.dumps(manifest))
+            else:
+                dst.writestr(name, src.read(name))
+    with pytest.raises(ValueError, match="Unsupported session archive version"):
+        read_session_archive(mutated.getvalue())
 
 
 def test_validate_session_archive_id_rejects_dotted_ids() -> None:
-    try:
+    with pytest.raises(ValueError, match="Invalid session ID"):
         validate_session_archive_id("fuel.review")
-    except ValueError as err:
-        assert "Invalid session ID" in str(err)
-    else:
-        raise AssertionError("Expected dotted session ID to be rejected")
+
+
+def _write_project(project_dir: Path, *, session_id: str, with_db: bool) -> None:
+    conv_dir = project_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+    if with_db:
+        _make_duckdb(project_dir / "database.duckdb", with_row=True)
+        (project_dir / ".env").write_text(
+            "DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8"
+        )
+    convo = _sample_conversation()
+    (conv_dir / f"{session_id}.json").write_text(json.dumps(convo), encoding="utf-8")
 
 
 def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> None:
@@ -336,22 +521,13 @@ def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> No
 
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
-    conv_dir = source_dir / ".datasight" / "conversations"
-    conv_dir.mkdir(parents=True)
     target_dir.mkdir()
-
-    db_path = source_dir / "database.duckdb"
-    duckdb.connect(str(db_path)).close()
-    (source_dir / ".env").write_text("DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8")
-
-    conversation = _sample_conversation()
-    conversation["dashboard"] = _sample_dashboard()
-    (conv_dir / "fuel-review.json").write_text(json.dumps(conversation), encoding="utf-8")
+    _write_project(source_dir, session_id="fuel-review", with_db=True)
 
     archive_path = tmp_path / "fuel-review.zip"
     runner = CliRunner()
 
-    export_result = runner.invoke(
+    export = runner.invoke(
         cli,
         [
             "session",
@@ -363,61 +539,38 @@ def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> No
             str(archive_path),
         ],
     )
-    assert export_result.exit_code == 0, export_result.output
+    assert export.exit_code == 0, export.output
     assert archive_path.exists()
 
-    import_result = runner.invoke(
+    imp = runner.invoke(
         cli,
-        [
-            "session",
-            "import",
-            str(archive_path),
-            "--project-dir",
-            str(target_dir),
-        ],
+        ["session", "import", str(archive_path), "--project-dir", str(target_dir)],
     )
-    assert import_result.exit_code == 0, import_result.output
+    assert imp.exit_code == 0, imp.output
 
     imported = json.loads(
         (target_dir / ".datasight" / "conversations" / "fuel-review.json").read_text(
             encoding="utf-8"
         )
     )
-    active_dashboard = json.loads(
-        (target_dir / ".datasight" / "dashboard.json").read_text(encoding="utf-8")
-    )
-
     assert imported["title"] == "Monthly generation review"
     assert imported["dashboard"]["filters"][0]["value"] == "NG"
-    assert active_dashboard["title"] == "Fuel dashboard"
+    # No active dashboard.json should be created by import.
+    assert not (target_dir / ".datasight" / "dashboard.json").exists()
 
 
-def test_cli_session_export_include_data_round_trip_restores_db(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_cli_session_export_include_data_round_trip(tmp_path: Path, monkeypatch) -> None:
     for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
         monkeypatch.delenv(key, raising=False)
 
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
-    conv_dir = source_dir / ".datasight" / "conversations"
-    conv_dir.mkdir(parents=True)
     target_dir.mkdir()
-
-    db_path = source_dir / "database.duckdb"
-    conn = duckdb.connect(str(db_path))
-    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
-    conn.execute("INSERT INTO generation_fuel VALUES ('NG')")
-    conn.close()
-    (source_dir / ".env").write_text("DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8")
-
-    conversation = _sample_conversation()
-    conversation["dashboard"] = _sample_dashboard()
-    (conv_dir / "fuel-review.json").write_text(json.dumps(conversation), encoding="utf-8")
+    _write_project(source_dir, session_id="fuel-review", with_db=True)
 
     archive_path = tmp_path / "fuel-review.zip"
     runner = CliRunner()
-    export_result = runner.invoke(
+    export = runner.invoke(
         cli,
         [
             "session",
@@ -430,112 +583,46 @@ def test_cli_session_export_include_data_round_trip_restores_db(
             "--include-data",
         ],
     )
-    assert export_result.exit_code == 0, export_result.output
+    assert export.exit_code == 0, export.output
 
-    import_result = runner.invoke(
+    imp = runner.invoke(
         cli,
-        [
-            "session",
-            "import",
-            str(archive_path),
-            "--project-dir",
-            str(target_dir),
-        ],
+        ["session", "import", str(archive_path), "--project-dir", str(target_dir)],
     )
-    assert import_result.exit_code == 0, import_result.output
+    assert imp.exit_code == 0, imp.output
     assert (target_dir / ".env").read_text(encoding="utf-8") == (
         "DB_MODE=duckdb\nDB_PATH=database.duckdb\n"
     )
-
     conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
     rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
     conn.close()
     assert rows == [("NG",)]
 
 
-def test_cli_session_export_defaults_to_zip_filename(tmp_path: Path, monkeypatch) -> None:
+def test_cli_session_export_defaults_filename_to_zip(tmp_path: Path, monkeypatch) -> None:
     for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
         monkeypatch.delenv(key, raising=False)
 
     project_dir = tmp_path / "project"
-    conv_dir = project_dir / ".datasight" / "conversations"
-    conv_dir.mkdir(parents=True)
-
-    db_path = project_dir / "database.duckdb"
-    duckdb.connect(str(db_path)).close()
-    (project_dir / ".env").write_text(
-        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8"
-    )
-
-    conversation = _sample_conversation()
-    conversation["dashboard"] = _sample_dashboard()
-    (conv_dir / "fuel-review.json").write_text(json.dumps(conversation), encoding="utf-8")
+    _write_project(project_dir, session_id="fuel-review-with-a-long-id", with_db=True)
 
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=str(tmp_path)):
         result = runner.invoke(
             cli,
-            [
-                "session",
-                "export",
-                "fuel-review",
-                "--project-dir",
-                str(project_dir),
-            ],
+            ["session", "export", "fuel-review-with-a-long-id", "--project-dir", str(project_dir)],
         )
         assert result.exit_code == 0, result.output
-        assert Path("fuel-review.zip").exists()
+        assert Path("fuel-review-with-a-long-id.zip").exists()
 
 
-def test_cli_session_export_uses_full_session_id_for_default_filename(
-    tmp_path: Path, monkeypatch
-) -> None:
-    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
-        monkeypatch.delenv(key, raising=False)
-
-    project_dir = tmp_path / "project"
-    long_session_id = "fuel-review-with-a-long-session-id"
-    conv_dir = project_dir / ".datasight" / "conversations"
-    conv_dir.mkdir(parents=True)
-
-    db_path = project_dir / "database.duckdb"
-    duckdb.connect(str(db_path)).close()
-    (project_dir / ".env").write_text(
-        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8"
-    )
-
-    conversation = _sample_conversation()
-    conversation["dashboard"] = _sample_dashboard()
-    (conv_dir / "{}.json".format(long_session_id)).write_text(
-        json.dumps(conversation), encoding="utf-8"
-    )
-
-    runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
-        result = runner.invoke(
-            cli,
-            [
-                "session",
-                "export",
-                long_session_id,
-                "--project-dir",
-                str(project_dir),
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert Path("{}.zip".format(long_session_id)).exists()
-
-
-def test_cli_session_list_warns_about_unreadable_session_files(tmp_path: Path) -> None:
+def test_cli_session_list_warns_about_unreadable_files(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     conv_dir = project_dir / ".datasight" / "conversations"
     conv_dir.mkdir(parents=True)
     (conv_dir / "valid.json").write_text(
         json.dumps(
-            {
-                "title": "Valid",
-                "events": [{"event": "user_message", "data": {"text": "hi"}}],
-            }
+            {"title": "Valid", "events": [{"event": "user_message", "data": {"text": "hi"}}]}
         ),
         encoding="utf-8",
     )
@@ -554,7 +641,6 @@ def test_cli_session_import_requires_overwrite_for_existing_session(tmp_path: Pa
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        dashboard=_sample_dashboard(),
         project_dir=str(project_dir),
     )
     archive_path = tmp_path / "fuel-review.zip"
@@ -567,13 +653,7 @@ def test_cli_session_import_requires_overwrite_for_existing_session(tmp_path: Pa
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        [
-            "session",
-            "import",
-            str(archive_path),
-            "--project-dir",
-            str(project_dir),
-        ],
+        ["session", "import", str(archive_path), "--project-dir", str(project_dir)],
     )
     assert result.exit_code != 0
     assert "already exists" in result.output

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -18,6 +18,7 @@ from datasight.session_archive import (
     import_session_archive,
     read_session_archive,
     validate_session_archive_id,
+    write_session_archive,
 )
 
 
@@ -159,24 +160,25 @@ def test_include_data_embeds_database_file(tmp_path: Path) -> None:
         assert "data/database.duckdb" in zf.namelist()
 
 
-def test_include_data_resolves_relative_path_independent_of_cwd(tmp_path: Path) -> None:
+def test_include_data_resolves_relative_path_independent_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     project_dir = tmp_path / "source"
     project_dir.mkdir()
     _make_duckdb(project_dir / "database.duckdb")
 
-    original_cwd = Path.cwd()
-    try:
-        archive = build_session_archive(
-            session_id="fuel-review",
-            conversation=_sample_conversation(),
-            project_dir=str(project_dir),
-            db_mode="duckdb",
-            db_path="database.duckdb",
-            include_data=True,
-        )
-    finally:
-        assert Path.cwd() == original_cwd
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
 
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+        include_data=True,
+    )
     assert read_session_archive(archive)["source_data"]["database"]["embedded"] is True
 
 
@@ -498,6 +500,167 @@ def test_read_archive_rejects_future_major_version(tmp_path: Path) -> None:
         read_session_archive(mutated.getvalue())
 
 
+def test_write_session_archive_streams_to_disk(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    _make_duckdb(project_dir / "database.duckdb", with_row=True)
+
+    out_path = tmp_path / "out.zip"
+    final = write_session_archive(
+        output=out_path,
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+        include_data=True,
+    )
+
+    assert final == out_path
+    assert out_path.exists()
+    # No leftover .part-* siblings on success.
+    assert not list(tmp_path.glob("out.zip.part-*"))
+
+    payload = read_session_archive(out_path)
+    assert payload["manifest"]["includes_data"] is True
+    assert payload["source_data"]["database"]["archive_path"] == "data/database.duckdb"
+
+
+def test_write_session_archive_cleans_up_partial_on_failure(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    # No database file → include_data fails after the .part has been opened.
+    out_path = tmp_path / "out.zip"
+    with pytest.raises(ValueError, match="Database file not found"):
+        write_session_archive(
+            output=out_path,
+            session_id="fuel-review",
+            conversation=_sample_conversation(),
+            project_dir=str(project_dir),
+            db_mode="duckdb",
+            db_path="database.duckdb",
+            include_data=True,
+        )
+    assert not out_path.exists()
+    assert not list(tmp_path.glob("out.zip.part-*"))
+
+
+def test_read_archive_accepts_path(tmp_path: Path) -> None:
+    project_dir = tmp_path / "source"
+    project_dir.mkdir()
+    out_path = tmp_path / "session.zip"
+    write_session_archive(
+        output=out_path,
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+    )
+    payload = read_session_archive(out_path)
+    assert payload["session_id"] == "fuel-review"
+
+
+def test_read_archive_rejects_bad_zip(tmp_path: Path) -> None:
+    bogus = tmp_path / "garbage.zip"
+    bogus.write_bytes(b"not a zip at all")
+    with pytest.raises(ValueError, match="valid zip archive"):
+        read_session_archive(bogus)
+
+
+def test_read_archive_rejects_non_object_manifest(tmp_path: Path) -> None:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(["this", "is", "an", "array"]))
+    with pytest.raises(ValueError, match="manifest.json must be a JSON object"):
+        read_session_archive(buf.getvalue())
+
+
+def test_import_rejects_symlink_escape(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    # ``project_dir/data`` is a symlink to a sibling outside the project.
+    (project_dir / "data").symlink_to(outside_dir, target_is_directory=True)
+
+    _make_duckdb(tmp_path / "src.duckdb")
+    base = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path=str(tmp_path / "src.duckdb"),
+        include_data=True,
+    )
+
+    # Mutate the metadata to claim the embedded DB belongs at data/x.duckdb,
+    # which would resolve through the symlink and escape the project tree.
+    mutated = BytesIO()
+    with (
+        zipfile.ZipFile(BytesIO(base)) as src,
+        zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
+    ):
+        for name in src.namelist():
+            if name == "metadata/source_data.json":
+                source_data = json.loads(src.read(name))
+                source_data["database"]["path"] = "data/x.duckdb"
+                source_data["database"]["path_kind"] = "relative"
+                dst.writestr(name, json.dumps(source_data))
+            else:
+                dst.writestr(name, src.read(name))
+
+    with pytest.raises(ValueError, match="escapes the project directory"):
+        import_session_archive(archive=mutated.getvalue(), project_dir=str(project_dir))
+    # No conversation file written on rejection.
+    assert not (project_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
+    # No file extracted into the symlinked-out location.
+    assert not list(outside_dir.iterdir())
+
+
+def test_import_rolls_back_on_missing_archive_member(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    base = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+        project_dir=str(project_dir),
+        db_mode="duckdb",
+        db_path="database.duckdb",
+    )
+
+    # Mark the archive as embedding a data file that doesn't actually exist
+    # in the zip — the import must reject before writing the conversation.
+    mutated = BytesIO()
+    with (
+        zipfile.ZipFile(BytesIO(base)) as src,
+        zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
+    ):
+        for name in src.namelist():
+            if name == "metadata/source_data.json":
+                source_data = json.loads(src.read(name))
+                source_data["database"] = {
+                    "mode": "duckdb",
+                    "embedded": True,
+                    "path": "database.duckdb",
+                    "path_kind": "relative",
+                    "archive_path": "data/database.duckdb",
+                }
+                dst.writestr(name, json.dumps(source_data))
+            else:
+                dst.writestr(name, src.read(name))
+
+    with pytest.raises(ValueError, match="missing embedded data file"):
+        import_session_archive(archive=mutated.getvalue(), project_dir=str(project_dir))
+
+    assert not (project_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
+    assert not (project_dir / "database.duckdb").exists()
+    # No leftover .part-* files.
+    assert (
+        not list((project_dir / ".datasight" / "conversations").glob("*.part-*"))
+        if (project_dir / ".datasight" / "conversations").exists()
+        else True
+    )
+
+
 def test_validate_session_archive_id_rejects_dotted_ids() -> None:
     with pytest.raises(ValueError, match="Invalid session ID"):
         validate_session_archive_id("fuel.review")
@@ -597,6 +760,65 @@ def test_cli_session_export_include_data_round_trip(tmp_path: Path, monkeypatch)
     rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
     conn.close()
     assert rows == [("NG",)]
+
+
+def test_cli_session_export_omits_db_metadata_for_project_without_env(
+    tmp_path: Path, monkeypatch
+) -> None:
+    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+    project_dir = tmp_path / "project"
+    _write_project(project_dir, session_id="fuel-review", with_db=False)
+    assert not (project_dir / ".env").exists()
+
+    archive_path = tmp_path / "out.zip"
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "export",
+                "fuel-review",
+                "--project-dir",
+                str(project_dir),
+                "--output-path",
+                str(archive_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    payload = read_session_archive(archive_path)
+    # A bare Settings.from_env() would have stamped DuckDB defaults into
+    # source_data; with no .env we should record no database metadata.
+    assert payload["source_data"] == {}
+
+
+def test_cli_session_export_include_data_without_env_errors(tmp_path: Path, monkeypatch) -> None:
+    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+    project_dir = tmp_path / "project"
+    _write_project(project_dir, session_id="fuel-review", with_db=False)
+
+    archive_path = tmp_path / "out.zip"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "session",
+            "export",
+            "fuel-review",
+            "--project-dir",
+            str(project_dir),
+            "--output-path",
+            str(archive_path),
+            "--include-data",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "requires a configured database" in result.output
 
 
 def test_cli_session_export_defaults_filename_to_zip(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import json
+import zipfile
 from io import BytesIO
 from pathlib import Path
-import zipfile
 
-import duckdb
 import pytest
 from click.testing import CliRunner
 
@@ -68,152 +67,66 @@ def _sample_dashboard() -> dict[str, object]:
     }
 
 
-def _make_duckdb(path: Path, *, with_row: bool = False) -> None:
-    conn = duckdb.connect(str(path))
-    conn.execute("CREATE TABLE generation_fuel (energy_source_code VARCHAR)")
-    if with_row:
-        conn.execute("INSERT INTO generation_fuel VALUES ('NG')")
-    conn.close()
-
-
-def test_build_and_read_round_trip(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-
+def test_build_and_read_round_trip() -> None:
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
     )
 
     payload = read_session_archive(archive)
     assert payload["session_id"] == "fuel-review"
     assert payload["manifest"]["archive_version"] == ARCHIVE_VERSION
-    assert payload["manifest"]["includes_data"] is False
     assert payload["conversation"]["title"] == "Monthly generation review"
     # Dashboard travels embedded in the conversation; no separate top-level entry.
     assert payload["dashboard"]["columns"] == 2
     assert payload["conversation"]["dashboard"]["filters"][0]["value"] == "NG"
-    assert payload["source_data"]["database"] == {
-        "mode": "duckdb",
-        "embedded": False,
-        "path": "database.duckdb",
-        "path_kind": "relative",
-    }
 
 
-def test_archive_omits_redundant_dashboard_entry(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-
+def test_archive_layout_is_minimal() -> None:
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
     )
     with zipfile.ZipFile(BytesIO(archive)) as zf:
         names = set(zf.namelist())
-    assert "session/conversation.json" in names
-    assert "session/dashboard.json" not in names
+    assert names == {"manifest.json", "session/conversation.json"}
 
 
-def test_dashboard_override_replaces_conversation_dashboard(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-
+def test_dashboard_override_replaces_conversation_dashboard() -> None:
     override = {"items": [], "columns": 0, "filters": [], "title": "Override"}
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
         dashboard=override,
-        project_dir=str(project_dir),
     )
     payload = read_session_archive(archive)
     assert payload["conversation"]["dashboard"] == override
 
 
-def test_include_data_embeds_database_file(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-    _make_duckdb(project_dir / "database.duckdb")
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-
-    payload = read_session_archive(archive)
-    assert payload["manifest"]["includes_data"] is True
-    db_meta = payload["source_data"]["database"]
-    assert db_meta["embedded"] is True
-    assert db_meta["archive_path"] == "data/database.duckdb"
-
+def test_archive_never_contains_env_or_secrets(tmp_path: Path) -> None:
+    convo = _sample_conversation()
+    # Anything in the user's project that might hold secrets must not
+    # find its way into a shareable archive.
+    archive = build_session_archive(session_id="fuel-review", conversation=convo)
     with zipfile.ZipFile(BytesIO(archive)) as zf:
-        assert "data/database.duckdb" in zf.namelist()
+        names = set(zf.namelist())
+        all_bytes = b"".join(zf.read(name) for name in names)
 
-
-def test_include_data_resolves_relative_path_independent_of_cwd(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-    _make_duckdb(project_dir / "database.duckdb")
-
-    elsewhere = tmp_path / "elsewhere"
-    elsewhere.mkdir()
-    monkeypatch.chdir(elsewhere)
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-    assert read_session_archive(archive)["source_data"]["database"]["embedded"] is True
-
-
-def test_include_data_rejects_unsupported_db_mode(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-    with pytest.raises(ValueError, match="DuckDB and SQLite"):
-        build_session_archive(
-            session_id="fuel-review",
-            conversation=_sample_conversation(),
-            project_dir=str(project_dir),
-            db_mode="postgres",
-            db_path="ignored",
-            include_data=True,
-        )
+    assert ".env" not in names
+    assert b"ANTHROPIC_API_KEY" not in all_bytes
 
 
 def test_import_writes_conversation_with_embedded_dashboard(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
-    source_dir.mkdir()
     target_dir.mkdir()
 
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
     )
 
     result = import_session_archive(archive=archive, project_dir=str(target_dir))
     assert result["session_id"] == "fuel-review"
-    assert result["restored_db_path"] is None
-    assert result["env_written"] is False
 
     conversation_path = target_dir / ".datasight" / "conversations" / "fuel-review.json"
     conversation = json.loads(conversation_path.read_text(encoding="utf-8"))
@@ -221,13 +134,10 @@ def test_import_writes_conversation_with_embedded_dashboard(tmp_path: Path) -> N
     assert conversation["events"][1]["data"]["tool"] == "run_sql"
 
 
-def test_import_does_not_clobber_active_dashboard(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
+def test_import_does_not_touch_active_dashboard_or_env(tmp_path: Path) -> None:
     target_dir = tmp_path / "target"
-    source_dir.mkdir()
     target_dir.mkdir()
 
-    # Pre-existing project-wide dashboard the user is editing.
     existing_dashboard = {
         "items": [
             {"id": 9, "type": "chart", "title": "Mine", "sql": "SELECT 1", "plotly_spec": {}}
@@ -240,235 +150,91 @@ def test_import_does_not_clobber_active_dashboard(tmp_path: Path) -> None:
     (target_dir / ".datasight" / "dashboard.json").write_text(
         json.dumps(existing_dashboard), encoding="utf-8"
     )
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-    )
-    import_session_archive(archive=archive, project_dir=str(target_dir))
-
-    preserved = json.loads(
-        (target_dir / ".datasight" / "dashboard.json").read_text(encoding="utf-8")
-    )
-    assert preserved == existing_dashboard
-
-
-def test_import_does_not_clobber_existing_env(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
-    target_dir = tmp_path / "target"
-    source_dir.mkdir()
-    target_dir.mkdir()
-
-    existing_env = (
-        "DB_MODE=duckdb\nDB_PATH=existing.duckdb\nANTHROPIC_API_KEY=secret-do-not-erase\n"
-    )
+    existing_env = "DB_MODE=duckdb\nDB_PATH=database.duckdb\nANTHROPIC_API_KEY=secret\n"
     (target_dir / ".env").write_text(existing_env, encoding="utf-8")
-    _make_duckdb(source_dir / "database.duckdb")
 
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-    # Allow the data file to land at database.duckdb in target (no prior file there).
-    result = import_session_archive(archive=archive, project_dir=str(target_dir))
-
-    assert (target_dir / ".env").read_text(encoding="utf-8") == existing_env
-    assert result["env_written"] is False
-    assert (target_dir / "database.duckdb").exists()
-
-
-def test_import_writes_minimal_env_in_fresh_project(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
-    target_dir = tmp_path / "target"
-    source_dir.mkdir()
-    target_dir.mkdir()
-    _make_duckdb(source_dir / "database.duckdb", with_row=True)
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-
-    result = import_session_archive(archive=archive, project_dir=str(target_dir))
-
-    assert result["env_written"] is True
-    assert (target_dir / ".env").read_text(encoding="utf-8") == (
-        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n"
-    )
-    conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
-    rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
-    conn.close()
-    assert rows == [("NG",)]
-
-
-def test_import_refuses_to_overwrite_existing_db_file(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
-    target_dir = tmp_path / "target"
-    source_dir.mkdir()
-    target_dir.mkdir()
-    _make_duckdb(source_dir / "database.duckdb")
-
-    # Drop a sentinel file at the same path the importer would restore to.
-    (target_dir / "database.duckdb").write_bytes(b"existing-bytes")
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-
-    with pytest.raises(ValueError, match="already exists"):
-        import_session_archive(archive=archive, project_dir=str(target_dir))
-
-    # The conversation file must not have been written either.
-    assert not (target_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
-    assert (target_dir / "database.duckdb").read_bytes() == b"existing-bytes"
-
-
-def test_import_overwrite_replaces_existing_db(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
-    target_dir = tmp_path / "target"
-    source_dir.mkdir()
-    target_dir.mkdir()
-    _make_duckdb(source_dir / "database.duckdb", with_row=True)
-    (target_dir / "database.duckdb").write_bytes(b"existing-bytes")
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-
-    import_session_archive(archive=archive, project_dir=str(target_dir), overwrite=True)
-    conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
-    rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
-    conn.close()
-    assert rows == [("NG",)]
-
-
-def test_archive_omits_env_and_scrubs_external_db_paths(tmp_path: Path) -> None:
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / ".env").write_text(
-        "DB_MODE=duckdb\nDB_PATH=database.duckdb\nANTHROPIC_API_KEY=top-secret\n",
-        encoding="utf-8",
-    )
-
-    external_dir = tmp_path / "private" / "datasets"
-    external_dir.mkdir(parents=True)
-    abs_db = external_dir / "shared.duckdb"
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path=str(abs_db),
-    )
-
-    with zipfile.ZipFile(BytesIO(archive)) as zf:
-        names = set(zf.namelist())
-        manifest = json.loads(zf.read("manifest.json"))
-        source_data = json.loads(zf.read("metadata/source_data.json"))
-        all_bytes = b"".join(zf.read(name) for name in names)
-
-    # The archive must not bundle any .env or echo the user's secrets.
-    assert ".env" not in names
-    assert b"top-secret" not in all_bytes
-    assert b"ANTHROPIC_API_KEY" not in all_bytes
-
-    # External absolute paths get reduced to a basename so the exporter's
-    # filesystem layout doesn't leak.
-    db = source_data["database"]
-    assert db["path"] == "shared.duckdb"
-    assert db["path_kind"] == "external"
-    assert str(external_dir) not in json.dumps(manifest) + json.dumps(source_data)
-
-
-def test_import_restores_external_db_under_basename_in_project(tmp_path: Path) -> None:
-    source_dir = tmp_path / "source"
-    target_dir = tmp_path / "target"
-    external_dir = tmp_path / "external"
-    source_dir.mkdir()
-    target_dir.mkdir()
-    external_dir.mkdir()
-    db_path = external_dir / "shared.duckdb"
-    _make_duckdb(db_path)
-
-    archive = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(source_dir),
-        db_mode="duckdb",
-        db_path=str(db_path),
-        include_data=True,
     )
     import_session_archive(archive=archive, project_dir=str(target_dir))
 
-    # External absolute paths get pinned to the project root by basename so
-    # the exporter can't dictate filesystem layout on the importer.
-    assert (target_dir / "shared.duckdb").exists()
-    assert not (external_dir / "shared.duckdb").samefile(target_dir / "shared.duckdb")
-    assert (target_dir / ".env").read_text(encoding="utf-8") == (
-        "DB_MODE=duckdb\nDB_PATH=shared.duckdb\n"
+    assert (
+        json.loads((target_dir / ".datasight" / "dashboard.json").read_text(encoding="utf-8"))
+        == existing_dashboard
     )
+    assert (target_dir / ".env").read_text(encoding="utf-8") == existing_env
 
 
-def test_import_rejects_traversal_restore_path(tmp_path: Path) -> None:
+def test_import_refuses_existing_session_without_overwrite(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-
-    base = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
+    (project_dir / ".datasight" / "conversations").mkdir(parents=True)
+    (project_dir / ".datasight" / "conversations" / "fuel-review.json").write_text(
+        "{}", encoding="utf-8"
     )
 
-    mutated = BytesIO()
-    with (
-        zipfile.ZipFile(BytesIO(base)) as src,
-        zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
-    ):
-        for name in src.namelist():
-            if name == "metadata/source_data.json":
-                source_data = json.loads(src.read(name))
-                source_data["database"] = {
-                    "mode": "duckdb",
-                    "embedded": True,
-                    "path_kind": "relative",
-                    "path": "../escape.duckdb",
-                    "archive_path": "data/database.duckdb",
-                }
-                dst.writestr(name, json.dumps(source_data))
-            else:
-                dst.writestr(name, src.read(name))
-        dst.writestr("data/database.duckdb", b"not-a-real-db")
-
-    with pytest.raises(ValueError, match="traverse upward"):
-        import_session_archive(archive=mutated.getvalue(), project_dir=str(project_dir))
-
-    # No partial state should be left behind on rejection.
-    assert not (project_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        import_session_archive(archive=archive, project_dir=str(project_dir))
 
 
-def test_read_archive_rejects_unknown_format(tmp_path: Path) -> None:
+def test_import_overwrite_replaces_existing_session(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    conv_dir = project_dir / ".datasight" / "conversations"
+    conv_dir.mkdir(parents=True)
+    (conv_dir / "fuel-review.json").write_text(
+        json.dumps({"title": "Old", "events": [], "messages": []}), encoding="utf-8"
+    )
+
+    archive = build_session_archive(
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+    )
+    import_session_archive(archive=archive, project_dir=str(project_dir), overwrite=True)
+    final = json.loads((conv_dir / "fuel-review.json").read_text(encoding="utf-8"))
+    assert final["title"] == "Monthly generation review"
+
+
+def test_write_session_archive_streams_to_disk(tmp_path: Path) -> None:
+    out_path = tmp_path / "out.zip"
+    final = write_session_archive(
+        output=out_path,
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+    )
+    assert final == out_path
+    assert out_path.exists()
+    # No leftover .part-* siblings on success.
+    assert not list(tmp_path.glob("out.zip.part-*"))
+
+    payload = read_session_archive(out_path)
+    assert payload["session_id"] == "fuel-review"
+
+
+def test_read_archive_accepts_path(tmp_path: Path) -> None:
+    out_path = tmp_path / "session.zip"
+    write_session_archive(
+        output=out_path,
+        session_id="fuel-review",
+        conversation=_sample_conversation(),
+    )
+    payload = read_session_archive(out_path)
+    assert payload["session_id"] == "fuel-review"
+
+
+def test_read_archive_rejects_bad_zip(tmp_path: Path) -> None:
+    bogus = tmp_path / "garbage.zip"
+    bogus.write_bytes(b"not a zip at all")
+    with pytest.raises(ValueError, match="valid zip archive"):
+        read_session_archive(bogus)
+
+
+def test_read_archive_rejects_unknown_format() -> None:
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("manifest.json", json.dumps({"format": "something-else"}))
@@ -476,13 +242,18 @@ def test_read_archive_rejects_unknown_format(tmp_path: Path) -> None:
         read_session_archive(buf.getvalue())
 
 
-def test_read_archive_rejects_future_major_version(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
+def test_read_archive_rejects_non_object_manifest() -> None:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(["this", "is", "an", "array"]))
+    with pytest.raises(ValueError, match="manifest.json must be a JSON object"):
+        read_session_archive(buf.getvalue())
+
+
+def test_read_archive_rejects_future_major_version() -> None:
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        project_dir=str(project_dir),
     )
     mutated = BytesIO()
     with (
@@ -500,192 +271,23 @@ def test_read_archive_rejects_future_major_version(tmp_path: Path) -> None:
         read_session_archive(mutated.getvalue())
 
 
-def test_write_session_archive_streams_to_disk(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-    _make_duckdb(project_dir / "database.duckdb", with_row=True)
-
-    out_path = tmp_path / "out.zip"
-    final = write_session_archive(
-        output=out_path,
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-        include_data=True,
-    )
-
-    assert final == out_path
-    assert out_path.exists()
-    # No leftover .part-* siblings on success.
-    assert not list(tmp_path.glob("out.zip.part-*"))
-
-    payload = read_session_archive(out_path)
-    assert payload["manifest"]["includes_data"] is True
-    assert payload["source_data"]["database"]["archive_path"] == "data/database.duckdb"
-
-
-def test_write_session_archive_cleans_up_partial_on_failure(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-    # No database file → include_data fails after the .part has been opened.
-    out_path = tmp_path / "out.zip"
-    with pytest.raises(ValueError, match="Database file not found"):
-        write_session_archive(
-            output=out_path,
-            session_id="fuel-review",
-            conversation=_sample_conversation(),
-            project_dir=str(project_dir),
-            db_mode="duckdb",
-            db_path="database.duckdb",
-            include_data=True,
-        )
-    assert not out_path.exists()
-    assert not list(tmp_path.glob("out.zip.part-*"))
-
-
-def test_read_archive_accepts_path(tmp_path: Path) -> None:
-    project_dir = tmp_path / "source"
-    project_dir.mkdir()
-    out_path = tmp_path / "session.zip"
-    write_session_archive(
-        output=out_path,
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-    )
-    payload = read_session_archive(out_path)
-    assert payload["session_id"] == "fuel-review"
-
-
-def test_read_archive_rejects_bad_zip(tmp_path: Path) -> None:
-    bogus = tmp_path / "garbage.zip"
-    bogus.write_bytes(b"not a zip at all")
-    with pytest.raises(ValueError, match="valid zip archive"):
-        read_session_archive(bogus)
-
-
-def test_read_archive_rejects_non_object_manifest(tmp_path: Path) -> None:
-    buf = BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("manifest.json", json.dumps(["this", "is", "an", "array"]))
-    with pytest.raises(ValueError, match="manifest.json must be a JSON object"):
-        read_session_archive(buf.getvalue())
-
-
-def test_import_rejects_symlink_escape(tmp_path: Path) -> None:
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    outside_dir = tmp_path / "outside"
-    outside_dir.mkdir()
-    # ``project_dir/data`` is a symlink to a sibling outside the project.
-    (project_dir / "data").symlink_to(outside_dir, target_is_directory=True)
-
-    _make_duckdb(tmp_path / "src.duckdb")
-    base = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path=str(tmp_path / "src.duckdb"),
-        include_data=True,
-    )
-
-    # Mutate the metadata to claim the embedded DB belongs at data/x.duckdb,
-    # which would resolve through the symlink and escape the project tree.
-    mutated = BytesIO()
-    with (
-        zipfile.ZipFile(BytesIO(base)) as src,
-        zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
-    ):
-        for name in src.namelist():
-            if name == "metadata/source_data.json":
-                source_data = json.loads(src.read(name))
-                source_data["database"]["path"] = "data/x.duckdb"
-                source_data["database"]["path_kind"] = "relative"
-                dst.writestr(name, json.dumps(source_data))
-            else:
-                dst.writestr(name, src.read(name))
-
-    with pytest.raises(ValueError, match="escapes the project directory"):
-        import_session_archive(archive=mutated.getvalue(), project_dir=str(project_dir))
-    # No conversation file written on rejection.
-    assert not (project_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
-    # No file extracted into the symlinked-out location.
-    assert not list(outside_dir.iterdir())
-
-
-def test_import_rolls_back_on_missing_archive_member(tmp_path: Path) -> None:
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    base = build_session_archive(
-        session_id="fuel-review",
-        conversation=_sample_conversation(),
-        project_dir=str(project_dir),
-        db_mode="duckdb",
-        db_path="database.duckdb",
-    )
-
-    # Mark the archive as embedding a data file that doesn't actually exist
-    # in the zip — the import must reject before writing the conversation.
-    mutated = BytesIO()
-    with (
-        zipfile.ZipFile(BytesIO(base)) as src,
-        zipfile.ZipFile(mutated, "w", compression=zipfile.ZIP_DEFLATED) as dst,
-    ):
-        for name in src.namelist():
-            if name == "metadata/source_data.json":
-                source_data = json.loads(src.read(name))
-                source_data["database"] = {
-                    "mode": "duckdb",
-                    "embedded": True,
-                    "path": "database.duckdb",
-                    "path_kind": "relative",
-                    "archive_path": "data/database.duckdb",
-                }
-                dst.writestr(name, json.dumps(source_data))
-            else:
-                dst.writestr(name, src.read(name))
-
-    with pytest.raises(ValueError, match="missing embedded data file"):
-        import_session_archive(archive=mutated.getvalue(), project_dir=str(project_dir))
-
-    assert not (project_dir / ".datasight" / "conversations" / "fuel-review.json").exists()
-    assert not (project_dir / "database.duckdb").exists()
-    # No leftover .part-* files.
-    assert (
-        not list((project_dir / ".datasight" / "conversations").glob("*.part-*"))
-        if (project_dir / ".datasight" / "conversations").exists()
-        else True
-    )
-
-
 def test_validate_session_archive_id_rejects_dotted_ids() -> None:
     with pytest.raises(ValueError, match="Invalid session ID"):
         validate_session_archive_id("fuel.review")
 
 
-def _write_project(project_dir: Path, *, session_id: str, with_db: bool) -> None:
+def _write_project(project_dir: Path, *, session_id: str) -> None:
     conv_dir = project_dir / ".datasight" / "conversations"
     conv_dir.mkdir(parents=True)
-    if with_db:
-        _make_duckdb(project_dir / "database.duckdb", with_row=True)
-        (project_dir / ".env").write_text(
-            "DB_MODE=duckdb\nDB_PATH=database.duckdb\n", encoding="utf-8"
-        )
     convo = _sample_conversation()
     (conv_dir / f"{session_id}.json").write_text(json.dumps(convo), encoding="utf-8")
 
 
-def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> None:
-    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
-        monkeypatch.delenv(key, raising=False)
-
+def test_cli_session_export_import_round_trip(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
     target_dir.mkdir()
-    _write_project(source_dir, session_id="fuel-review", with_db=True)
+    _write_project(source_dir, session_id="fuel-review")
 
     archive_path = tmp_path / "fuel-review.zip"
     runner = CliRunner()
@@ -722,111 +324,9 @@ def test_cli_session_export_import_round_trip(tmp_path: Path, monkeypatch) -> No
     assert not (target_dir / ".datasight" / "dashboard.json").exists()
 
 
-def test_cli_session_export_include_data_round_trip(tmp_path: Path, monkeypatch) -> None:
-    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
-        monkeypatch.delenv(key, raising=False)
-
-    source_dir = tmp_path / "source"
-    target_dir = tmp_path / "target"
-    target_dir.mkdir()
-    _write_project(source_dir, session_id="fuel-review", with_db=True)
-
-    archive_path = tmp_path / "fuel-review.zip"
-    runner = CliRunner()
-    export = runner.invoke(
-        cli,
-        [
-            "session",
-            "export",
-            "fuel-review",
-            "--project-dir",
-            str(source_dir),
-            "--output-path",
-            str(archive_path),
-            "--include-data",
-        ],
-    )
-    assert export.exit_code == 0, export.output
-
-    imp = runner.invoke(
-        cli,
-        ["session", "import", str(archive_path), "--project-dir", str(target_dir)],
-    )
-    assert imp.exit_code == 0, imp.output
-    assert (target_dir / ".env").read_text(encoding="utf-8") == (
-        "DB_MODE=duckdb\nDB_PATH=database.duckdb\n"
-    )
-    conn = duckdb.connect(str(target_dir / "database.duckdb"), read_only=True)
-    rows = conn.execute("SELECT energy_source_code FROM generation_fuel").fetchall()
-    conn.close()
-    assert rows == [("NG",)]
-
-
-def test_cli_session_export_omits_db_metadata_for_project_without_env(
-    tmp_path: Path, monkeypatch
-) -> None:
-    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
-        monkeypatch.delenv(key, raising=False)
-
+def test_cli_session_export_defaults_filename_to_zip(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    _write_project(project_dir, session_id="fuel-review", with_db=False)
-    assert not (project_dir / ".env").exists()
-
-    archive_path = tmp_path / "out.zip"
-    runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
-        result = runner.invoke(
-            cli,
-            [
-                "session",
-                "export",
-                "fuel-review",
-                "--project-dir",
-                str(project_dir),
-                "--output-path",
-                str(archive_path),
-            ],
-        )
-        assert result.exit_code == 0, result.output
-
-    payload = read_session_archive(archive_path)
-    # A bare Settings.from_env() would have stamped DuckDB defaults into
-    # source_data; with no .env we should record no database metadata.
-    assert payload["source_data"] == {}
-
-
-def test_cli_session_export_include_data_without_env_errors(tmp_path: Path, monkeypatch) -> None:
-    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
-        monkeypatch.delenv(key, raising=False)
-
-    project_dir = tmp_path / "project"
-    _write_project(project_dir, session_id="fuel-review", with_db=False)
-
-    archive_path = tmp_path / "out.zip"
-    runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "session",
-            "export",
-            "fuel-review",
-            "--project-dir",
-            str(project_dir),
-            "--output-path",
-            str(archive_path),
-            "--include-data",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "requires a configured database" in result.output
-
-
-def test_cli_session_export_defaults_filename_to_zip(tmp_path: Path, monkeypatch) -> None:
-    for key in ("DB_PATH", "DB_MODE", "DATASIGHT_PROJECT"):
-        monkeypatch.delenv(key, raising=False)
-
-    project_dir = tmp_path / "project"
-    _write_project(project_dir, session_id="fuel-review-with-a-long-id", with_db=True)
+    _write_project(project_dir, session_id="fuel-review-with-a-long-id")
 
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=str(tmp_path)):
@@ -863,7 +363,6 @@ def test_cli_session_import_requires_overwrite_for_existing_session(tmp_path: Pa
     archive = build_session_archive(
         session_id="fuel-review",
         conversation=_sample_conversation(),
-        project_dir=str(project_dir),
     )
     archive_path = tmp_path / "fuel-review.zip"
     archive_path.write_bytes(archive)


### PR DESCRIPTION
Summary:
- add a new datasight session CLI group for listing, exporting, and importing session archives
- add a versioned session archive format with lightweight reference mode and optional include-data embedding for DuckDB and SQLite databases
- restore embedded databases on import, write a minimal .env, and add round-trip test coverage plus CLI docs

Testing:
- .venv/bin/pytest -q tests/test_session_archive.py tests/test_export.py tests/test_cli_tools_extra.py -k session\ or\ export
- .venv/bin/ruff check src/datasight/session_archive.py src/datasight/cli_commands/session.py tests/test_session_archive.py