### PR TITLE
Detect untidy datasets and add tidy reshape command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,6 +64,7 @@ datasight [OPTIONS] COMMAND [ARGS]...
 - `profile`: Profile your dataset - row counts, date coverage, and column statistics.
 - `measures`: Surface likely measures and default aggregations.
 - `quality`: Audit data quality - nulls, suspicious ranges, and date coverage.
+- `tidy`: Detect untidy column shapes and reshape into long form.
 - `integrity`: Audit cross-table referential integrity - keys, orphans, and join risks.
 - `distribution`: Profile value distributions - percentiles, outliers, and measure flags.
 - `validate`: Run declarative validation rules against the database.
@@ -600,6 +601,108 @@ datasight quality [OPTIONS]
 | `--table` | Audit a specific table. |
 | `--format` | Output format (default: table). Default: `table`. |
 | `--output`, `-o` | Write the quality audit to a file instead of stdout. |
+
+### `datasight tidy`
+
+Detect untidy column shapes and reshape into long form.
+
+Use 'tidy suggest' to inspect candidates, 'tidy view' to create
+long-form views, or 'tidy table' to materialize long-form tables.
+Detection is deterministic — column names plus dtypes plus row counts —
+so no LLM is involved.
+
+Examples:
+
+```
+datasight tidy suggest
+datasight tidy suggest --table sales_wide
+datasight tidy view --dry-run
+datasight tidy view
+datasight tidy table --table sales_wide
+```
+
+```bash
+datasight tidy [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands**
+
+- `suggest`: List detected untidy column shapes without changing the database.
+- `view`: Create CREATE OR REPLACE VIEW <table>_long for each detected pattern.
+- `table`: Materialize CREATE OR REPLACE TABLE <table>_long for each detected pattern.
+
+#### `datasight tidy suggest`
+
+List detected untidy column shapes without changing the database.
+
+Examples:
+
+```
+datasight tidy suggest
+datasight tidy suggest --table sales_wide
+datasight tidy suggest --format markdown -o tidy.md
+```
+
+```bash
+datasight tidy suggest [OPTIONS]
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `--project-dir` | Project directory containing .env and config files. Default: `.`. |
+| `--table` | Scope tidy detection to a specific source table. |
+| `--format` | Output format (default: table). Default: `table`. |
+| `--output`, `-o` | Write the tidy listing to a file instead of stdout. |
+
+#### `datasight tidy view`
+
+Create CREATE OR REPLACE VIEW <table>_long for each detected pattern.
+
+Examples:
+
+```
+datasight tidy view
+datasight tidy view --dry-run
+datasight tidy view --table sales_wide
+```
+
+```bash
+datasight tidy view [OPTIONS]
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `--project-dir` | Project directory containing .env and config files. Default: `.`. |
+| `--table` | Scope tidy detection to a specific source table. |
+| `--dry-run` | Print the DDL without executing it. |
+
+#### `datasight tidy table`
+
+Materialize CREATE OR REPLACE TABLE <table>_long for each detected pattern.
+
+Examples:
+
+```
+datasight tidy table
+datasight tidy table --dry-run
+datasight tidy table --table sales_wide
+```
+
+```bash
+datasight tidy table [OPTIONS]
+```
+
+**Parameters**
+
+| Name | Details |
+| --- | --- |
+| `--project-dir` | Project directory containing .env and config files. Default: `.`. |
+| `--table` | Scope tidy detection to a specific source table. |
+| `--dry-run` | Print the DDL without executing it. |
 
 ### `datasight integrity`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -635,22 +635,29 @@ datasight tidy [OPTIONS] COMMAND [ARGS]...
 
 List detected untidy column shapes without changing the database.
 
+Pass one or more CSV / Parquet / Excel / DuckDB files as positional
+arguments to inspect them in an ephemeral session — no project setup
+required. With no files, runs against the current project's database.
+
 Examples:
 
 ```
-datasight tidy suggest
+datasight tidy suggest                           # current project
+datasight tidy suggest monthly_generation.csv    # standalone file
+datasight tidy suggest gen.csv plants.parquet    # multiple files
 datasight tidy suggest --table sales_wide
 datasight tidy suggest --format markdown -o tidy.md
 ```
 
 ```bash
-datasight tidy suggest [OPTIONS]
+datasight tidy suggest [OPTIONS] [FILES]...
 ```
 
 **Parameters**
 
 | Name | Details |
 | --- | --- |
+| `FILES` |   |
 | `--project-dir` | Project directory containing .env and config files. Default: `.`. |
 | `--table` | Scope tidy detection to a specific source table. |
 | `--format` | Output format (default: table). Default: `table`. |

--- a/docs/use/how-to/audit-data-quality.md
+++ b/docs/use/how-to/audit-data-quality.md
@@ -163,9 +163,13 @@ name are replaced. After the view or table exists, reference it in your
 `SELECT year, SUM(sales) FROM sales_wide_long GROUP BY year` over wide-column
 arithmetic.
 
-The generated SQL is portable `UNION ALL` — it survives DuckDB's view storage
-and is also valid SQLite / PostgreSQL, though `tidy view` and `tidy table`
-currently only execute against DuckDB project databases.
+The inner `SELECT … UNION ALL …` body is portable to SQLite and PostgreSQL,
+but the surrounding `CREATE OR REPLACE VIEW` / `CREATE OR REPLACE TABLE`
+wrapper is DuckDB-specific (PostgreSQL has no `CREATE OR REPLACE TABLE`,
+SQLite has no `CREATE OR REPLACE VIEW`). `tidy view` and `tidy table`
+correspondingly only execute against DuckDB project databases — paste the
+`SELECT` body into the equivalent `CREATE VIEW` / `CREATE TABLE AS` syntax
+yourself if your project runs on a different backend.
 
 ## Find measures
 

--- a/docs/use/how-to/audit-data-quality.md
+++ b/docs/use/how-to/audit-data-quality.md
@@ -63,6 +63,110 @@ Use it to spot:
 - quick notes worth turning into follow-up questions
 - temporal completeness issues when [`time_series.yaml`](../../project-setup/how-to/declare-time-series.md) is present
 
+## Detect untidy column shapes
+
+`datasight quality` also flags tables whose **column names encode dimension
+values** — a common spreadsheet shape that confuses both DuckDB and the LLM
+agent. To list, preview, or apply reshapes, use the dedicated
+`datasight tidy` command described below.
+
+### What "tidy" means
+
+A *tidy* dataset, as defined by Hadley Wickham in [Tidy
+Data](https://www.jstatsoft.org/article/view/v059i10) (J. Stat. Softw., 2014),
+follows three rules:
+
+1. each variable forms a column,
+2. each observation forms a row,
+3. each type of observational unit forms a table.
+
+In a tidy `generation_fuel` table, that means one row per *(plant, date, fuel)*
+observation, with `net_generation_mwh` as a single column — not 12 columns
+named `jan`, `feb`, `mar`, … or 24 columns named `hour_00`, `hour_01`, ….
+When dimension values (year, month, quarter, hour, day) live in the column
+headers, the data is *untidy* and queries become awkward (e.g. "average across
+months" turns into a SUM across 12 columns instead of a `GROUP BY month`).
+
+For a longer treatment with worked examples, the R for Data Science chapter
+[Data tidying](https://r4ds.hadley.nz/data-tidy) walks through the same ideas
+with concrete reshapes.
+
+### What datasight detects
+
+The `quality` command flags two structural patterns from the schema alone — no
+extra SQL is issued:
+
+- **Period values in column names** — three or more columns whose names match
+  a recognized year, year-month, year-quarter, quarter, month, hour, or day
+  token. Both shared-prefix shapes (`sales_2020`, `sales_2021`, `sales_2022`)
+  and bare-token shapes (`q1`, `q2`, `q3`, `q4` or `hour_00` … `hour_23`) are
+  recognized.
+- **Wide tables with low row counts** — tables with 30 or more columns where
+  the row count is comparable to the column count. This is a softer note,
+  emitted only when no period pattern is detected.
+
+### List suggestions: `datasight tidy suggest`
+
+To inspect the suggestions on their own, use:
+
+```bash
+datasight tidy suggest
+datasight tidy suggest --table sales_wide
+datasight tidy suggest --format markdown -o tidy.md
+```
+
+Example output:
+
+```
+$ datasight tidy suggest --table sales_wide --format markdown
+# Tidy Reshape Suggestions
+
+- Tables scanned: 1
+
+## Suggestions
+- `sales_wide` (repeated_prefix_period, year, 4 columns): Columns share prefix
+  `sales` with year suffixes — 4 columns look like a single measure spread
+  across year values.
+
+  ```sql
+  CREATE OR REPLACE VIEW "sales_wide_long" AS
+  SELECT "region", '2020' AS "year", "sales_2020" AS "sales" FROM "sales_wide"
+  UNION ALL SELECT "region", '2021', "sales_2021" FROM "sales_wide"
+  UNION ALL SELECT "region", '2022', "sales_2022" FROM "sales_wide"
+  UNION ALL SELECT "region", '2023', "sales_2023" FROM "sales_wide";
+  ```
+```
+
+### Apply a reshape: `datasight tidy view` / `tidy table`
+
+Two sibling subcommands write the long-form object directly to the project's
+DuckDB database. Both accept `--dry-run` to preview the DDL without executing
+it:
+
+```bash
+# Preview the view DDL
+datasight tidy view --dry-run
+
+# Create one long-form view per suggestion (CREATE OR REPLACE VIEW)
+datasight tidy view
+
+# Materialize as physical tables instead (CREATE OR REPLACE TABLE)
+datasight tidy table
+
+# Scope to a single source table
+datasight tidy view --table sales_wide
+```
+
+The default target name is `<source_table>_long`; existing objects with that
+name are replaced. After the view or table exists, reference it in your
+`schema_description.md` so the LLM agent prefers tidy queries like
+`SELECT year, SUM(sales) FROM sales_wide_long GROUP BY year` over wide-column
+arithmetic.
+
+The generated SQL is portable `UNION ALL` — it survives DuckDB's view storage
+and is also valid SQLite / PostgreSQL, though `tidy view` and `tidy table`
+currently only execute against DuckDB project databases.
+
 ## Find measures
 
 `datasight measures` infers likely metrics and their aggregation semantics:
@@ -237,7 +341,7 @@ directory name appears in the report title.
 For a thorough data quality audit, run the commands in this order:
 
 1. **Profile** — understand the shape of the data
-2. **Quality** — find nulls, range issues, and date gaps
+2. **Quality** — find nulls, range issues, date gaps, and untidy column shapes
 3. **Integrity** — verify primary keys, foreign keys, and join behavior
 4. **Distribution** — inspect percentiles, outliers, and temporal spikes
 5. **Measures** — identify metrics and verify aggregation defaults

--- a/docs/use/how-to/audit-data-quality.md
+++ b/docs/use/how-to/audit-data-quality.md
@@ -110,10 +110,16 @@ extra SQL is issued:
 To inspect the suggestions on their own, use:
 
 ```bash
-datasight tidy suggest
+datasight tidy suggest                        # current project
+datasight tidy suggest sales_wide.csv         # standalone file, no project
+datasight tidy suggest gen.csv plants.parquet # multiple files
 datasight tidy suggest --table sales_wide
 datasight tidy suggest --format markdown -o tidy.md
 ```
+
+When you pass file arguments, datasight registers them in an ephemeral
+DuckDB session and skips project loading entirely — useful for the "is
+this spreadsheet untidy?" question before committing to project setup.
 
 Example output:
 

--- a/docs/use/how-to/audit-data-quality.md
+++ b/docs/use/how-to/audit-data-quality.md
@@ -135,11 +135,17 @@ $ datasight tidy suggest --table sales_wide --format markdown
   across year values.
 
   ```sql
-  CREATE OR REPLACE VIEW "sales_wide_long" AS
-  SELECT "region", '2020' AS "year", "sales_2020" AS "sales" FROM "sales_wide"
-  UNION ALL SELECT "region", '2021', "sales_2021" FROM "sales_wide"
-  UNION ALL SELECT "region", '2022', "sales_2022" FROM "sales_wide"
-  UNION ALL SELECT "region", '2023', "sales_2023" FROM "sales_wide";
+  CREATE OR REPLACE TABLE "sales_wide_long" AS
+  SELECT * FROM (
+    UNPIVOT "sales_wide"
+    ON "sales_2020" AS '2020',
+      "sales_2021" AS '2021',
+      "sales_2022" AS '2022',
+      "sales_2023" AS '2023'
+    INTO
+      NAME "year"
+      VALUE "sales"
+  );
   ```
 ```
 
@@ -150,32 +156,37 @@ DuckDB database. Both accept `--dry-run` to preview the DDL without executing
 it:
 
 ```bash
-# Preview the view DDL
-datasight tidy view --dry-run
-
-# Create one long-form view per suggestion (CREATE OR REPLACE VIEW)
-datasight tidy view
-
-# Materialize as physical tables instead (CREATE OR REPLACE TABLE)
+# Materialize a physical table — the recommended default
 datasight tidy table
 
+# Preview the table DDL first
+datasight tidy table --dry-run
+
+# Or create a view that re-evaluates against the source on every query
+datasight tidy view
+
 # Scope to a single source table
-datasight tidy view --table sales_wide
+datasight tidy table --table sales_wide
 ```
 
 The default target name is `<source_table>_long`; existing objects with that
-name are replaced. After the view or table exists, reference it in your
+name are replaced. After the table or view exists, reference it in your
 `schema_description.md` so the LLM agent prefers tidy queries like
 `SELECT year, SUM(sales) FROM sales_wide_long GROUP BY year` over wide-column
 arithmetic.
 
-The inner `SELECT … UNION ALL …` body is portable to SQLite and PostgreSQL,
-but the surrounding `CREATE OR REPLACE VIEW` / `CREATE OR REPLACE TABLE`
-wrapper is DuckDB-specific (PostgreSQL has no `CREATE OR REPLACE TABLE`,
-SQLite has no `CREATE OR REPLACE VIEW`). `tidy view` and `tidy table`
-correspondingly only execute against DuckDB project databases — paste the
-`SELECT` body into the equivalent `CREATE VIEW` / `CREATE TABLE AS` syntax
-yourself if your project runs on a different backend.
+!!! note "Why view and table emit different SQL"
+    `tidy table` emits the canonical DuckDB `UNPIVOT` form. `tidy view`
+    falls back to `UNION ALL` branches because of a regression in the
+    Python `duckdb` 1.5.2 binding — UNPIVOT stored inside a view fails to
+    re-bind on a fresh connection through that binding, raising
+    `Binder Error: UNPIVOT name count mismatch`. The standalone `duckdb`
+    CLI 1.5.1 doesn't reproduce the failure, but every datasight query
+    path (the agent, the web UI, `datasight ask`) goes through the Python
+    binding, so views created without the workaround would break for any
+    in-datasight consumer. Materialized tables don't re-bind, so they
+    keep the cleaner form. Prefer `tidy table` unless you specifically
+    need the view's auto-update semantics.
 
 ## Find measures
 

--- a/docs/use/tutorials/tidy.md
+++ b/docs/use/tutorials/tidy.md
@@ -1,0 +1,161 @@
+# Tidy a wide-month spreadsheet
+
+This tutorial walks through detecting and reshaping an "untidy" CSV — the
+kind of spreadsheet that arrives with one column per month, quarter, or
+year — into a tidy long-form view that the LLM agent (and DuckDB) can
+query naturally. Allow about five minutes. No API key required: every
+step in this tutorial is deterministic.
+
+For background on what "tidy" means, see Hadley Wickham's
+[Tidy Data](https://www.jstatsoft.org/article/view/v059i10) (J. Stat.
+Softw., 2014) or the [R for Data Science chapter on data
+tidying](https://r4ds.hadley.nz/data-tidy).
+
+## 1. Install datasight
+
+```bash
+uv tool install datasight
+```
+
+Don't have [uv](https://docs.astral.sh/uv/) yet? See
+[Install datasight](../how-to/install.md) for the one-line installer.
+
+## 2. Create a project directory
+
+```bash
+mkdir tidy-tutorial && cd tidy-tutorial
+```
+
+## 3. Save a wide CSV
+
+The CSV below mirrors a common spreadsheet shape: one row per plant, with
+twelve numeric columns named `jan` through `dec` holding monthly net
+generation (MWh).
+
+```bash
+cat > monthly_generation.csv <<'EOF'
+plant_id,fuel_type,jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec
+1,coal,180,165,140,120,110,100,95,105,130,160,175,200
+2,gas,220,200,180,170,160,175,200,220,210,200,215,230
+3,wind,150,145,160,175,190,200,195,180,170,155,145,140
+4,solar,60,90,130,175,215,240,245,225,180,130,90,55
+EOF
+```
+
+This is the *untidy* shape: the `month` dimension is hidden in the column
+headers, so a question like "average generation by month across plants"
+becomes an awkward sum across twelve columns instead of a `GROUP BY`.
+
+## 4. Load the CSV into DuckDB
+
+```bash
+uv run --with duckdb python -c "
+import duckdb
+conn = duckdb.connect('generation.duckdb')
+conn.execute('CREATE TABLE monthly_generation_mwh AS SELECT * FROM read_csv_auto(\"monthly_generation.csv\")')
+"
+```
+
+`uv run --with duckdb` runs Python with DuckDB available without
+installing it system-wide.
+
+## 5. Configure the project
+
+Create a `.env` so datasight knows which database to read:
+
+```bash
+cat > .env <<'EOF'
+DB_MODE=duckdb
+DB_PATH=generation.duckdb
+LLM_PROVIDER=anthropic
+ANTHROPIC_API_KEY=stub
+EOF
+```
+
+The `tidy` command is fully deterministic and doesn't call the LLM, so
+the `ANTHROPIC_API_KEY` value is a placeholder here — replace it with a
+real key only when you're ready to start asking questions.
+
+## 6. Detect untidy column shapes
+
+```bash
+datasight tidy suggest
+```
+
+You'll see:
+
+```
+                                  Suggestions
+┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┓
+┃ Source                 ┃ Target                      ┃ Pattern             ┃ Period ┃ Columns ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━┩
+│ monthly_generation_mwh │ monthly_generation_mwh_long │ date_in_column_…    │ month  │      12 │
+└────────────────────────┴─────────────────────────────┴─────────────────────┴────────┴─────────┘
+```
+
+datasight has spotted that twelve column names look like month tokens —
+`jan`, `feb`, … `dec` — and proposes to reshape the table into a long
+form named `monthly_generation_mwh_long`.
+
+## 7. Preview the reshape SQL
+
+Before writing anything to the database, see exactly what would run:
+
+```bash
+datasight tidy view --dry-run
+```
+
+You'll see a `CREATE OR REPLACE VIEW` statement built from a `UNION ALL`
+of twelve per-month `SELECT`s. The `id_columns` (`plant_id`, `fuel_type`)
+are carried through; the wide measure columns are stacked into a
+two-column `(month, value)` pair.
+
+## 8. Apply the reshape
+
+When the preview looks right, drop the `--dry-run` flag to write the
+view:
+
+```bash
+datasight tidy view
+```
+
+```
+Created view 'monthly_generation_mwh_long' from monthly_generation_mwh (12 columns)
+```
+
+If you'd rather materialize a physical table instead of a view, use
+`datasight tidy table`. The shape of the result is identical; the
+difference is whether the rows are computed on demand (view) or stored
+once (table).
+
+## 9. Query the tidy form
+
+```bash
+uv run --with duckdb python -c "
+import duckdb
+conn = duckdb.connect('generation.duckdb', read_only=True)
+rows = conn.execute('''
+  SELECT month, ROUND(AVG(value), 1) AS avg_mwh
+  FROM monthly_generation_mwh_long
+  GROUP BY month
+  ORDER BY month
+''').fetchall()
+for month, avg in rows:
+    print(f'{month}: {avg}')
+"
+```
+
+The same question on the wide table would have required summing twelve
+named columns by hand. With the long form, monthly aggregation is a
+plain `GROUP BY`.
+
+## What's next
+
+- **Point the agent at the long form.** Mention `monthly_generation_mwh_long`
+  and its columns in your `schema_description.md` so the LLM agent prefers
+  tidy queries. See [Write a schema description](../../project-setup/how-to/schema-description.md).
+- **Audit the rest of your data.** [Audit data quality](../how-to/audit-data-quality.md)
+  covers `datasight quality`, which surfaces tidy suggestions alongside
+  null/range/date-coverage checks during routine audits.
+- **Try a real dataset.** [Explore US electricity generation (EIA)](getting-started.md)
+  walks through the same loop on the PUDL EIA dataset.

--- a/docs/use/tutorials/tidy.md
+++ b/docs/use/tutorials/tidy.md
@@ -104,31 +104,33 @@ questions.
 Before writing anything to the database, see exactly what would run:
 
 ```bash
-datasight tidy view --dry-run
+datasight tidy table --dry-run
 ```
 
-You'll see a `CREATE OR REPLACE VIEW` statement built from a `UNION ALL`
-of twelve per-month `SELECT`s. The `id_columns` (`plant_id`, `fuel_type`)
-are carried through; the wide measure columns are stacked into a
+You'll see a `CREATE OR REPLACE TABLE` statement built around a DuckDB
+`UNPIVOT`. The id columns (`plant_id`, `fuel_type`) come through
+automatically; the twelve wide measure columns are stacked into a
 two-column `(month, value)` pair.
 
 ## 6. Apply the reshape
 
-When the preview looks right, drop the `--dry-run` flag to write the
-view:
+When the preview looks right, drop the `--dry-run` flag:
 
 ```bash
-datasight tidy view
+datasight tidy table
 ```
 
 ```
-Created view 'monthly_generation_mwh_long' from monthly_generation_mwh (12 columns)
+Created table 'monthly_generation_mwh_long' from monthly_generation_mwh (12 columns)
 ```
 
-If you'd rather materialize a physical table instead of a view, use
-`datasight tidy table`. The shape of the result is identical; the
-difference is whether the rows are computed on demand (view) or stored
-once (table).
+`datasight tidy view` is also available if you want a view that
+re-evaluates against the source on every query (useful when the source
+table is updated periodically). Because of a regression in the Python
+`duckdb` 1.5.2 binding that breaks UNPIVOT inside views, `tidy view`
+emits a `UNION ALL` form instead — the result is identical but the SQL
+is more verbose. Prefer `tidy table` unless you specifically need view
+semantics.
 
 ## 7. Query the tidy form
 

--- a/docs/use/tutorials/tidy.md
+++ b/docs/use/tutorials/tidy.md
@@ -20,13 +20,7 @@ uv tool install datasight
 Don't have [uv](https://docs.astral.sh/uv/) yet? See
 [Install datasight](../how-to/install.md) for the one-line installer.
 
-## 2. Create a project directory
-
-```bash
-mkdir tidy-tutorial && cd tidy-tutorial
-```
-
-## 3. Save a wide CSV
+## 2. Save a wide CSV
 
 The CSV below mirrors a common spreadsheet shape: one row per plant, with
 twelve numeric columns named `jan` through `dec` holding monthly net
@@ -46,43 +40,14 @@ This is the *untidy* shape: the `month` dimension is hidden in the column
 headers, so a question like "average generation by month across plants"
 becomes an awkward sum across twelve columns instead of a `GROUP BY`.
 
-## 4. Load the CSV into DuckDB
+## 3. Detect untidy column shapes — no setup required
+
+Point `datasight tidy suggest` straight at the CSV. It runs in an
+ephemeral DuckDB session, so no project directory or `.env` is needed:
 
 ```bash
-uv run --with duckdb python -c "
-import duckdb
-conn = duckdb.connect('generation.duckdb')
-conn.execute('CREATE TABLE monthly_generation_mwh AS SELECT * FROM read_csv_auto(\"monthly_generation.csv\")')
-"
+datasight tidy suggest monthly_generation.csv
 ```
-
-`uv run --with duckdb` runs Python with DuckDB available without
-installing it system-wide.
-
-## 5. Configure the project
-
-Create a `.env` so datasight knows which database to read:
-
-```bash
-cat > .env <<'EOF'
-DB_MODE=duckdb
-DB_PATH=generation.duckdb
-LLM_PROVIDER=anthropic
-ANTHROPIC_API_KEY=stub
-EOF
-```
-
-The `tidy` command is fully deterministic and doesn't call the LLM, so
-the `ANTHROPIC_API_KEY` value is a placeholder here — replace it with a
-real key only when you're ready to start asking questions.
-
-## 6. Detect untidy column shapes
-
-```bash
-datasight tidy suggest
-```
-
-You'll see:
 
 ```
                                   Suggestions
@@ -97,7 +62,44 @@ datasight has spotted that twelve column names look like month tokens —
 `jan`, `feb`, … `dec` — and proposes to reshape the table into a long
 form named `monthly_generation_mwh_long`.
 
-## 7. Preview the reshape SQL
+You can also pass several files at once, or `parquet` / `xlsx` / `duckdb`
+sources:
+
+```bash
+datasight tidy suggest data/*.csv
+datasight tidy suggest hourly.parquet plants.duckdb
+```
+
+## 4. Set up a project to apply the reshape
+
+`tidy suggest` is read-only and ephemeral, but applying the reshape
+(`tidy view` or `tidy table`) needs a writable database. That means
+loading the CSV into a DuckDB file and pointing a `.env` at it.
+
+```bash
+mkdir tidy-tutorial && mv monthly_generation.csv tidy-tutorial && cd tidy-tutorial
+
+uv run --with duckdb python -c "
+import duckdb
+conn = duckdb.connect('generation.duckdb')
+conn.execute('CREATE TABLE monthly_generation_mwh AS SELECT * FROM read_csv_auto(\"monthly_generation.csv\")')
+"
+
+cat > .env <<'EOF'
+DB_MODE=duckdb
+DB_PATH=generation.duckdb
+LLM_PROVIDER=anthropic
+ANTHROPIC_API_KEY=stub
+EOF
+```
+
+`uv run --with duckdb` runs Python with DuckDB available without
+installing it system-wide. The `tidy` command is fully deterministic and
+doesn't call the LLM, so the `ANTHROPIC_API_KEY` value is a placeholder
+here — replace it with a real key only when you're ready to start asking
+questions.
+
+## 5. Preview the reshape SQL
 
 Before writing anything to the database, see exactly what would run:
 
@@ -110,7 +112,7 @@ of twelve per-month `SELECT`s. The `id_columns` (`plant_id`, `fuel_type`)
 are carried through; the wide measure columns are stacked into a
 two-column `(month, value)` pair.
 
-## 8. Apply the reshape
+## 6. Apply the reshape
 
 When the preview looks right, drop the `--dry-run` flag to write the
 view:
@@ -128,7 +130,7 @@ If you'd rather materialize a physical table instead of a view, use
 difference is whether the rows are computed on demand (view) or stored
 once (table).
 
-## 9. Query the tidy form
+## 7. Query the tidy form
 
 ```bash
 uv run --with duckdb python -c "

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - Tutorials:
           - Explore US electricity generation (EIA): use/tutorials/getting-started.md
           - Explore EV charging demand (TEMPO): use/tutorials/tempo.md
+          - Tidy a wide-month spreadsheet: use/tutorials/tidy.md
       - How-to guides:
           - Install datasight: use/how-to/install.md
           - Explore files without a project: use/how-to/explore-files.md

--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -520,6 +520,22 @@ def _render_quality_markdown(quality_data: dict[str, Any]) -> str:
             lines.append(
                 f"- `{item['table']}.{item['timestamp_column']}` [{item['issue']}]: {item['detail']}"
             )
+    if quality_data.get("tidy_suggestions"):
+        lines.extend(["", "## Tidy Reshape Suggestions"])
+        for item in quality_data["tidy_suggestions"]:
+            lines.append(
+                f"- `{item['table']}` ({item['pattern']}, {item['period_kind']}, "
+                f"{len(item['affected_columns'])} columns): {item['rationale']}"
+            )
+            lines.append("")
+            lines.append("  ```sql")
+            for sql_line in item["reshape_sql"].splitlines():
+                lines.append(f"  {sql_line}")
+            lines.append("  ```")
+    if quality_data.get("wide_tables"):
+        lines.extend(["", "## Wide Tables"])
+        for item in quality_data["wide_tables"]:
+            lines.append(f"- `{item['table']}`: {item['reason']}")
     if quality_data["notes"]:
         lines.extend(["", "## Notes"])
         for item in quality_data["notes"]:
@@ -729,6 +745,42 @@ def _render_validation_markdown(data: dict[str, Any]) -> str:
             lines.append(
                 f"- [{r['status'].upper()}] `{r['table']}` {r['rule']}{col}: {r['detail']}"
             )
+    return "\n".join(lines)
+
+
+def _render_tidy_markdown(data: dict[str, Any]) -> str:
+    lines = [
+        "# Tidy Reshape Suggestions",
+        "",
+        f"- Tables scanned: {data['table_count']}",
+    ]
+    suggestions = data.get("period_suggestions") or []
+    wide_tables = data.get("wide_tables") or []
+    if suggestions:
+        lines.extend(["", "## Suggestions"])
+        for item in suggestions:
+            lines.append(
+                f"- `{item['table']}` ({item['pattern']}, {item['period_kind']}, "
+                f"{len(item['affected_columns'])} columns): {item['rationale']}"
+            )
+            lines.append("")
+            lines.append("  ```sql")
+            for sql_line in item["reshape_sql"].splitlines():
+                lines.append(f"  {sql_line}")
+            lines.append("  ```")
+    if wide_tables:
+        lines.extend(["", "## Wide Tables"])
+        for item in wide_tables:
+            lines.append(f"- `{item['table']}`: {item['reason']}")
+    if data.get("applied"):
+        lines.extend(["", "## Applied"])
+        for item in data["applied"]:
+            lines.append(
+                f"- Created {item['object_type']} `{item['suggested_view']}` "
+                f"from `{item['table']}` ({len(item['affected_columns'])} columns)"
+            )
+    if not suggestions and not wide_tables:
+        lines.extend(["", "_No untidy column-shape patterns detected._"])
     return "\n".join(lines)
 
 
@@ -1421,6 +1473,7 @@ def _register_commands() -> None:
     from datasight.cli_commands.run import run
     from datasight.cli_commands.session import session
     from datasight.cli_commands.templates import templates
+    from datasight.cli_commands.tidy import tidy
     from datasight.cli_commands.trends import trends
     from datasight.cli_commands.validate import validate
     from datasight.cli_commands.verify import verify
@@ -1436,6 +1489,7 @@ def _register_commands() -> None:
     cli.add_command(profile)
     cli.add_command(measures)
     cli.add_command(quality)
+    cli.add_command(tidy)
     cli.add_command(integrity)
     cli.add_command(distribution)
     cli.add_command(validate)

--- a/src/datasight/cli_commands/quality.py
+++ b/src/datasight/cli_commands/quality.py
@@ -103,6 +103,7 @@ def quality(project_dir, table, output_format, output_path):
 
     from datasight.config import load_time_series_config
     from datasight.data_profile import build_time_series_quality
+    from datasight.tidy import analyze_tidy_patterns
 
     time_series_configs = load_time_series_config(None, project_dir)
 
@@ -121,6 +122,9 @@ def quality(project_dir, table, output_format, output_path):
             ts_data = await build_time_series_quality(ts_configs, sql_runner.run_sql)
             base["time_series_issues"] = ts_data.get("time_series_issues", [])
             base["time_series_summaries"] = ts_data.get("time_series_summaries", [])
+        tidy = analyze_tidy_patterns(schema_info)
+        base["tidy_suggestions"] = tidy["period_suggestions"]
+        base["wide_tables"] = tidy["wide_tables"]
         return base
 
     quality_data = asyncio.run(_run_quality())
@@ -209,6 +213,45 @@ def quality(project_dir, table, output_format, output_path):
                         item["detail"],
                     ]
                     for item in quality_data["time_series_issues"]
+                ],
+            )
+        )
+    if quality_data.get("tidy_suggestions"):
+        console.print(
+            _build_profile_detail_table(
+                "Tidy Reshape Suggestions",
+                [
+                    ("Table", "left"),
+                    ("Pattern", "left"),
+                    ("Period", "left"),
+                    ("Columns", "right"),
+                    ("Rationale", "left"),
+                ],
+                [
+                    [
+                        item["table"],
+                        item["pattern"],
+                        item["period_kind"],
+                        str(len(item["affected_columns"])),
+                        item["rationale"],
+                    ]
+                    for item in quality_data["tidy_suggestions"]
+                ],
+            )
+        )
+    if quality_data.get("wide_tables"):
+        console.print(
+            _build_profile_detail_table(
+                "Wide Tables",
+                [("Table", "left"), ("Columns", "right"), ("Rows", "right"), ("Reason", "left")],
+                [
+                    [
+                        item["table"],
+                        str(item["column_count"]),
+                        str(item.get("row_count") if item.get("row_count") is not None else "?"),
+                        item["reason"],
+                    ]
+                    for item in quality_data["wide_tables"]
                 ],
             )
         )

--- a/src/datasight/cli_commands/tidy.py
+++ b/src/datasight/cli_commands/tidy.py
@@ -1,0 +1,338 @@
+# ruff: noqa: F401, F403, F405
+"""CLI command module."""
+
+from datasight import cli as cli_root
+from datasight.cli import *  # noqa: F403
+from datasight.cli import (
+    _build_metric_table,
+    _build_profile_detail_table,
+    _build_sql_script,
+    _configure_logging,
+    _current_db_settings_or_none,
+    _default_chart_extension,
+    _default_data_extension,
+    _emit_ask_result,
+    _emit_cli_provenance,
+    _epilog,
+    _fmt_dist,
+    _format_profile_value,
+    _iter_sql_tool_results,
+    _load_batch_entries,
+    _load_recipe_entries,
+    _load_schema_info_for_project,
+    _prepare_web_runtime,
+    _print_sql_queries,
+    _question_table_prefix,
+    _render_dimensions_markdown,
+    _render_distribution_markdown,
+    _render_doctor_markdown,
+    _render_integrity_markdown,
+    _render_measures_markdown,
+    _render_profile_markdown,
+    _render_quality_markdown,
+    _render_recipes_markdown,
+    _render_tidy_markdown,
+    _render_trends_markdown,
+    _render_validation_markdown,
+    _resolve_db_path,
+    _resolve_settings,
+    _sanitize_sql_identifier,
+    _slugify_filename,
+    _sql_comment_lines,
+    _validate_batch_entry,
+    _validate_settings_for_llm,
+    _write_batch_result_files,
+    _write_or_print,
+)
+
+
+def create_llm_client(*args, **kwargs):
+    return cli_root.create_llm_client(*args, **kwargs)
+
+
+async def _run_ask_pipeline(*args, **kwargs):
+    return await cli_root._run_ask_pipeline(*args, **kwargs)
+
+
+def _project_scope_options(func):
+    """Add the --project-dir and --table options shared by all tidy subcommands."""
+    func = click.option(
+        "--table",
+        "source_table",
+        default=None,
+        help="Scope tidy detection to a specific source table.",
+    )(func)
+    func = click.option(
+        "--project-dir",
+        type=click.Path(exists=True),
+        default=".",
+        help="Project directory containing .env and config files.",
+    )(func)
+    return func
+
+
+async def _gather_tidy_data(project_dir: str, source_table: str | None, settings):
+    from datasight.tidy import _detect_period_groups, analyze_tidy_patterns
+
+    sql_runner, schema_info = await _load_schema_info_for_project(project_dir, settings)
+    try:
+        if source_table:
+            table_info = find_table_info(schema_info, source_table)
+            if table_info is None:
+                raise click.ClickException(f"Table not found: {source_table}")
+            schema_info = [table_info]
+        data = analyze_tidy_patterns(schema_info)
+        suggestions_by_table = {t["name"]: _detect_period_groups(t) for t in schema_info}
+        return data, suggestions_by_table
+    finally:
+        sql_runner.close()
+
+
+def _resolve_tidy_settings(project_dir: str) -> tuple[Any, str, str]:
+    project_dir = str(Path(project_dir).resolve())
+    settings, _ = _resolve_settings(project_dir)
+    resolved_db_path = _resolve_db_path(settings, project_dir)
+    if settings.database.mode in ("duckdb", "sqlite") and not os.path.exists(resolved_db_path):
+        click.echo(f"Error: Database file not found: {resolved_db_path}", err=True)
+        sys.exit(1)
+    return settings, project_dir, resolved_db_path
+
+
+def _apply_reshapes(
+    suggestions_by_table: dict[str, list[Any]],
+    mode: str,
+    dry_run: bool,
+    resolved_db_path: str,
+) -> list[dict[str, Any]]:
+    """Apply (or preview) tidy suggestions and return a per-statement audit log."""
+    ddl_statements: list[tuple[str, Any]] = [
+        (source_table, suggestion)
+        for source_table, suggestions in suggestions_by_table.items()
+        for suggestion in suggestions
+    ]
+    applied: list[dict[str, Any]] = []
+    if not ddl_statements:
+        click.echo("No untidy column-shape patterns detected.")
+        return applied
+
+    if dry_run:
+        for source_table, suggestion in ddl_statements:
+            click.echo(f"-- Would apply for {source_table}:")
+            click.echo(suggestion.build_sql(mode))
+    else:
+        import duckdb
+
+        conn = duckdb.connect(resolved_db_path)
+        try:
+            for source_table, suggestion in ddl_statements:
+                conn.execute(suggestion.build_sql(mode))
+                click.echo(
+                    f"Created {mode} {suggestion.suggested_view!r} "
+                    f"from {source_table} ({len(suggestion.affected_columns)} columns)"
+                )
+        finally:
+            conn.close()
+
+    for source_table, suggestion in ddl_statements:
+        applied.append(
+            {
+                "table": source_table,
+                "suggested_view": suggestion.suggested_view,
+                "object_type": mode,
+                "affected_columns": suggestion.affected_columns,
+                "dry_run": dry_run,
+            }
+        )
+    return applied
+
+
+@click.group(
+    epilog=_epilog(
+        """
+        Examples:
+
+            datasight tidy suggest
+            datasight tidy suggest --table sales_wide
+            datasight tidy view --dry-run
+            datasight tidy view
+            datasight tidy table --table sales_wide
+        """
+    )
+)
+def tidy():
+    """Detect untidy column shapes and reshape into long form.
+
+    Use 'tidy suggest' to inspect candidates, 'tidy view' to create
+    long-form views, or 'tidy table' to materialize long-form tables.
+    Detection is deterministic — column names plus dtypes plus row counts —
+    so no LLM is involved.
+    """
+
+
+@click.command(
+    name="suggest",
+    epilog=_epilog(
+        """
+        Examples:
+
+            datasight tidy suggest
+            datasight tidy suggest --table sales_wide
+            datasight tidy suggest --format markdown -o tidy.md
+        """
+    ),
+)
+@_project_scope_options
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json", "markdown"]),
+    default="table",
+    help="Output format (default: table).",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    type=click.Path(),
+    default=None,
+    help="Write the tidy listing to a file instead of stdout.",
+)
+def tidy_suggest(project_dir, source_table, output_format, output_path):
+    """List detected untidy column shapes without changing the database."""
+    from rich.console import Console
+
+    settings, project_dir, _ = _resolve_tidy_settings(project_dir)
+    tidy_data, _ = asyncio.run(_gather_tidy_data(project_dir, source_table, settings))
+
+    if output_format == "json":
+        _write_or_print(json.dumps(tidy_data, indent=2), output_path)
+        return
+
+    if output_format == "markdown":
+        _write_or_print(_render_tidy_markdown(tidy_data), output_path)
+        return
+
+    console = Console(record=bool(output_path))
+    console.print(
+        _build_metric_table(
+            "Tidy Reshape Suggestions",
+            [
+                ("Tables scanned", str(tidy_data["table_count"])),
+                ("Suggestions", str(len(tidy_data.get("period_suggestions") or []))),
+            ],
+        )
+    )
+    suggestions = tidy_data.get("period_suggestions") or []
+    if suggestions:
+        console.print(
+            _build_profile_detail_table(
+                "Suggestions",
+                [
+                    ("Source", "left"),
+                    ("Target", "left"),
+                    ("Pattern", "left"),
+                    ("Period", "left"),
+                    ("Columns", "right"),
+                    ("Rationale", "left"),
+                ],
+                [
+                    [
+                        item["table"],
+                        item["suggested_view"],
+                        item["pattern"],
+                        item["period_kind"],
+                        str(len(item["affected_columns"])),
+                        item["rationale"],
+                    ]
+                    for item in suggestions
+                ],
+            )
+        )
+    wide_tables = tidy_data.get("wide_tables") or []
+    if wide_tables:
+        console.print(
+            _build_profile_detail_table(
+                "Wide Tables",
+                [("Table", "left"), ("Columns", "right"), ("Rows", "right"), ("Reason", "left")],
+                [
+                    [
+                        item["table"],
+                        str(item["column_count"]),
+                        str(item.get("row_count") if item.get("row_count") is not None else "?"),
+                        item["reason"],
+                    ]
+                    for item in wide_tables
+                ],
+            )
+        )
+    if not suggestions and not wide_tables:
+        console.print("[dim]No untidy column-shape patterns detected.[/dim]")
+    if output_path:
+        _write_or_print(console.export_text(), output_path)
+
+
+@click.command(
+    name="view",
+    epilog=_epilog(
+        """
+        Examples:
+
+            datasight tidy view
+            datasight tidy view --dry-run
+            datasight tidy view --table sales_wide
+        """
+    ),
+)
+@_project_scope_options
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print the DDL without executing it.",
+)
+def tidy_view(project_dir, source_table, dry_run):
+    """Create CREATE OR REPLACE VIEW <table>_long for each detected pattern."""
+    settings, project_dir, resolved_db_path = _resolve_tidy_settings(project_dir)
+    if settings.database.mode != "duckdb":
+        raise click.UsageError(
+            "tidy view requires DuckDB; the apply path opens a writable DuckDB connection."
+        )
+    _, suggestions_by_table = asyncio.run(_gather_tidy_data(project_dir, source_table, settings))
+    _apply_reshapes(suggestions_by_table, "view", dry_run, resolved_db_path)
+
+
+@click.command(
+    name="table",
+    epilog=_epilog(
+        """
+        Examples:
+
+            datasight tidy table
+            datasight tidy table --dry-run
+            datasight tidy table --table sales_wide
+        """
+    ),
+)
+@_project_scope_options
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print the DDL without executing it.",
+)
+def tidy_table(project_dir, source_table, dry_run):
+    """Materialize CREATE OR REPLACE TABLE <table>_long for each detected pattern."""
+    settings, project_dir, resolved_db_path = _resolve_tidy_settings(project_dir)
+    if settings.database.mode != "duckdb":
+        raise click.UsageError(
+            "tidy table requires DuckDB; the apply path opens a writable DuckDB connection."
+        )
+    _, suggestions_by_table = asyncio.run(_gather_tidy_data(project_dir, source_table, settings))
+    _apply_reshapes(suggestions_by_table, "table", dry_run, resolved_db_path)
+
+
+tidy.add_command(tidy_suggest)
+tidy.add_command(tidy_view)
+tidy.add_command(tidy_table)

--- a/src/datasight/cli_commands/tidy.py
+++ b/src/datasight/cli_commands/tidy.py
@@ -88,6 +88,36 @@ async def _gather_tidy_data(project_dir: str, source_table: str | None, settings
         sql_runner.close()
 
 
+async def _gather_tidy_data_for_files(files: tuple[str, ...]):
+    """Like ``_gather_tidy_data`` but registers ``files`` in an ephemeral DuckDB.
+
+    No project / .env required; mirrors the file-mode entry point used by
+    ``datasight inspect``. The returned ``suggestions_by_table`` is empty
+    on this path because ephemeral file sessions can't usefully persist a
+    reshape — callers should treat file mode as suggest-only.
+    """
+    from datasight.explore import create_files_session_for_settings
+    from datasight.schema import introspect_schema
+    from datasight.tidy import analyze_tidy_patterns
+
+    runner, _tables_info = create_files_session_for_settings(list(files), None)
+    try:
+        tables = await introspect_schema(runner.run_sql, runner=runner)
+        schema_info = [
+            {
+                "name": t.name,
+                "row_count": t.row_count,
+                "columns": [
+                    {"name": c.name, "dtype": c.dtype, "nullable": c.nullable} for c in t.columns
+                ],
+            }
+            for t in tables
+        ]
+        return analyze_tidy_patterns(schema_info)
+    finally:
+        runner.close()
+
+
 def _resolve_tidy_settings(project_dir: str) -> tuple[Any, str, str]:
     project_dir = str(Path(project_dir).resolve())
     settings, _ = _resolve_settings(project_dir)
@@ -175,12 +205,15 @@ def tidy():
         """
         Examples:
 
-            datasight tidy suggest
+            datasight tidy suggest                           # current project
+            datasight tidy suggest monthly_generation.csv    # standalone file
+            datasight tidy suggest gen.csv plants.parquet    # multiple files
             datasight tidy suggest --table sales_wide
             datasight tidy suggest --format markdown -o tidy.md
         """
     ),
 )
+@click.argument("files", nargs=-1, required=False, type=click.Path(exists=True))
 @_project_scope_options
 @click.option(
     "--format",
@@ -197,12 +230,25 @@ def tidy():
     default=None,
     help="Write the tidy listing to a file instead of stdout.",
 )
-def tidy_suggest(project_dir, source_table, output_format, output_path):
-    """List detected untidy column shapes without changing the database."""
+def tidy_suggest(files, project_dir, source_table, output_format, output_path):
+    """List detected untidy column shapes without changing the database.
+
+    Pass one or more CSV / Parquet / Excel / DuckDB files as positional
+    arguments to inspect them in an ephemeral session — no project setup
+    required. With no files, runs against the current project's database.
+    """
     from rich.console import Console
 
-    settings, project_dir, _ = _resolve_tidy_settings(project_dir)
-    tidy_data, _ = asyncio.run(_gather_tidy_data(project_dir, source_table, settings))
+    if files:
+        if source_table:
+            raise click.UsageError(
+                "--table cannot be combined with positional FILES; "
+                "scope is implicit when files are passed."
+            )
+        tidy_data = asyncio.run(_gather_tidy_data_for_files(files))
+    else:
+        settings, project_dir, _ = _resolve_tidy_settings(project_dir)
+        tidy_data, _ = asyncio.run(_gather_tidy_data(project_dir, source_table, settings))
 
     if output_format == "json":
         _write_or_print(json.dumps(tidy_data, indent=2), output_path)

--- a/src/datasight/tidy.py
+++ b/src/datasight/tidy.py
@@ -1,0 +1,369 @@
+"""Detect untidy dataset patterns and suggest tidy-reshape views.
+
+Inspects table schemas and flags columns whose names appear to encode a
+dimension value (year, month, quarter, hour, day) rather than holding a
+single measure across rows. Each suggestion is paired with a previewable
+DuckDB ``UNPIVOT`` statement so users can inspect or materialize the
+reshape via ``CREATE VIEW``.
+
+The detection is deterministic and purely structural (column names plus
+dtypes plus row count), so it can run as part of the schema inspection
+pass without issuing extra SQL.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from datasight.schema import _quote_identifier
+
+MIN_GROUP_SIZE = 3
+WIDE_TABLE_COLUMN_THRESHOLD = 30
+
+_MONTH_TOKENS: frozenset[str] = frozenset(
+    {
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "may",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "sept",
+        "oct",
+        "nov",
+        "dec",
+        "january",
+        "february",
+        "march",
+        "april",
+        "june",
+        "july",
+        "august",
+        "september",
+        "october",
+        "november",
+        "december",
+    }
+)
+
+_PERIOD_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("year_month", re.compile(r"^(?:19|20)\d{2}[-_]?(?:0[1-9]|1[0-2])$")),
+    ("year_quarter", re.compile(r"^(?:19|20)\d{2}[-_]?q[1-4]$")),
+    ("year", re.compile(r"^(?:y|yr|year)?(?:19|20)\d{2}$")),
+    ("quarter", re.compile(r"^q[1-4]$")),
+    ("hour", re.compile(r"^h(?:our|r)?[-_]?(?:0?\d|1\d|2[0-3])$")),
+    ("day", re.compile(r"^d(?:ay)?[-_]?(?:0?[1-9]|[12]\d|3[01])$")),
+    ("month_num", re.compile(r"^m(?:onth|o)?[-_]?(?:0?[1-9]|1[0-2])$")),
+)
+
+
+def _classify_period_token(token: str) -> str | None:
+    """Return a period kind name if ``token`` looks like a period value, else None."""
+    t = token.lower()
+    if t in _MONTH_TOKENS:
+        return "month"
+    for kind, pattern in _PERIOD_PATTERNS:
+        if pattern.match(t):
+            return kind
+    parts = re.split(r"[-_]", t)
+    if len(parts) == 2:
+        a, b = parts
+        if a in _MONTH_TOKENS and re.fullmatch(r"(?:19|20)\d{2}", b):
+            return "month_year"
+        if b in _MONTH_TOKENS and re.fullmatch(r"(?:19|20)\d{2}", a):
+            return "year_month_word"
+    return None
+
+
+def _split_prefix_period(name: str) -> tuple[str, str, str] | None:
+    """Split ``name`` into (prefix, period_token, period_kind) or return None.
+
+    Tries progressively longer trailing segments so that names like
+    ``sales_2020_01`` resolve to ``("sales", "2020_01", "year_month")``.
+    """
+    parts = name.split("_")
+    max_take = min(3, len(parts))
+    for take in range(max_take, 0, -1):
+        suffix_parts = parts[-take:]
+        suffix = "_".join(suffix_parts)
+        kind = _classify_period_token(suffix)
+        if kind:
+            prefix = "_".join(parts[:-take]) if take < len(parts) else ""
+            return (prefix, suffix, kind)
+        if take >= 2:
+            suffix_concat = "".join(suffix_parts)
+            kind = _classify_period_token(suffix_concat)
+            if kind:
+                prefix = "_".join(parts[:-take]) if take < len(parts) else ""
+                return (prefix, suffix_concat, kind)
+    kind = _classify_period_token(name)
+    if kind:
+        return ("", name, kind)
+    return None
+
+
+_PERIOD_COLUMN_NAMES: dict[str, str] = {
+    "year": "year",
+    "year_month": "year_month",
+    "year_quarter": "year_quarter",
+    "year_month_word": "year_month",
+    "month_year": "year_month",
+    "quarter": "quarter",
+    "month": "month",
+    "month_num": "month",
+    "hour": "hour",
+    "day": "day",
+}
+
+
+@dataclass
+class TidySuggestion:
+    """A concrete suggestion to reshape an untidy table into long form."""
+
+    pattern: str
+    table: str
+    affected_columns: list[str]
+    id_columns: list[str]
+    period_kind: str
+    common_prefix: str
+    period_column_name: str
+    value_column_name: str
+    suggested_view: str
+    rationale: str
+    reshape_sql: str
+
+    def build_sql(self, mode: str = "view") -> str:
+        """Return DDL that materializes this suggestion as a view or table."""
+        if mode not in ("view", "table"):
+            raise ValueError(f"mode must be 'view' or 'table', got {mode!r}")
+        pairs = _column_period_pairs(self.affected_columns)
+        return _build_reshape_sql(
+            self.table,
+            self.id_columns,
+            pairs,
+            self.period_column_name,
+            self.value_column_name,
+            self.suggested_view,
+            mode=mode,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _column_period_pairs(affected_columns: list[str]) -> list[tuple[str, str]]:
+    """Recover (column_name, period_token) pairs by re-running the period split.
+
+    The period token isn't stored on ``TidySuggestion`` because it can be
+    derived deterministically from the column name; this helper exposes that
+    derivation for callers (CLI ``--create-table``) that need to regenerate
+    the SQL with a different ``CREATE`` mode.
+    """
+    pairs: list[tuple[str, str]] = []
+    for col in affected_columns:
+        result = _split_prefix_period(col)
+        if result is None:
+            continue
+        _, period_token, _ = result
+        pairs.append((col, period_token))
+    return pairs
+
+
+@dataclass
+class WideTableNote:
+    """A softer note for tables that look transposed but have no reshape inferred."""
+
+    table: str
+    column_count: int
+    row_count: int | None
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _build_reshape_sql(
+    table: str,
+    id_columns: list[str],
+    column_period_pairs: list[tuple[str, str]],
+    period_column_name: str,
+    value_column_name: str,
+    suggested_view: str,
+    mode: str = "view",
+) -> str:
+    """Build a portable ``UNION ALL`` reshape statement.
+
+    DuckDB's ``UNPIVOT … ON col AS 'literal'`` form gets mangled when stored
+    inside a view definition (column references get rewritten as string
+    literals on round-trip), so we emit explicit ``UNION ALL`` branches
+    instead. The result is also valid SQLite / PostgreSQL.
+    """
+    keyword = "VIEW" if mode == "view" else "TABLE"
+    quoted_period = _quote_identifier(period_column_name)
+    quoted_value = _quote_identifier(value_column_name)
+    quoted_table = _quote_identifier(table)
+    id_select = ", ".join(_quote_identifier(c) for c in id_columns)
+    id_prefix = f"{id_select}, " if id_select else ""
+    branches: list[str] = []
+    for index, (col, period) in enumerate(column_period_pairs):
+        period_literal = period.replace("'", "''")
+        quoted_col = _quote_identifier(col)
+        if index == 0:
+            branches.append(
+                f"SELECT {id_prefix}'{period_literal}' AS {quoted_period}, "
+                f"{quoted_col} AS {quoted_value} FROM {quoted_table}"
+            )
+        else:
+            branches.append(
+                f"UNION ALL SELECT {id_prefix}'{period_literal}', {quoted_col} FROM {quoted_table}"
+            )
+    body = "\n".join(branches)
+    return f"CREATE OR REPLACE {keyword} {_quote_identifier(suggested_view)} AS\n{body};"
+
+
+def _build_period_suggestion(
+    table_name: str,
+    all_columns: list[str],
+    column_period_pairs: list[tuple[str, str]],
+    period_kind: str,
+    common_prefix: str,
+) -> TidySuggestion:
+    affected_columns = [col for col, _ in column_period_pairs]
+    affected_set = set(affected_columns)
+    id_columns = [c for c in all_columns if c not in affected_set]
+    period_column_name = _PERIOD_COLUMN_NAMES.get(period_kind, "period")
+    value_column_name = common_prefix.strip("_") if common_prefix else "value"
+    if not value_column_name:
+        value_column_name = "value"
+    suggested_view = f"{table_name}_long"
+    pattern = "repeated_prefix_period" if common_prefix else "date_in_column_names"
+    if common_prefix:
+        rationale = (
+            f"Columns share prefix `{common_prefix}` with {period_kind} suffixes — "
+            f"{len(affected_columns)} columns look like a single measure spread across "
+            f"{period_kind} values."
+        )
+    else:
+        rationale = (
+            f"{len(affected_columns)} columns are named like {period_kind} values — "
+            f"the {period_kind} dimension appears to be encoded in column headers."
+        )
+    reshape_sql = _build_reshape_sql(
+        table_name,
+        id_columns,
+        column_period_pairs,
+        period_column_name,
+        value_column_name,
+        suggested_view,
+    )
+    return TidySuggestion(
+        pattern=pattern,
+        table=table_name,
+        affected_columns=affected_columns,
+        id_columns=id_columns,
+        period_kind=period_kind,
+        common_prefix=common_prefix,
+        period_column_name=period_column_name,
+        value_column_name=value_column_name,
+        suggested_view=suggested_view,
+        rationale=rationale,
+        reshape_sql=reshape_sql,
+    )
+
+
+def _detect_period_groups(table: dict[str, Any]) -> list[TidySuggestion]:
+    columns = [c["name"] for c in table.get("columns", [])]
+    groups: dict[tuple[str, str], list[tuple[str, str]]] = defaultdict(list)
+    for column_name in columns:
+        result = _split_prefix_period(column_name)
+        if result is None:
+            continue
+        prefix, period_token, kind = result
+        groups[(prefix, kind)].append((column_name, period_token))
+    suggestions: list[TidySuggestion] = []
+    for (prefix, kind), entries in groups.items():
+        if len(entries) < MIN_GROUP_SIZE:
+            continue
+        suggestions.append(
+            _build_period_suggestion(
+                table_name=table["name"],
+                all_columns=columns,
+                column_period_pairs=entries,
+                period_kind=kind,
+                common_prefix=prefix,
+            )
+        )
+    suggestions.sort(key=lambda s: (-len(s.affected_columns), s.common_prefix))
+    return suggestions
+
+
+def _detect_wide_low_rows(
+    table: dict[str, Any],
+    period_suggestions: list[TidySuggestion],
+) -> WideTableNote | None:
+    columns = table.get("columns", [])
+    column_count = len(columns)
+    if column_count < WIDE_TABLE_COLUMN_THRESHOLD:
+        return None
+    if period_suggestions:
+        return None
+    row_count = table.get("row_count")
+    if row_count is not None and row_count > column_count * 2:
+        return None
+    if row_count is None:
+        reason = f"table has {column_count} columns; row count unknown"
+    elif row_count <= column_count:
+        reason = f"table has {column_count} columns and only {row_count} rows"
+    else:
+        reason = f"table has {column_count} columns and only {row_count} rows ({row_count // column_count}x)"
+    return WideTableNote(
+        table=table["name"],
+        column_count=column_count,
+        row_count=row_count,
+        reason=reason,
+    )
+
+
+def analyze_tidy_patterns(schema_info: list[dict[str, Any]]) -> dict[str, Any]:
+    """Inspect ``schema_info`` and return tidy-reshape suggestions and notes.
+
+    The result has the same shape as other ``data_profile`` overviews: a
+    JSON-serializable dict suitable for printing or feeding to a renderer.
+    """
+    period_suggestions: list[TidySuggestion] = []
+    wide_tables: list[WideTableNote] = []
+    notes: list[str] = []
+
+    for table in schema_info:
+        if not table.get("name"):
+            continue
+        table_period = _detect_period_groups(table)
+        period_suggestions.extend(table_period)
+        wide_note = _detect_wide_low_rows(table, table_period)
+        if wide_note is not None:
+            wide_tables.append(wide_note)
+
+    if not period_suggestions and not wide_tables:
+        notes.append("No untidy column-shape patterns detected.")
+
+    return {
+        "table_count": len(schema_info),
+        "period_suggestions": [s.to_dict() for s in period_suggestions],
+        "wide_tables": [w.to_dict() for w in wide_tables],
+        "notes": notes,
+    }
+
+
+__all__ = [
+    "MIN_GROUP_SIZE",
+    "WIDE_TABLE_COLUMN_THRESHOLD",
+    "TidySuggestion",
+    "WideTableNote",
+    "analyze_tidy_patterns",
+]

--- a/src/datasight/tidy.py
+++ b/src/datasight/tidy.py
@@ -3,8 +3,8 @@
 Inspects table schemas and flags columns whose names appear to encode a
 dimension value (year, month, quarter, hour, day) rather than holding a
 single measure across rows. Each suggestion is paired with a previewable
-DuckDB ``UNPIVOT`` statement so users can inspect or materialize the
-reshape via ``CREATE VIEW``.
+``CREATE OR REPLACE VIEW … UNION ALL …`` statement so users can inspect
+or materialize the reshape.
 
 The detection is deterministic and purely structural (column names plus
 dtypes plus row count), so it can run as part of the schema inspection
@@ -197,12 +197,15 @@ def _build_reshape_sql(
     suggested_view: str,
     mode: str = "view",
 ) -> str:
-    """Build a portable ``UNION ALL`` reshape statement.
+    """Build a ``CREATE OR REPLACE VIEW|TABLE`` reshape statement.
 
     DuckDB's ``UNPIVOT … ON col AS 'literal'`` form gets mangled when stored
     inside a view definition (column references get rewritten as string
     literals on round-trip), so we emit explicit ``UNION ALL`` branches
-    instead. The result is also valid SQLite / PostgreSQL.
+    instead. The inner ``SELECT … UNION ALL …`` body is portable to
+    SQLite and PostgreSQL; the ``CREATE OR REPLACE`` wrapper is
+    DuckDB-specific (PostgreSQL has no ``CREATE OR REPLACE TABLE``,
+    SQLite has no ``CREATE OR REPLACE VIEW``).
     """
     keyword = "VIEW" if mode == "view" else "TABLE"
     quoted_period = _quote_identifier(period_column_name)
@@ -233,10 +236,11 @@ def _build_period_suggestion(
     column_period_pairs: list[tuple[str, str]],
     period_kind: str,
     common_prefix: str,
+    excluded_from_id: set[str] | None = None,
 ) -> TidySuggestion:
     affected_columns = [col for col, _ in column_period_pairs]
-    affected_set = set(affected_columns)
-    id_columns = [c for c in all_columns if c not in affected_set]
+    excluded = set(affected_columns) if excluded_from_id is None else excluded_from_id
+    id_columns = [c for c in all_columns if c not in excluded]
     period_column_name = _PERIOD_COLUMN_NAMES.get(period_kind, "period")
     value_column_name = common_prefix.strip("_") if common_prefix else "value"
     if not value_column_name:
@@ -286,10 +290,14 @@ def _detect_period_groups(table: dict[str, Any]) -> list[TidySuggestion]:
             continue
         prefix, period_token, kind = result
         groups[(prefix, kind)].append((column_name, period_token))
+    qualifying_groups = [
+        ((prefix, kind), entries)
+        for (prefix, kind), entries in groups.items()
+        if len(entries) >= MIN_GROUP_SIZE
+    ]
+    excluded_from_id: set[str] = {col for _, entries in qualifying_groups for col, _ in entries}
     suggestions: list[TidySuggestion] = []
-    for (prefix, kind), entries in groups.items():
-        if len(entries) < MIN_GROUP_SIZE:
-            continue
+    for (prefix, kind), entries in qualifying_groups:
         suggestions.append(
             _build_period_suggestion(
                 table_name=table["name"],
@@ -297,6 +305,7 @@ def _detect_period_groups(table: dict[str, Any]) -> list[TidySuggestion]:
                 column_period_pairs=entries,
                 period_kind=kind,
                 common_prefix=prefix,
+                excluded_from_id=excluded_from_id,
             )
         )
     suggestions.sort(key=lambda s: (-len(s.affected_columns), s.common_prefix))

--- a/src/datasight/tidy.py
+++ b/src/datasight/tidy.py
@@ -1,14 +1,29 @@
-"""Detect untidy dataset patterns and suggest tidy-reshape views.
+"""Detect untidy dataset patterns and suggest tidy-reshape DDL.
 
 Inspects table schemas and flags columns whose names appear to encode a
 dimension value (year, month, quarter, hour, day) rather than holding a
-single measure across rows. Each suggestion is paired with a previewable
-``CREATE OR REPLACE VIEW … UNION ALL …`` statement so users can inspect
-or materialize the reshape.
+single measure across rows. Each suggestion carries a previewable DuckDB
+DDL statement so users can inspect or materialize the reshape.
 
-The detection is deterministic and purely structural (column names plus
-dtypes plus row count), so it can run as part of the schema inspection
-pass without issuing extra SQL.
+The DDL emitted depends on the target object:
+
+- ``CREATE OR REPLACE TABLE`` uses the canonical DuckDB ``UNPIVOT`` form,
+  which is what ``tidy table`` runs and what ``tidy suggest`` displays.
+- ``CREATE OR REPLACE VIEW`` falls back to ``UNION ALL`` branches because
+  of a regression in the Python ``duckdb`` 1.5.2 binding — UNPIVOT stored
+  inside a view fails to re-bind on a fresh connection in that binding,
+  raising ``Binder Error: UNPIVOT name count mismatch``. (The standalone
+  ``duckdb`` CLI 1.5.1 is unaffected, but datasight depends on the Python
+  binding for every internal query path, so views created through
+  datasight need the workaround to remain queryable from datasight
+  itself.) Materialized tables don't re-bind, so they keep the cleaner
+  UNPIVOT form.
+
+Detection is deterministic and purely structural (column names plus
+dtypes plus row count), so it runs without issuing extra SQL. The DDL is
+DuckDB-specific — which matches the typical workflow for this feature:
+untidy CSV / Parquet / Excel sources land in DuckDB before being
+reshaped.
 """
 
 from __future__ import annotations
@@ -138,8 +153,8 @@ class TidySuggestion:
     rationale: str
     reshape_sql: str
 
-    def build_sql(self, mode: str = "view") -> str:
-        """Return DDL that materializes this suggestion as a view or table."""
+    def build_sql(self, mode: str = "table") -> str:
+        """Return DDL that materializes this suggestion as a table or view."""
         if mode not in ("view", "table"):
             raise ValueError(f"mode must be 'view' or 'table', got {mode!r}")
         pairs = _column_period_pairs(self.affected_columns)
@@ -188,26 +203,62 @@ class WideTableNote:
         return asdict(self)
 
 
-def _build_reshape_sql(
+def _build_unpivot_sql(
+    table: str,
+    column_period_pairs: list[tuple[str, str]],
+    period_column_name: str,
+    value_column_name: str,
+    suggested_view: str,
+    mode: str,
+) -> str:
+    """Build a ``CREATE OR REPLACE TABLE|VIEW`` using DuckDB ``UNPIVOT``.
+
+    Use ``UNPIVOT … ON col AS '<period>'`` so each affected column maps to
+    a clean period token in the new period column. UNPIVOT carries the
+    remaining id columns through automatically.
+
+    Note: this form is only safe for ``mode='table'``. The Python
+    ``duckdb`` 1.5.2 binding has a regression where UNPIVOT stored inside
+    a view fails to re-bind on a fresh connection (the standalone CLI
+    1.5.1 is unaffected). ``_build_reshape_sql`` falls back to UNION ALL
+    for view mode so views remain queryable through datasight itself.
+    """
+    keyword = "TABLE" if mode == "table" else "VIEW"
+    on_clause = ",\n    ".join(
+        f"{_quote_identifier(col)} AS '{period.replace(chr(39), chr(39) * 2)}'"
+        for col, period in column_period_pairs
+    )
+    return (
+        f"CREATE OR REPLACE {keyword} {_quote_identifier(suggested_view)} AS\n"
+        f"SELECT * FROM (\n"
+        f"  UNPIVOT {_quote_identifier(table)}\n"
+        f"  ON {on_clause}\n"
+        f"  INTO\n"
+        f"    NAME {_quote_identifier(period_column_name)}\n"
+        f"    VALUE {_quote_identifier(value_column_name)}\n"
+        f");"
+    )
+
+
+def _build_union_all_view_sql(
     table: str,
     id_columns: list[str],
     column_period_pairs: list[tuple[str, str]],
     period_column_name: str,
     value_column_name: str,
     suggested_view: str,
-    mode: str = "view",
 ) -> str:
-    """Build a ``CREATE OR REPLACE VIEW|TABLE`` reshape statement.
+    """Build a ``CREATE OR REPLACE VIEW`` using ``UNION ALL`` branches.
 
-    DuckDB's ``UNPIVOT … ON col AS 'literal'`` form gets mangled when stored
-    inside a view definition (column references get rewritten as string
-    literals on round-trip), so we emit explicit ``UNION ALL`` branches
-    instead. The inner ``SELECT … UNION ALL …`` body is portable to
-    SQLite and PostgreSQL; the ``CREATE OR REPLACE`` wrapper is
-    DuckDB-specific (PostgreSQL has no ``CREATE OR REPLACE TABLE``,
-    SQLite has no ``CREATE OR REPLACE VIEW``).
+    A workaround for a regression in the Python ``duckdb`` 1.5.2 binding:
+    UNPIVOT stored inside a view re-binds incorrectly on a fresh
+    connection through that binding, raising ``UNPIVOT name count
+    mismatch``. The standalone ``duckdb`` CLI 1.5.1 doesn't reproduce
+    the failure, but every datasight query path uses the Python binding,
+    so we need a form that survives re-bind. Materialized tables
+    (``CREATE OR REPLACE TABLE``) don't re-bind and keep the cleaner
+    UNPIVOT form.
     """
-    keyword = "VIEW" if mode == "view" else "TABLE"
     quoted_period = _quote_identifier(period_column_name)
     quoted_value = _quote_identifier(value_column_name)
     quoted_table = _quote_identifier(table)
@@ -227,7 +278,52 @@ def _build_reshape_sql(
                 f"UNION ALL SELECT {id_prefix}'{period_literal}', {quoted_col} FROM {quoted_table}"
             )
     body = "\n".join(branches)
-    return f"CREATE OR REPLACE {keyword} {_quote_identifier(suggested_view)} AS\n{body};"
+    return (
+        f"-- Python `duckdb` 1.5.2 fails to re-bind UNPIVOT inside views on a fresh\n"
+        f"-- connection (Binder Error: UNPIVOT name count mismatch), so we use\n"
+        f"-- UNION ALL here. `tidy table` keeps the cleaner UNPIVOT form because\n"
+        f"-- materialized tables don't re-bind. The standalone duckdb CLI 1.5.1\n"
+        f"-- is unaffected.\n"
+        f"CREATE OR REPLACE VIEW {_quote_identifier(suggested_view)} AS\n"
+        f"{body};"
+    )
+
+
+def _build_reshape_sql(
+    table: str,
+    id_columns: list[str],
+    column_period_pairs: list[tuple[str, str]],
+    period_column_name: str,
+    value_column_name: str,
+    suggested_view: str,
+    mode: str = "table",
+) -> str:
+    """Build the DDL for one tidy reshape.
+
+    For ``mode='table'`` (the default), emits the canonical DuckDB
+    ``UNPIVOT`` form. For ``mode='view'``, falls back to ``UNION ALL``
+    branches because of a DuckDB binder bug that breaks UNPIVOT inside
+    stored views.
+    """
+    if mode == "table":
+        return _build_unpivot_sql(
+            table,
+            column_period_pairs,
+            period_column_name,
+            value_column_name,
+            suggested_view,
+            mode,
+        )
+    if mode == "view":
+        return _build_union_all_view_sql(
+            table,
+            id_columns,
+            column_period_pairs,
+            period_column_name,
+            value_column_name,
+            suggested_view,
+        )
+    raise ValueError(f"mode must be 'view' or 'table', got {mode!r}")
 
 
 def _build_period_suggestion(
@@ -265,6 +361,7 @@ def _build_period_suggestion(
         period_column_name,
         value_column_name,
         suggested_view,
+        mode="table",
     )
     return TidySuggestion(
         pattern=pattern,

--- a/tests/test_tidy.py
+++ b/tests/test_tidy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 import duckdb
 import pytest
@@ -630,7 +631,10 @@ def test_tidy_suggest_file_mode_rejects_table_filter(tmp_path):
     runner = CliRunner()
     result = runner.invoke(cli, ["tidy", "suggest", str(csv_path), "--table", "anything"])
     assert result.exit_code != 0
-    assert "--table cannot be combined" in result.output
+    # Click 8.3 wraps usage errors in a Rich panel with ANSI styling that
+    # interpolates codes inside option names, so check the ANSI-stripped form.
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--table cannot be combined" in plain
 
 
 def test_tidy_suggest_no_suggestions_message(tmp_path):

--- a/tests/test_tidy.py
+++ b/tests/test_tidy.py
@@ -249,6 +249,34 @@ def test_multiple_groups_in_same_table():
     assert prefixes == {"sales", "cost"}
 
 
+def test_multi_group_id_columns_exclude_sibling_period_columns():
+    """When a table has two period groups, neither suggestion should keep the
+    other group's pivoted columns as id columns — that would defeat the tidy
+    reshape by carrying duplicated wide measures into the long form."""
+    schema = [
+        _table(
+            "mixed",
+            [
+                ("region", "VARCHAR"),
+                ("year_started", "INTEGER"),
+                ("sales_2020", "DOUBLE"),
+                ("sales_2021", "DOUBLE"),
+                ("sales_2022", "DOUBLE"),
+                ("cost_q1", "DOUBLE"),
+                ("cost_q2", "DOUBLE"),
+                ("cost_q3", "DOUBLE"),
+            ],
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    suggestions = out["period_suggestions"]
+    assert len(suggestions) == 2
+    for s in suggestions:
+        assert s["id_columns"] == ["region", "year_started"]
+        for col in ("sales_2020", "sales_2021", "cost_q1", "cost_q2"):
+            assert col not in s["id_columns"]
+
+
 # ---------------------------------------------------------------------------
 # Generated reshape SQL must round-trip in DuckDB (and survive view storage)
 # ---------------------------------------------------------------------------

--- a/tests/test_tidy.py
+++ b/tests/test_tidy.py
@@ -1,0 +1,561 @@
+"""Tests for untidy-dataset detection in datasight.tidy."""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from datasight.cli import cli
+from datasight.tidy import (
+    MIN_GROUP_SIZE,
+    _classify_period_token,
+    _split_prefix_period,
+    analyze_tidy_patterns,
+)
+
+from tests._env_helpers import DATASIGHT_ENV_VARS, scrub_datasight_env
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Scrub datasight env vars before AND after each test in this module."""
+    for key in DATASIGHT_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+    scrub_datasight_env()
+
+
+def _table(name: str, columns: list[tuple[str, str]], row_count: int | None = 0) -> dict:
+    return {
+        "name": name,
+        "row_count": row_count,
+        "columns": [{"name": n, "dtype": dt, "nullable": True} for n, dt in columns],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Period token classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "token,expected_kind",
+    [
+        ("2020", "year"),
+        ("y2020", "year"),
+        ("year2024", "year"),
+        ("2020_01", "year_month"),
+        ("2020-12", "year_month"),
+        ("202012", "year_month"),
+        ("2020_q1", "year_quarter"),
+        ("2024Q4", "year_quarter"),
+        ("q1", "quarter"),
+        ("q4", "quarter"),
+        ("jan", "month"),
+        ("january", "month"),
+        ("hour_01", "hour"),
+        ("hour23", "hour"),
+        ("h00", "hour"),
+        ("hr_3", "hour"),
+        ("day_01", "day"),
+        ("day31", "day"),
+        ("m_07", "month_num"),
+        ("m12", "month_num"),
+        ("month_03", "month_num"),
+        ("jan_2020", "month_year"),
+        ("2020_jan", "year_month_word"),
+    ],
+)
+def test_classify_period_token(token, expected_kind):
+    assert _classify_period_token(token) == expected_kind
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["plant_id", "id", "fuel_type", "net_generation_mwh", "report_date", "name"],
+)
+def test_classify_period_token_rejects_normal_columns(name):
+    assert _classify_period_token(name) is None
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("sales_2020", ("sales", "2020", "year")),
+        ("revenue_2020_q1", ("revenue", "2020_q1", "year_quarter")),
+        ("hour_01", ("", "hour_01", "hour")),
+        ("h00", ("", "h00", "hour")),
+        ("q1", ("", "q1", "quarter")),
+        ("2020", ("", "2020", "year")),
+        ("plant_id", None),
+    ],
+)
+def test_split_prefix_period(name, expected):
+    assert _split_prefix_period(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# analyze_tidy_patterns: detection cases
+# ---------------------------------------------------------------------------
+
+
+def test_detects_year_columns_with_shared_prefix():
+    schema = [
+        _table(
+            "sales_wide",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "DOUBLE"),
+                ("sales_2021", "DOUBLE"),
+                ("sales_2022", "DOUBLE"),
+                ("sales_2023", "DOUBLE"),
+            ],
+            row_count=50,
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    assert len(out["period_suggestions"]) == 1
+    s = out["period_suggestions"][0]
+    assert s["pattern"] == "repeated_prefix_period"
+    assert s["period_kind"] == "year"
+    assert s["common_prefix"] == "sales"
+    assert s["affected_columns"] == ["sales_2020", "sales_2021", "sales_2022", "sales_2023"]
+    assert s["id_columns"] == ["region"]
+    assert s["value_column_name"] == "sales"
+    assert s["period_column_name"] == "year"
+    assert s["suggested_view"] == "sales_wide_long"
+    assert "UNION ALL" in s["reshape_sql"]
+
+
+def test_detects_hour_columns_no_prefix():
+    schema = [
+        _table(
+            "load_profile",
+            [("plant_id", "INTEGER"), ("date", "DATE")]
+            + [(f"hour_{i:02d}", "DOUBLE") for i in range(24)],
+            row_count=365,
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    assert len(out["period_suggestions"]) == 1
+    s = out["period_suggestions"][0]
+    assert s["pattern"] == "date_in_column_names"
+    assert s["period_kind"] == "hour"
+    assert s["common_prefix"] == ""
+    assert len(s["affected_columns"]) == 24
+    assert s["value_column_name"] == "value"
+    assert s["id_columns"] == ["plant_id", "date"]
+
+
+def test_detects_quarter_columns():
+    schema = [
+        _table(
+            "kpi",
+            [
+                ("metric", "VARCHAR"),
+                ("q1", "DOUBLE"),
+                ("q2", "DOUBLE"),
+                ("q3", "DOUBLE"),
+                ("q4", "DOUBLE"),
+            ],
+            row_count=10,
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    assert len(out["period_suggestions"]) == 1
+    assert out["period_suggestions"][0]["period_kind"] == "quarter"
+
+
+def test_clean_table_produces_no_suggestions():
+    schema = [
+        _table(
+            "generation",
+            [
+                ("plant_id", "INTEGER"),
+                ("report_date", "DATE"),
+                ("fuel_type", "VARCHAR"),
+                ("net_generation_mwh", "DOUBLE"),
+            ],
+            row_count=10000,
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    assert out["period_suggestions"] == []
+    assert out["wide_tables"] == []
+    assert out["notes"] == ["No untidy column-shape patterns detected."]
+
+
+def test_below_min_group_size_is_not_flagged():
+    schema = [
+        _table(
+            "tiny_wide",
+            [("region", "VARCHAR"), ("sales_2020", "DOUBLE"), ("sales_2021", "DOUBLE")],
+            row_count=5,
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    assert MIN_GROUP_SIZE == 3
+    assert out["period_suggestions"] == []
+
+
+def test_detects_wide_table_with_no_period_pattern():
+    columns = [("id", "INTEGER")] + [(f"feature_{i}", "DOUBLE") for i in range(35)]
+    schema = [_table("feature_dump", columns, row_count=10)]
+    out = analyze_tidy_patterns(schema)
+    assert out["period_suggestions"] == []
+    assert len(out["wide_tables"]) == 1
+    note = out["wide_tables"][0]
+    assert note["table"] == "feature_dump"
+    assert note["column_count"] == 36
+
+
+def test_wide_check_skipped_when_period_pattern_already_detected():
+    columns = [("id", "INTEGER")] + [(f"y{2000 + i}", "DOUBLE") for i in range(40)]
+    schema = [_table("annual_history", columns, row_count=5)]
+    out = analyze_tidy_patterns(schema)
+    assert len(out["period_suggestions"]) == 1
+    assert out["wide_tables"] == []
+
+
+def test_wide_check_respects_row_count_threshold():
+    columns = [(f"feature_{i}", "DOUBLE") for i in range(35)]
+    schema = [_table("ml_features", columns, row_count=10000)]
+    out = analyze_tidy_patterns(schema)
+    assert out["wide_tables"] == []
+
+
+def test_multiple_groups_in_same_table():
+    schema = [
+        _table(
+            "mixed",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "DOUBLE"),
+                ("sales_2021", "DOUBLE"),
+                ("sales_2022", "DOUBLE"),
+                ("cost_q1", "DOUBLE"),
+                ("cost_q2", "DOUBLE"),
+                ("cost_q3", "DOUBLE"),
+            ],
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    suggestions = out["period_suggestions"]
+    assert len(suggestions) == 2
+    prefixes = {s["common_prefix"] for s in suggestions}
+    assert prefixes == {"sales", "cost"}
+
+
+# ---------------------------------------------------------------------------
+# Generated reshape SQL must round-trip in DuckDB (and survive view storage)
+# ---------------------------------------------------------------------------
+
+
+def test_reshape_sql_executes_in_duckdb(tmp_path):
+    db_path = tmp_path / "wide.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales_wide ("
+        "region VARCHAR, "
+        "sales_2020 DOUBLE, sales_2021 DOUBLE, sales_2022 DOUBLE, sales_2023 DOUBLE)"
+    )
+    conn.execute(
+        "INSERT INTO sales_wide VALUES ('north', 10, 20, 30, 40), ('south', 5, 15, 25, 35)"
+    )
+
+    schema = [
+        _table(
+            "sales_wide",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "DOUBLE"),
+                ("sales_2021", "DOUBLE"),
+                ("sales_2022", "DOUBLE"),
+                ("sales_2023", "DOUBLE"),
+            ],
+            row_count=2,
+        )
+    ]
+    out = analyze_tidy_patterns(schema)
+    sql = out["period_suggestions"][0]["reshape_sql"]
+    conn.execute(sql)
+    rows = conn.execute(
+        "SELECT region, year, sales FROM sales_wide_long ORDER BY region, year"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("north", "2020", 10.0),
+        ("north", "2021", 20.0),
+        ("north", "2022", 30.0),
+        ("north", "2023", 40.0),
+        ("south", "2020", 5.0),
+        ("south", "2021", 15.0),
+        ("south", "2022", 25.0),
+        ("south", "2023", 35.0),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: `datasight quality` surfaces tidy suggestions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wide_project(tmp_path):
+    db_path = tmp_path / "wide.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales_wide ("
+        "region VARCHAR, "
+        "sales_2020 DOUBLE, sales_2021 DOUBLE, sales_2022 DOUBLE, sales_2023 DOUBLE)"
+    )
+    conn.execute("INSERT INTO sales_wide VALUES ('north', 10, 20, 30, 40)")
+    conn.close()
+    (tmp_path / ".env").write_text(
+        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={db_path}\n",
+        encoding="utf-8",
+    )
+    return str(tmp_path)
+
+
+def test_quality_cli_emits_tidy_suggestions_json(wide_project):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality", "--project-dir", wide_project, "--format", "json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "tidy_suggestions" in data
+    assert len(data["tidy_suggestions"]) == 1
+    s = data["tidy_suggestions"][0]
+    assert s["table"] == "sales_wide"
+    assert s["period_kind"] == "year"
+    assert "UNION ALL" in s["reshape_sql"]
+
+
+def test_quality_cli_emits_tidy_suggestions_markdown(wide_project):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["quality", "--project-dir", wide_project, "--format", "markdown"])
+    assert result.exit_code == 0, result.output
+    assert "Tidy Reshape Suggestions" in result.output
+    assert "sales_wide" in result.output
+    assert "UNION ALL" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `datasight tidy` command
+# ---------------------------------------------------------------------------
+
+
+def _wide_project_dir(tmp_path) -> tuple[str, str]:
+    """Return (project_dir, db_path) for a single-table wide-CSV project."""
+    db_path = tmp_path / "wide.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales_wide ("
+        "region VARCHAR, "
+        "sales_2020 DOUBLE, sales_2021 DOUBLE, sales_2022 DOUBLE, sales_2023 DOUBLE)"
+    )
+    conn.execute(
+        "INSERT INTO sales_wide VALUES ('north', 10, 20, 30, 40), ('south', 5, 15, 25, 35)"
+    )
+    conn.close()
+    (tmp_path / ".env").write_text(
+        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={db_path}\n",
+        encoding="utf-8",
+    )
+    return str(tmp_path), str(db_path)
+
+
+def test_tidy_suggest_lists_by_default(tmp_path):
+    project_dir, _ = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "suggest", "--project-dir", project_dir])
+    assert result.exit_code == 0, result.output
+    assert "sales_wide" in result.output
+    assert "Suggestions" in result.output
+
+
+def test_tidy_suggest_json_output(tmp_path):
+    project_dir, _ = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["tidy", "suggest", "--project-dir", project_dir, "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["table_count"] == 1
+    assert len(data["period_suggestions"]) == 1
+    assert "applied" not in data
+
+
+def test_tidy_suggest_markdown_output(tmp_path):
+    project_dir, _ = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["tidy", "suggest", "--project-dir", project_dir, "--format", "markdown"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "# Tidy Reshape Suggestions" in result.output
+    assert "## Suggestions" in result.output
+
+
+def test_tidy_view_dry_run_does_not_apply(tmp_path):
+    project_dir, db_path = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "view", "--project-dir", project_dir, "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "Would apply" in result.output
+    assert "CREATE OR REPLACE VIEW" in result.output
+    conn = duckdb.connect(db_path)
+    views = [r[0] for r in conn.execute("SHOW TABLES").fetchall()]
+    conn.close()
+    assert "sales_wide_long" not in views
+
+
+def test_tidy_table_dry_run_emits_table_ddl(tmp_path):
+    project_dir, db_path = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "table", "--project-dir", project_dir, "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "CREATE OR REPLACE TABLE" in result.output
+    conn = duckdb.connect(db_path)
+    rows = conn.execute("SHOW TABLES").fetchall()
+    conn.close()
+    assert all("long" not in name for (name,) in rows)
+
+
+def test_tidy_view_actually_creates_view(tmp_path):
+    project_dir, db_path = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "view", "--project-dir", project_dir])
+    assert result.exit_code == 0, result.output
+    conn = duckdb.connect(db_path)
+    rows = conn.execute(
+        "SELECT region, year, sales FROM sales_wide_long ORDER BY region, year"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("north", "2020", 10.0),
+        ("north", "2021", 20.0),
+        ("north", "2022", 30.0),
+        ("north", "2023", 40.0),
+        ("south", "2020", 5.0),
+        ("south", "2021", 15.0),
+        ("south", "2022", 25.0),
+        ("south", "2023", 35.0),
+    ]
+
+
+def test_tidy_table_materializes(tmp_path):
+    project_dir, db_path = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "table", "--project-dir", project_dir])
+    assert result.exit_code == 0, result.output
+    conn = duckdb.connect(db_path)
+    kind = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_name = 'sales_wide_long'"
+    ).fetchone()
+    row = conn.execute("SELECT COUNT(*) FROM sales_wide_long").fetchone()
+    conn.close()
+    assert kind is not None
+    assert kind[0] == "BASE TABLE"
+    assert row is not None
+    assert row[0] == 8
+
+
+def test_tidy_help_lists_subcommands():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "--help"])
+    assert result.exit_code == 0
+    assert "suggest" in result.output
+    assert "view" in result.output
+    assert "table" in result.output
+
+
+def test_tidy_suggest_table_filter_scopes_detection(tmp_path):
+    db_path = tmp_path / "multi.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales_wide ("
+        "region VARCHAR, sales_2020 DOUBLE, sales_2021 DOUBLE, sales_2022 DOUBLE)"
+    )
+    conn.execute("INSERT INTO sales_wide VALUES ('n', 1, 2, 3)")
+    conn.execute(
+        "CREATE TABLE costs_wide ("
+        "region VARCHAR, cost_q1 DOUBLE, cost_q2 DOUBLE, cost_q3 DOUBLE, cost_q4 DOUBLE)"
+    )
+    conn.execute("INSERT INTO costs_wide VALUES ('n', 1, 2, 3, 4)")
+    conn.close()
+    (tmp_path / ".env").write_text(
+        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={db_path}\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tidy",
+            "suggest",
+            "--project-dir",
+            str(tmp_path),
+            "--table",
+            "sales_wide",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["table_count"] == 1
+    assert len(data["period_suggestions"]) == 1
+    assert data["period_suggestions"][0]["table"] == "sales_wide"
+
+
+def test_tidy_view_table_filter_scopes_apply(tmp_path):
+    db_path = tmp_path / "multi.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales_wide ("
+        "region VARCHAR, sales_2020 DOUBLE, sales_2021 DOUBLE, sales_2022 DOUBLE)"
+    )
+    conn.execute("INSERT INTO sales_wide VALUES ('n', 1, 2, 3)")
+    conn.execute(
+        "CREATE TABLE costs_wide ("
+        "region VARCHAR, cost_q1 DOUBLE, cost_q2 DOUBLE, cost_q3 DOUBLE, cost_q4 DOUBLE)"
+    )
+    conn.execute("INSERT INTO costs_wide VALUES ('n', 1, 2, 3, 4)")
+    conn.close()
+    (tmp_path / ".env").write_text(
+        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={db_path}\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["tidy", "view", "--project-dir", str(tmp_path), "--table", "sales_wide"]
+    )
+    assert result.exit_code == 0, result.output
+    conn = duckdb.connect(str(db_path))
+    names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
+    conn.close()
+    assert "sales_wide_long" in names
+    assert "costs_wide_long" not in names
+
+
+def test_tidy_suggest_no_suggestions_message(tmp_path):
+    db_path = tmp_path / "clean.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE generation ("
+        "plant_id INTEGER, report_date DATE, fuel VARCHAR, net_generation_mwh DOUBLE)"
+    )
+    conn.close()
+    (tmp_path / ".env").write_text(
+        f"LLM_PROVIDER=ollama\nOLLAMA_MODEL=qwen2.5:7b\nDB_MODE=duckdb\nDB_PATH={db_path}\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "suggest", "--project-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "No untidy column-shape patterns detected" in result.output

--- a/tests/test_tidy.py
+++ b/tests/test_tidy.py
@@ -127,7 +127,8 @@ def test_detects_year_columns_with_shared_prefix():
     assert s["value_column_name"] == "sales"
     assert s["period_column_name"] == "year"
     assert s["suggested_view"] == "sales_wide_long"
-    assert "UNION ALL" in s["reshape_sql"]
+    assert "UNPIVOT" in s["reshape_sql"]
+    assert "CREATE OR REPLACE TABLE" in s["reshape_sql"]
 
 
 def test_detects_hour_columns_no_prefix():
@@ -359,7 +360,7 @@ def test_quality_cli_emits_tidy_suggestions_json(wide_project):
     s = data["tidy_suggestions"][0]
     assert s["table"] == "sales_wide"
     assert s["period_kind"] == "year"
-    assert "UNION ALL" in s["reshape_sql"]
+    assert "UNPIVOT" in s["reshape_sql"]
 
 
 def test_quality_cli_emits_tidy_suggestions_markdown(wide_project):
@@ -368,7 +369,7 @@ def test_quality_cli_emits_tidy_suggestions_markdown(wide_project):
     assert result.exit_code == 0, result.output
     assert "Tidy Reshape Suggestions" in result.output
     assert "sales_wide" in result.output
-    assert "UNION ALL" in result.output
+    assert "UNPIVOT" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -452,6 +453,35 @@ def test_tidy_table_dry_run_emits_table_ddl(tmp_path):
     rows = conn.execute("SHOW TABLES").fetchall()
     conn.close()
     assert all("long" not in name for (name,) in rows)
+
+
+def test_tidy_view_sql_uses_union_all_workaround(tmp_path):
+    """View mode must use UNION ALL — UNPIVOT inside a view fails to re-bind
+    on a fresh DuckDB connection (1.5.2 binder bug). This test pins the
+    workaround so a future "simplification" back to UNPIVOT doesn't silently
+    re-introduce the bug."""
+    project_dir, db_path = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "view", "--project-dir", project_dir, "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "UNION ALL" in result.output
+    # Strip leading SQL comments before checking — the workaround note
+    # mentions UNPIVOT in prose, but the actual SQL must not use it.
+    body = "\n".join(
+        line for line in result.output.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert "UNPIVOT" not in body
+
+
+def test_tidy_table_sql_uses_unpivot(tmp_path):
+    """Table mode uses the canonical UNPIVOT form (works because materialized
+    tables don't re-bind on query)."""
+    project_dir, _ = _wide_project_dir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "table", "--project-dir", project_dir, "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "UNPIVOT" in result.output
+    assert "UNION ALL" not in result.output
 
 
 def test_tidy_view_actually_creates_view(tmp_path):

--- a/tests/test_tidy.py
+++ b/tests/test_tidy.py
@@ -571,6 +571,38 @@ def test_tidy_view_table_filter_scopes_apply(tmp_path):
     assert "costs_wide_long" not in names
 
 
+def test_tidy_suggest_accepts_csv_without_project(tmp_path):
+    csv_path = tmp_path / "monthly_generation.csv"
+    csv_path.write_text(
+        "plant_id,fuel_type,jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec\n"
+        "1,coal,180,165,140,120,110,100,95,105,130,160,175,200\n"
+        "2,gas,220,200,180,170,160,175,200,220,210,200,215,230\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "suggest", str(csv_path), "--format", "json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["table_count"] == 1
+    assert len(data["period_suggestions"]) == 1
+    s = data["period_suggestions"][0]
+    assert s["period_kind"] == "month"
+    assert len(s["affected_columns"]) == 12
+    assert s["id_columns"] == ["plant_id", "fuel_type"]
+
+
+def test_tidy_suggest_file_mode_rejects_table_filter(tmp_path):
+    csv_path = tmp_path / "monthly.csv"
+    csv_path.write_text(
+        "plant_id,jan,feb,mar,apr\n1,1,2,3,4\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tidy", "suggest", str(csv_path), "--table", "anything"])
+    assert result.exit_code != 0
+    assert "--table cannot be combined" in result.output
+
+
 def test_tidy_suggest_no_suggestions_message(tmp_path):
     db_path = tmp_path / "clean.duckdb"
     conn = duckdb.connect(str(db_path))


### PR DESCRIPTION
## Summary
- New `datasight.tidy` module: deterministic detection of period values encoded in column names (year, year-month, year-quarter, quarter, month, hour, day), with portable `UNION ALL` reshape SQL per finding.
- New `datasight tidy {suggest,view,table}` command group: list candidates, preview DDL with `--dry-run`, or apply as views / materialized tables. Mutual exclusion of view-vs-table is structural via subcommands rather than runtime-validated flags.
- `datasight quality` output now includes a "Tidy Reshape Suggestions" section so the patterns surface during routine quality audits.
- Documentation: new "Detect untidy column shapes" section in `audit-data-quality.md` with Wickham's tidy-data definition and links to the paper and R4DS; CLI reference regenerated.

Closes #51.

## Test plan
- [ ] `pytest -m "not integration"` — 1329 tests pass locally
- [ ] `prek run --all-files` — clean (ruff, ruff-format, ty, docs CLI reference drift)
- [ ] `datasight tidy --help` lists the three subcommands
- [ ] `datasight tidy suggest` on a wide-CSV project produces a reshape suggestion
- [ ] `datasight tidy view --dry-run` prints the DDL without modifying the database
- [ ] `datasight tidy view` creates the long-form view and `SELECT * FROM <table>_long` returns tidy rows
- [ ] `datasight tidy table` materializes a physical table with the expected row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)