### PR TITLE
Robustness fixes: spaced identifiers, mixed-line-ending CSVs, generate failures

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -322,6 +322,7 @@ datasight generate [OPTIONS] [FILES]...
 | `--db-path` | Output DuckDB path to create from CSV/Parquet/Excel or mixed file inputs (default: database.duckdb). Do not use this with a single existing DuckDB or SQLite database; those are referenced directly. |
 | `--import-mode` | When FILES are CSV/Parquet inputs, choose whether datasight creates source-backed views or materialized DuckDB tables. 'auto' preserves the existing cheap behavior and keeps CSV/Parquet source-backed; use 'table' to opt into materialization. Excel workbooks are always materialized as tables. Default: `auto`. |
 | `--compact-schema` | Write schema.yaml with table names only. Default adds an empty 'excluded_columns: []' placeholder per table so you can fill in glob patterns for columns to hide. |
+| `--max-tokens` | Output token budget for the documentation LLM call. Defaults to a per-provider safe value. Reasoning models that hide <think> tokens may need a larger value (subject to provider limits — GitHub Models caps output around 8K). |
 
 ### `datasight run`
 

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -99,6 +99,17 @@ from datasight.cli_helpers import format_epilog
         "glob patterns for columns to hide."
     ),
 )
+@click.option(
+    "--max-tokens",
+    type=int,
+    default=None,
+    help=(
+        "Output token budget for the documentation LLM call. Defaults to "
+        "a per-provider safe value. Reasoning models that hide <think> "
+        "tokens may need a larger value (subject to provider limits — "
+        "GitHub Models caps output around 8K)."
+    ),
+)
 def generate(
     files,
     project_dir,
@@ -108,6 +119,7 @@ def generate(
     db_path,
     import_mode,
     compact_schema,
+    max_tokens,
 ):
     """Generate schema_description.md, queries.yaml, measures.yaml, and time_series.yaml from your database.
 
@@ -378,33 +390,45 @@ def generate(
             tables, sql_dialect, samples_text, timestamps_text=timestamps_text
         )
 
-        from datasight.llm import TextBlock
+        from datasight.llm import TextBlock, default_max_output_tokens
 
+        budget = (
+            max_tokens
+            if max_tokens is not None
+            else default_max_output_tokens(settings.llm.provider)
+        )
         response = await llm_client.create_message(
             model=resolved_model,
             system=system_prompt,
             messages=[{"role": "user", "content": user_msg}],
             tools=[],
-            max_tokens=4096,
+            max_tokens=budget,
         )
 
         parts = [block.text for block in response.content if isinstance(block, TextBlock)]
-        return "".join(parts), sql_runner, tables_info, tables
+        return "".join(parts), response.stop_reason, sql_runner, tables_info, tables
 
-    text, sql_runner, tables_info, generated_tables = asyncio.run(_run())
+    text, stop_reason, sql_runner, tables_info, generated_tables = asyncio.run(_run())
 
-    # Parse response into two files
-    from datasight.generate import parse_generation_response
+    # Validate response BEFORE writing any project files. A silent partial
+    # write (schema.yaml + measures.yaml + .env without
+    # schema_description.md / queries.yaml) leaves the project unusable,
+    # so abort here instead.
+    from datasight.generate import (
+        GenerationResponseError,
+        parse_and_validate_response,
+    )
 
-    schema_content, queries_content = parse_generation_response(text)
-    if schema_content is None:
-        click.echo("Warning: Could not parse LLM response.", err=True)
+    try:
+        schema_content, queries_content = parse_and_validate_response(text, stop_reason)
+    except GenerationResponseError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
 
     # Write files
     written = []
-    if schema_content:
-        schema_path.write_text(schema_content + "\n", encoding="utf-8")
-        written.append("schema_description.md")
+    schema_path.write_text(schema_content + "\n", encoding="utf-8")
+    written.append("schema_description.md")
 
     schema_yaml_lines = ["tables:"]
     for t in generated_tables:

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -439,6 +439,8 @@ def generate(
             try:
                 sql_runner.close()
             except Exception:
+                # Swallow close errors so they don't mask the LLM-failure
+                # message we're already surfacing to the user.
                 pass
             try:
                 created_persistent_db.unlink(missing_ok=True)

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import rich_click as click
+from loguru import logger
 
 from datasight.config import create_sql_runner_from_settings
 from datasight.data_profile import (
@@ -287,7 +288,15 @@ def generate(
         click.echo(f"  Database: {settings.database.mode} — {resolved_db_path or sql_dialect}")
     click.echo()
 
+    # When --import-mode=table runs, build_persistent_duckdb materializes
+    # a fresh DuckDB file *before* the LLM call. If validation later
+    # fails we need to know to delete it — otherwise the orphan-prevention
+    # claim only holds for the auto/view paths. Other branches (existing
+    # sqlite/duckdb sources) point at user-owned files we must NOT touch.
+    created_persistent_db: Path | None = None
+
     async def _run():
+        nonlocal created_persistent_db
         from datasight.generate import (
             build_generation_context,
             sample_enum_columns,
@@ -342,6 +351,7 @@ def generate(
                     err=True,
                 )
                 sys.exit(1)
+            created_persistent_db = db_target
             sql_runner = DuckDBRunner(str(db_target))
             tables_info = persistent_tables_info
         elif use_files:
@@ -423,6 +433,19 @@ def generate(
         schema_content, queries_content = parse_and_validate_response(text, stop_reason)
     except GenerationResponseError as e:
         click.echo(f"Error: {e}", err=True)
+        if created_persistent_db is not None:
+            # --import-mode=table built this file before the LLM call;
+            # leaving it behind contradicts the no-orphan-files contract.
+            try:
+                sql_runner.close()
+            except Exception:
+                pass
+            try:
+                created_persistent_db.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    f"Could not remove partial DuckDB file {created_persistent_db}: {exc}"
+                )
         sys.exit(1)
 
     # Write files

--- a/src/datasight/explore.py
+++ b/src/datasight/explore.py
@@ -194,12 +194,19 @@ def resolve_import_mode(file_type: str, import_mode: ImportMode) -> Literal["vie
         raise ValueError(f"Unsupported import mode for file type: {file_type}") from e
 
 
-def _select_from_file_sql(file_path: str, file_type: str) -> str:
-    """Generate a SELECT statement that reads from a supported file source."""
+def _select_from_file_sql(file_path: str, file_type: str, *, lenient: bool = False) -> str:
+    """Generate a SELECT statement that reads from a supported file source.
+
+    When ``lenient`` is true, CSV reads pass ``strict_mode=false`` so DuckDB
+    accepts files whose dialect the sniffer can't pin down — most commonly
+    CSVs with mixed line endings (e.g. CRLF throughout but LF on the final
+    line, which Windows-produced files sometimes have).
+    """
     escaped_path = file_path.replace("'", "''")
+    csv_opts = ", strict_mode=false" if lenient else ""
 
     if file_type == "csv":
-        return f"SELECT * FROM read_csv_auto('{escaped_path}')"
+        return f"SELECT * FROM read_csv_auto('{escaped_path}'{csv_opts})"
     if file_type == "parquet":
         return f"SELECT * FROM read_parquet('{escaped_path}')"
     if file_type == "hive_parquet":
@@ -207,7 +214,7 @@ def _select_from_file_sql(file_path: str, file_type: str) -> str:
         return f"SELECT * FROM read_parquet('{glob_path}', hive_partitioning=true)"
     if file_type == "csv_dir":
         glob_path = f"{escaped_path}/*.csv"
-        return f"SELECT * FROM read_csv_auto('{glob_path}')"
+        return f"SELECT * FROM read_csv_auto('{glob_path}'{csv_opts})"
     raise ValueError(f"Unknown file type: {file_type}")
 
 
@@ -217,14 +224,53 @@ def create_relation_sql(
     file_type: str,
     *,
     import_mode: ImportMode = "view",
+    lenient: bool = False,
 ) -> str:
-    """Generate SQL to create a view or table for a data file."""
+    """Generate SQL to create a view or table for a data file.
+
+    ``lenient`` is forwarded to the file-read call (CSV only) — see
+    ``_select_from_file_sql``.
+    """
     quoted_name = f'"{table_name}"'
-    select_sql = _select_from_file_sql(file_path, file_type)
+    select_sql = _select_from_file_sql(file_path, file_type, lenient=lenient)
     resolved_mode = resolve_import_mode(file_type, import_mode)
     if resolved_mode == "table":
         return f"CREATE TABLE {quoted_name} AS {select_sql}"
     return f"CREATE VIEW {quoted_name} AS {select_sql}"
+
+
+def _execute_relation_with_csv_fallback(
+    conn: duckdb.DuckDBPyConnection,
+    table_name: str,
+    file_path: str,
+    file_type: str,
+    *,
+    import_mode: ImportMode = "view",
+) -> None:
+    """Run ``create_relation_sql`` then ``conn.execute``, retrying CSV files
+    with ``strict_mode=false`` when DuckDB's sniffer fails on inconsistent
+    files (mixed line endings, ragged rows, etc.).
+
+    The retry only fires when the failing file is ``csv``/``csv_dir`` and
+    the error message indicates a sniffer dialect-detection failure — any
+    other DuckDB error (missing file, permission denied, etc.) propagates
+    unchanged.
+    """
+    sql = create_relation_sql(table_name, file_path, file_type, import_mode=import_mode)
+    try:
+        conn.execute(sql)
+        return
+    except duckdb.Error as e:
+        if file_type not in ("csv", "csv_dir") or "sniff" not in str(e).lower():
+            raise
+        logger.warning(
+            f"CSV sniffer failed on {file_path}; "
+            f"retrying with strict_mode=false (likely mixed line endings)"
+        )
+    sql = create_relation_sql(
+        table_name, file_path, file_type, import_mode=import_mode, lenient=True
+    )
+    conn.execute(sql)
 
 
 def create_view_sql(table_name: str, file_path: str, file_type: str) -> str:
@@ -501,8 +547,9 @@ def create_ephemeral_session(
 
         try:
             resolved_mode = resolve_import_mode(file_type, import_mode)
-            sql = create_relation_sql(table_name, path, file_type, import_mode=resolved_mode)
-            conn.execute(sql)
+            _execute_relation_with_csv_fallback(
+                conn, table_name, path, file_type, import_mode=resolved_mode
+            )
             existing_names.add(table_name)
             tables_info.append(
                 {
@@ -757,8 +804,9 @@ def add_files_to_connection(
 
         try:
             resolved_mode = resolve_import_mode(file_type, import_mode)
-            sql = create_relation_sql(table_name, path, file_type, import_mode=resolved_mode)
-            conn.execute(sql)
+            _execute_relation_with_csv_fallback(
+                conn, table_name, path, file_type, import_mode=resolved_mode
+            )
             names.add(table_name)
             tables_info.append(
                 {
@@ -840,13 +888,12 @@ def build_persistent_duckdb(
                 object_type = "table"
             else:
                 relation_mode = table.get("import_mode", "view")
-                conn.execute(
-                    create_relation_sql(
-                        table["name"],
-                        table["path"],
-                        table["type"],
-                        import_mode=relation_mode,
-                    )
+                _execute_relation_with_csv_fallback(
+                    conn,
+                    table["name"],
+                    table["path"],
+                    table["type"],
+                    import_mode=relation_mode,
                 )
                 object_type = str(relation_mode)
             logger.info(f"Created {object_type} '{table['name']}' in {db_path}")
@@ -948,13 +995,13 @@ def save_ephemeral_as_project(
                 object_type = "table"
             else:
                 relation_mode = table.get("import_mode", "view")
-                sql = create_relation_sql(
+                _execute_relation_with_csv_fallback(
+                    db_conn,
                     table["name"],
                     table["path"],
                     table["type"],
                     import_mode=relation_mode,
                 )
-                db_conn.execute(sql)
                 object_type = str(relation_mode)
             logger.info(f"Created persistent {object_type} '{table['name']}' in {db_path}")
 

--- a/src/datasight/generate.py
+++ b/src/datasight/generate.py
@@ -225,6 +225,17 @@ def build_generation_context(
     return DESCRIBE_SYSTEM_PROMPT, user_msg
 
 
+class GenerationResponseError(RuntimeError):
+    """Raised when the LLM did not produce a usable documentation response.
+
+    Carried up by ``parse_and_validate_response`` so the CLI command can
+    abort *before* writing any project files — silently leaving behind a
+    half-built project (no schema_description.md but schema.yaml,
+    measures.yaml, .env, etc.) is the failure mode this exception
+    prevents.
+    """
+
+
 def parse_generation_response(text: str) -> tuple[str | None, str | None]:
     """Parse LLM response into schema_description and queries content.
 
@@ -257,6 +268,42 @@ def parse_generation_response(text: str) -> tuple[str | None, str | None]:
     logger.warning("Could not parse LLM response into separate files")
     stripped = text.strip()
     return stripped or None, None
+
+
+def parse_and_validate_response(text: str, stop_reason: str) -> tuple[str, str | None]:
+    """Parse the LLM response and raise on unusable output.
+
+    A truncated response (``stop_reason == "max_tokens"``) is the most
+    common cause of a missing ``schema_description.md`` when running
+    against a reasoning model whose hidden ``<think>`` tokens consumed
+    the whole budget. We surface that explicitly so the user can pick a
+    different model or raise ``--max-tokens`` instead of being left
+    with a partial project.
+
+    Returns ``(schema_content, queries_content)`` where ``schema_content``
+    is non-empty. ``queries_content`` may still be ``None`` if the LLM
+    omitted the queries section but produced a usable description.
+    """
+    schema_content, queries_content = parse_generation_response(text)
+
+    if schema_content:
+        return schema_content, queries_content
+
+    if stop_reason == "max_tokens":
+        raise GenerationResponseError(
+            "LLM hit its output token budget before producing the schema "
+            "description. Reasoning models (qwen3, gpt-oss, Anthropic "
+            "extended thinking, etc.) often spend thousands of tokens on "
+            "hidden <think> content before any visible output. "
+            "Try a non-reasoning model, or pass --max-tokens with a "
+            "larger value (subject to provider limits — GitHub Models "
+            "caps output around 8K)."
+        )
+    raise GenerationResponseError(
+        "LLM did not produce a parseable schema description. The "
+        "response was empty or could not be split into the required "
+        "sections."
+    )
 
 
 def _clean_yaml_content(content: str) -> str:

--- a/src/datasight/identifiers.py
+++ b/src/datasight/identifiers.py
@@ -23,6 +23,7 @@ Two related rewrites land here:
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 from typing import Any
 
 from loguru import logger
@@ -157,7 +158,13 @@ def quote_special_identifiers(sql: str, special_names: list[str]) -> str:
     if not special_names or not sql.strip():
         return sql
 
-    patterns = [(_build_special_pattern(name), f'"{name}"') for name in special_names]
+    # Escape any embedded `"` per SQL standard (double them) when emitting
+    # the quoted form, so a column literally named `say "hi" there` round-
+    # trips as `"say ""hi"" there"` rather than the malformed `"say "hi" there"`.
+    patterns = [
+        (_build_special_pattern(name), '"' + name.replace('"', '""') + '"')
+        for name in special_names
+    ]
 
     parts = _LITERAL_OR_COMMENT_RE.split(sql)
     # re.split with one capturing group: even indices are code, odd are
@@ -171,9 +178,15 @@ def quote_special_identifiers(sql: str, special_names: list[str]) -> str:
     return "".join(parts)
 
 
+@lru_cache(maxsize=512)
 def _build_special_pattern(name: str) -> re.Pattern[str]:
     """Pattern that matches the words of ``name`` separated by whitespace,
-    not preceded or followed by another identifier character."""
+    not preceded or followed by another identifier character.
+
+    Cached because runners call ``quote_special_identifiers`` on every
+    query — `inspect` / `generate` can fire hundreds of probes against
+    the same handful of names, and each `re.compile` is wasted work.
+    """
     words = name.split()
     body = r"\s+".join(re.escape(w) for w in words)
     return re.compile(

--- a/src/datasight/identifiers.py
+++ b/src/datasight/identifiers.py
@@ -1,41 +1,94 @@
 """
-Helpers for handling Postgres identifier quoting.
+Helpers for SQL identifier quoting.
 
-Postgres folds unquoted identifiers to lowercase, so a table created as
-``"Battery"`` can only be referenced as ``"Battery"`` (double-quoted) — a bare
-``Battery`` is resolved to ``battery`` and errors. LLMs frequently emit the
-unquoted form, triggering a round-trip where the model sees the error and
-retries with quotes. This module lets us preemptively rewrite SQL to quote
-identifiers we know from introspection need it, eliminating that retry.
+Two related rewrites land here:
+
+1. **Mixed-case identifiers (Postgres-only).** Postgres folds unquoted
+   identifiers to lowercase, so a table created as ``"Battery"`` can only be
+   referenced as ``"Battery"`` (double-quoted) — a bare ``Battery`` is
+   resolved to ``battery`` and errors. LLMs frequently emit the unquoted
+   form, triggering a round-trip where the model sees the error and retries
+   with quotes. ``quote_mixed_case_identifiers`` preemptively rewrites SQL
+   to quote identifiers we know from introspection need it.
+
+2. **Names containing whitespace (any dialect).** A CSV header like
+   ``Net Generation MWh`` becomes a column whose name contains spaces.
+   Smaller LLMs (Ollama) often emit ``SELECT Net Generation MWh FROM t``
+   bare — the dialect parses this as ``Net AS Generation`` and a stray
+   ``MWh``, so the query fails with a confusing "column not found" or
+   syntax error. ``quote_special_identifiers`` finds bare references whose
+   adjacent words match a known column and wraps them in double quotes.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from loguru import logger
 
 
+# Identifier chars that signal we're already inside an identifier and
+# should not start/end a match. Includes the double-quote character so we
+# don't double-quote an already-quoted name.
+_IDENT_CHAR = r"[A-Za-z0-9_\"]"
+
+# Splits SQL into chunks: capturing groups for string literals, quoted
+# identifiers, and comments — anything else is "code" we may rewrite.
+# Standard SQL escapes: '' inside '...' and "" inside "...".
+_LITERAL_OR_COMMENT_RE = re.compile(
+    r"('(?:[^']|'')*'"
+    r'|"(?:[^"]|"")*"'
+    r"|--[^\n]*"
+    r"|/\*[\s\S]*?\*/)"
+)
+
+
 def configure_runner_identifier_quoting(runner: Any, schema_info: list[dict[str, Any]]) -> None:
-    """Set ``mixed_case_identifiers`` on an underlying ``PostgresRunner``,
-    unwrapping any ``CachingSqlRunner`` layer. No-op for non-Postgres runners.
+    """Configure identifier-rewriting state on a SqlRunner.
+
+    Walks through any wrapping layers (e.g. ``CachingSqlRunner``) to find
+    the underlying runner, then populates whichever rewrite hooks it
+    exposes:
+
+    - ``special_identifiers`` (DuckDB, SQLite, Postgres) — names that must
+      be double-quoted because they contain whitespace.
+    - ``mixed_case_identifiers`` (Postgres only) — full case map for
+      Postgres's identifier folding.
+
+    No-op when the runner exposes neither attribute.
     """
     target = runner
-    while target is not None and not hasattr(target, "mixed_case_identifiers"):
+    seen: set[int] = set()
+    while target is not None and id(target) not in seen:
+        seen.add(id(target))
+        if hasattr(target, "special_identifiers") or hasattr(target, "mixed_case_identifiers"):
+            break
         inner = getattr(target, "_inner", None)
         if inner is target:
             break
         target = inner
-    if target is None or not hasattr(target, "mixed_case_identifiers"):
+
+    if target is None:
         return
-    case_map = build_identifier_case_map(schema_info)
-    target.mixed_case_identifiers = case_map or None
-    if case_map:
-        mixed = sum(1 for v in case_map.values() if v != v.lower())
-        logger.info(
-            f"Postgres identifier normalization enabled "
-            f"({len(case_map)} identifiers, {mixed} mixed-case)"
-        )
+
+    if hasattr(target, "special_identifiers"):
+        special = build_special_identifier_list(schema_info)
+        target.special_identifiers = special or None
+        if special:
+            logger.info(
+                f"Identifier quoting enabled for {len(special)} name(s) containing whitespace"
+            )
+
+    if hasattr(target, "mixed_case_identifiers"):
+        case_map = build_identifier_case_map(schema_info)
+        target.mixed_case_identifiers = case_map or None
+        if case_map:
+            mixed = sum(1 for v in case_map.values() if v != v.lower())
+            logger.info(
+                f"Postgres identifier normalization enabled "
+                f"({len(case_map)} identifiers, {mixed} mixed-case)"
+            )
 
 
 def build_identifier_case_map(schema_info: list[dict[str, Any]]) -> dict[str, str]:
@@ -58,6 +111,75 @@ def build_identifier_case_map(schema_info: list[dict[str, Any]]) -> dict[str, st
             if isinstance(cname, str):
                 case_map.setdefault(cname.lower(), cname)
     return case_map
+
+
+def build_special_identifier_list(schema_info: list[dict[str, Any]]) -> list[str]:
+    """Return identifiers from ``schema_info`` that need double-quoting.
+
+    Currently scoped to names containing whitespace — those are the case
+    the rewriter can fix safely. Names with other special characters (e.g.
+    ``co-2`` or ``col.sub``) are also unquotable bare, but the LLM-emitted
+    form is ambiguous to parse (``co-2`` parses as subtraction) so we
+    cannot rewrite them without false positives. They're left to the
+    LLM's retry loop.
+
+    Order: longest first (by word count, then char length) so multi-word
+    names match before any prefix that's also a column.
+    """
+    names: set[str] = set()
+    for table in schema_info:
+        tname = table.get("name")
+        if isinstance(tname, str) and _has_whitespace(tname):
+            names.add(tname)
+        for col in table.get("columns", []) or []:
+            cname = col.get("name") if isinstance(col, dict) else None
+            if isinstance(cname, str) and _has_whitespace(cname):
+                names.add(cname)
+    return sorted(names, key=lambda n: (-len(n.split()), -len(n), n))
+
+
+def _has_whitespace(name: str) -> bool:
+    return any(c.isspace() for c in name)
+
+
+def quote_special_identifiers(sql: str, special_names: list[str]) -> str:
+    """Wrap bare references to ``special_names`` in double quotes.
+
+    Each name in ``special_names`` is expected to contain whitespace (e.g.
+    ``"Net Generation MWh"``). For each, find sequences of words in the
+    SQL that match the name's words separated by whitespace, and replace
+    with the canonical double-quoted form.
+
+    String literals, already-quoted identifiers, and comments are left
+    alone. Matching is case-insensitive; the replacement uses the schema's
+    original casing.
+    """
+    if not special_names or not sql.strip():
+        return sql
+
+    patterns = [(_build_special_pattern(name), f'"{name}"') for name in special_names]
+
+    parts = _LITERAL_OR_COMMENT_RE.split(sql)
+    # re.split with one capturing group: even indices are code, odd are
+    # literal/quoted/comment chunks to leave untouched.
+    for i in range(0, len(parts), 2):
+        code = parts[i]
+        for pattern, replacement in patterns:
+            code = pattern.sub(replacement, code)
+        parts[i] = code
+
+    return "".join(parts)
+
+
+def _build_special_pattern(name: str) -> re.Pattern[str]:
+    """Pattern that matches the words of ``name`` separated by whitespace,
+    not preceded or followed by another identifier character."""
+    words = name.split()
+    body = r"\s+".join(re.escape(w) for w in words)
+    return re.compile(
+        rf"(?<!{_IDENT_CHAR}){body}(?!{_IDENT_CHAR})",
+        re.IGNORECASE,
+    )
 
 
 def quote_mixed_case_identifiers(sql: str, case_map: dict[str, str]) -> str:

--- a/src/datasight/llm.py
+++ b/src/datasight/llm.py
@@ -868,6 +868,29 @@ _PROVIDERS: dict[str, _ProviderSpec] = {
 SUPPORTED_PROVIDERS: frozenset[str] = frozenset(_PROVIDERS)
 
 
+# Per-provider default for the documentation-generation path. Reasoning
+# models (qwen3, etc. via Ollama; Anthropic extended-thinking models) burn
+# thousands of tokens on hidden ``<think>`` content before emitting any
+# visible output, so a 4K budget is too tight in practice. GitHub Models
+# caps output around 8K across most hosted models, so its budget stays
+# below that ceiling. Other providers get more headroom. The unknown-
+# provider fallback matches GitHub's lower limit so we don't blow up on
+# providers we haven't characterized yet.
+_DEFAULT_OUTPUT_TOKENS_BY_PROVIDER: dict[str, int] = {
+    "anthropic": 16384,
+    "openai": 16384,
+    "github": 8000,
+    "ollama": 16384,
+}
+_FALLBACK_DEFAULT_OUTPUT_TOKENS = 8000
+
+
+def default_max_output_tokens(provider: str) -> int:
+    """Return a sensible default ``max_tokens`` for one-shot LLM calls
+    (currently the documentation-generation path) given the provider."""
+    return _DEFAULT_OUTPUT_TOKENS_BY_PROVIDER.get(provider, _FALLBACK_DEFAULT_OUTPUT_TOKENS)
+
+
 def create_llm_client(
     provider: str,
     api_key: str = "",

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -74,6 +74,7 @@ class DuckDBRunner:
         self._database_path = database_path
         self._conn: duckdb.DuckDBPyConnection | None = None
         self._query_timeout = query_timeout
+        self.special_identifiers: list[str] | None = None
         self._connect()
 
     def _connect(self) -> None:
@@ -109,6 +110,10 @@ class DuckDBRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("DuckDBRunner is closed")
+        if self.special_identifiers:
+            from datasight.identifiers import quote_special_identifiers
+
+            sql = quote_special_identifiers(sql, self.special_identifiers)
         # Per-query logs at DEBUG: a single inspect / generate run can fire
         # hundreds of these and they drown out genuinely interesting INFO
         # output. Run with -v (or LOG_LEVEL=DEBUG) to surface them.
@@ -160,6 +165,7 @@ class EphemeralDuckDBRunner:
         """
         self._conn = conn
         self._query_timeout = query_timeout
+        self.special_identifiers: list[str] | None = None
 
     def close(self) -> None:
         """Close the database connection."""
@@ -186,6 +192,10 @@ class EphemeralDuckDBRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("EphemeralDuckDBRunner is closed")
+        if self.special_identifiers:
+            from datasight.identifiers import quote_special_identifiers
+
+            sql = quote_special_identifiers(sql, self.special_identifiers)
         # Per-query logs at DEBUG: a single inspect / generate run can fire
         # hundreds of these and they drown out genuinely interesting INFO
         # output. Run with -v (or LOG_LEVEL=DEBUG) to surface them.
@@ -223,6 +233,7 @@ class SQLiteRunner:
         self._database_path = database_path
         self._conn: sqlite3.Connection | None = None
         self._query_timeout = query_timeout
+        self.special_identifiers: list[str] | None = None
         self._connect()
 
     def _connect(self) -> None:
@@ -259,6 +270,10 @@ class SQLiteRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("SQLiteRunner is closed")
+        if self.special_identifiers:
+            from datasight.identifiers import quote_special_identifiers
+
+            sql = quote_special_identifiers(sql, self.special_identifiers)
         try:
             cursor = self._conn.execute(sql)
             rows = cursor.fetchall()
@@ -307,6 +322,7 @@ class PostgresRunner:
         self._query_timeout = query_timeout
         self._connection_info = f"{host}:{port}/{dbname}" if not url else "via URL"
         self.mixed_case_identifiers: dict[str, str] | None = None
+        self.special_identifiers: list[str] | None = None
 
         try:
             if url:
@@ -351,6 +367,10 @@ class PostgresRunner:
         """Execute SQL synchronously."""
         if self._conn is None:
             raise ConnectionError("PostgresRunner is closed")
+        if self.special_identifiers:
+            from datasight.identifiers import quote_special_identifiers
+
+            sql = quote_special_identifiers(sql, self.special_identifiers)
         if self.mixed_case_identifiers:
             from datasight.identifiers import quote_mixed_case_identifiers
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1375,7 +1375,8 @@ def test_generate_seeds_measure_overrides(project_dir, monkeypatch):
                         "- question: Example\n"
                         "  sql: SELECT 1\n"
                     )
-                ]
+                ],
+                stop_reason="end_turn",
             )
 
     monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: StubClient())
@@ -2644,7 +2645,8 @@ def test_generate_seeds_time_series(project_dir, monkeypatch):
                         "- question: Example\n"
                         "  sql: SELECT 1\n"
                     )
-                ]
+                ],
+                stop_reason="end_turn",
             )
 
     monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: StubClient())

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -228,6 +228,76 @@ class TestCreateViewSql:
             create_view_sql("x", "/path", "unknown")
 
 
+class TestCsvSnifferFallback:
+    """When DuckDB's CSV sniffer fails (mixed line endings, ragged rows),
+    create_ephemeral_session should retry with strict_mode=false."""
+
+    @staticmethod
+    def _write_mixed_endings_csv(path):
+        """CRLF on every row except the last, which uses LF only — trips
+        DuckDB's sniffer."""
+        body = b"a,b,c\r\n1,2,3\r\n4,5,6\r\n7,8,9\n"
+        path.write_bytes(body)
+
+    @staticmethod
+    def _capture_loguru_warnings():
+        """Return (capture_list, cleanup) — datasight uses loguru, which
+        bypasses pytest's caplog by default."""
+        from loguru import logger as _logger
+
+        captured: list[str] = []
+        sink_id = _logger.add(lambda msg: captured.append(str(msg)), level="WARNING")
+        return captured, lambda: _logger.remove(sink_id)
+
+    def test_mixed_line_endings_csv_loads(self, tmp_path):
+        """File that fails strict sniffing should still load via the
+        lenient retry."""
+        csv_file = tmp_path / "mixed.csv"
+        self._write_mixed_endings_csv(csv_file)
+
+        runner, tables = create_ephemeral_session([str(csv_file)])
+        assert len(tables) == 1
+        assert tables[0]["name"] == "mixed"
+
+        import asyncio
+
+        df = asyncio.run(runner.run_sql("SELECT COUNT(*) AS n FROM mixed"))
+        assert df["n"].iloc[0] == 3
+        runner.close()
+
+    def test_mixed_line_endings_logs_warning(self, tmp_path):
+        """The fallback path should log a warning so the user sees that
+        we relaxed parsing."""
+        csv_file = tmp_path / "mixed.csv"
+        self._write_mixed_endings_csv(csv_file)
+
+        captured, cleanup = self._capture_loguru_warnings()
+        try:
+            runner, _ = create_ephemeral_session([str(csv_file)])
+        finally:
+            cleanup()
+        runner.close()
+
+        combined = "\n".join(captured)
+        assert "strict_mode=false" in combined
+
+    def test_clean_csv_does_not_log_fallback_warning(self, tmp_path):
+        """The strict path is preferred; no warning when sniffing
+        succeeds."""
+        csv_file = tmp_path / "clean.csv"
+        csv_file.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+
+        captured, cleanup = self._capture_loguru_warnings()
+        try:
+            runner, _ = create_ephemeral_session([str(csv_file)])
+        finally:
+            cleanup()
+        runner.close()
+
+        combined = "\n".join(captured)
+        assert "strict_mode=false" not in combined
+
+
 class TestCreateEphemeralSession:
     """Tests for create_ephemeral_session function."""
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,7 +3,9 @@
 import pytest
 
 from datasight.generate import (
+    GenerationResponseError,
     build_generation_context,
+    parse_and_validate_response,
     parse_generation_response,
     sample_enum_columns,
     sample_timestamp_columns,
@@ -53,6 +55,51 @@ class TestParseGenerationResponse:
         # Falls through to raw text path since queries marker missing
         assert schema is not None
         assert queries is None
+
+
+class TestParseAndValidateResponse:
+    """Tests for parse_and_validate_response — the gate that prevents
+    silent partial-project writes when the LLM output is unusable."""
+
+    def test_valid_response_returns_both(self):
+        text = (
+            "--- schema_description.md ---\n# Schema\n\n"
+            "--- queries.yaml ---\n- question: q\n  sql: SELECT 1\n"
+        )
+        schema, queries = parse_and_validate_response(text, stop_reason="end_turn")
+        assert "Schema" in schema
+        assert queries is not None and "question" in queries
+
+    def test_raw_text_treated_as_schema(self):
+        """When markers are missing but the LLM produced text, accept it
+        as the schema description (queries=None)."""
+        schema, queries = parse_and_validate_response(
+            "Just a description, no markers", stop_reason="end_turn"
+        )
+        assert schema == "Just a description, no markers"
+        assert queries is None
+
+    def test_empty_response_with_max_tokens_raises_with_hint(self):
+        """The exact failure mode the user reported: reasoning model
+        burned all tokens on <think> output, schema is empty."""
+        with pytest.raises(GenerationResponseError) as exc_info:
+            parse_and_validate_response("", stop_reason="max_tokens")
+        msg = str(exc_info.value)
+        assert "token budget" in msg
+        assert "--max-tokens" in msg
+
+    def test_empty_response_without_truncation_raises_generic(self):
+        """Empty response with stop_reason=end_turn — different cause
+        (model returned nothing, not truncation), different message."""
+        with pytest.raises(GenerationResponseError) as exc_info:
+            parse_and_validate_response("", stop_reason="end_turn")
+        msg = str(exc_info.value)
+        assert "empty" in msg.lower() or "parseable" in msg.lower()
+        assert "token budget" not in msg
+
+    def test_whitespace_only_response_raises(self):
+        with pytest.raises(GenerationResponseError):
+            parse_and_validate_response("   \n  \n", stop_reason="max_tokens")
 
 
 class TestBuildGenerationContext:

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -136,21 +136,27 @@ def test_set_env_vars_appends_missing(tmp_path):
 class _StubLLMClient:
     calls: list[dict]
 
-    def __init__(self):
+    def __init__(self, *, content_text: str | None = None, stop_reason: str = "end_turn"):
         self.calls = []
+        self._content_text = (
+            content_text
+            if content_text is not None
+            else (
+                "--- schema_description.md ---\n"
+                "# Schema\n\nGeneration fuel data.\n\n"
+                "--- queries.yaml ---\n"
+                "- question: Total MWh\n"
+                "  sql: SELECT SUM(net_generation_mwh) FROM generation_fuel\n"
+            )
+        )
+        self._stop_reason = stop_reason
 
     async def create_message(self, **kwargs):
         self.calls.append(kwargs)
-        text = (
-            "--- schema_description.md ---\n"
-            "# Schema\n\nGeneration fuel data.\n\n"
-            "--- queries.yaml ---\n"
-            "- question: Total MWh\n"
-            "  sql: SELECT SUM(net_generation_mwh) FROM generation_fuel\n"
-        )
+        content = [TextBlock(self._content_text)] if self._content_text else []
         return SimpleNamespace(
-            content=[TextBlock(text)],
-            stop_reason="end_turn",
+            content=content,
+            stop_reason=self._stop_reason,
             usage=SimpleNamespace(input_tokens=1, output_tokens=1),
         )
 
@@ -161,6 +167,80 @@ def stub_llm(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: client)
     return client
+
+
+@pytest.fixture
+def stub_llm_truncated(monkeypatch):
+    """LLM returned no content and hit max_tokens — the failure mode a
+    reasoning model triggers when its <think> output exhausts the
+    budget before any visible response."""
+    client = _StubLLMClient(content_text="", stop_reason="max_tokens")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: client)
+    return client
+
+
+def test_generate_aborts_on_truncated_llm_response(tmp_path, parquet_file, stub_llm_truncated):
+    """Reasoning model used the whole budget on hidden <think> tokens
+    and emitted no visible content. The command must exit non-zero
+    AND leave no project files behind — silently writing schema.yaml /
+    .env / database.duckdb without schema_description.md is the bug
+    this guards against."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["generate", str(parquet_file), "--project-dir", str(tmp_path)],
+    )
+    assert result.exit_code != 0, result.output
+    assert "token budget" in result.output
+    assert "--max-tokens" in result.output
+
+    for orphan in (
+        "schema_description.md",
+        "queries.yaml",
+        "schema.yaml",
+        "measures.yaml",
+        "time_series.yaml",
+        "database.duckdb",
+        ".env",
+    ):
+        assert not (tmp_path / orphan).exists(), (
+            f"{orphan} written despite LLM failure — partial project leak"
+        )
+
+
+def test_generate_max_tokens_flag_overrides_default(tmp_path, parquet_file, stub_llm):
+    """--max-tokens, when supplied, is forwarded to the LLM call."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(parquet_file),
+            "--project-dir",
+            str(tmp_path),
+            "--max-tokens",
+            "12345",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert stub_llm.calls, "LLM was not called"
+    assert stub_llm.calls[0]["max_tokens"] == 12345
+
+
+def test_generate_default_max_tokens_matches_provider(tmp_path, parquet_file, stub_llm):
+    """Without --max-tokens, the per-provider default is used. The
+    Anthropic stub_llm fixture configures provider=anthropic via the
+    ANTHROPIC_API_KEY env var, so we expect the anthropic default."""
+    from datasight.llm import default_max_output_tokens
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["generate", str(parquet_file), "--project-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert stub_llm.calls[0]["max_tokens"] == default_max_output_tokens("anthropic")
 
 
 def test_generate_creates_db_and_updates_env(tmp_path, parquet_file, stub_llm):

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -209,6 +209,30 @@ def test_generate_aborts_on_truncated_llm_response(tmp_path, parquet_file, stub_
         )
 
 
+def test_generate_truncated_with_import_mode_table_cleans_up_persistent_db(
+    tmp_path, parquet_file, stub_llm_truncated
+):
+    """`--import-mode=table` materializes a DuckDB file *before* the LLM
+    call. Validation failure must clean it up, otherwise the orphan-files
+    promise only holds for the auto/view paths."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "generate",
+            str(parquet_file),
+            "--project-dir",
+            str(tmp_path),
+            "--import-mode",
+            "table",
+        ],
+    )
+    assert result.exit_code != 0, result.output
+    assert not (tmp_path / "database.duckdb").exists(), (
+        "database.duckdb leaked despite LLM failure"
+    )
+
+
 def test_generate_max_tokens_flag_overrides_default(tmp_path, parquet_file, stub_llm):
     """--max-tokens, when supplied, is forwarded to the LLM call."""
     runner = CliRunner()

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -305,3 +305,13 @@ class TestQuoteSpecialIdentifiers:
     def test_no_match_returns_unchanged(self):
         sql = "SELECT id FROM orders"
         assert quote_special_identifiers(sql, ["Host Name"]) == sql
+
+    def test_embedded_double_quote_escaped_per_sql_standard(self):
+        """An identifier name containing a literal `"` (rare but legal in
+        a CSV header) must be emitted as `"a "" b"`, not the malformed
+        `"a " b"`. Use a single unpaired `"` so the literal-splitter
+        leaves it in code chunks where the rewriter actually sees it."""
+        out = quote_special_identifiers('SELECT a " b FROM t', ['a " b'])
+        assert '"a "" b"' in out
+        # And the broken form must not appear.
+        assert 'SELECT a " b FROM t' not in out

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,9 +1,11 @@
-"""Tests for Postgres mixed-case identifier quoting."""
+"""Tests for SQL identifier quoting (mixed case + whitespace)."""
 
 from datasight.identifiers import (
     build_identifier_case_map,
+    build_special_identifier_list,
     configure_runner_identifier_quoting,
     quote_mixed_case_identifiers,
+    quote_special_identifiers,
 )
 
 
@@ -120,6 +122,12 @@ class TestQuoteMixedCaseIdentifiers:
 class _FakePostgresRunner:
     def __init__(self):
         self.mixed_case_identifiers: dict[str, str] | None = None
+        self.special_identifiers: list[str] | None = None
+
+
+class _FakeDuckDBRunner:
+    def __init__(self):
+        self.special_identifiers: list[str] | None = None
 
 
 class _FakeCachingRunner:
@@ -155,3 +163,145 @@ class TestConfigureRunnerIdentifierQuoting:
         d = Dummy()
         configure_runner_identifier_quoting(d, [{"name": "Battery", "columns": [{"name": "id"}]}])
         assert not hasattr(d, "mixed_case_identifiers")
+
+    def test_sets_special_identifiers_on_duckdb_runner(self):
+        r = _FakeDuckDBRunner()
+        configure_runner_identifier_quoting(
+            r,
+            [
+                {
+                    "name": "hosts",
+                    "columns": [{"name": "Host Name"}, {"name": "id"}],
+                }
+            ],
+        )
+        assert r.special_identifiers == ["Host Name"]
+
+    def test_special_identifiers_unset_when_no_spaces(self):
+        r = _FakeDuckDBRunner()
+        configure_runner_identifier_quoting(r, [{"name": "orders", "columns": [{"name": "id"}]}])
+        assert r.special_identifiers is None
+
+    def test_postgres_runner_gets_both_lists(self):
+        r = _FakePostgresRunner()
+        configure_runner_identifier_quoting(
+            r,
+            [
+                {
+                    "name": "Battery",
+                    "columns": [{"name": "Host Name"}],
+                }
+            ],
+        )
+        assert r.mixed_case_identifiers == {"battery": "Battery", "host name": "Host Name"}
+        assert r.special_identifiers == ["Host Name"]
+
+
+class TestBuildSpecialIdentifierList:
+    def test_picks_columns_with_spaces(self):
+        info = [{"name": "t", "columns": [{"name": "Host Name"}, {"name": "id"}]}]
+        assert build_special_identifier_list(info) == ["Host Name"]
+
+    def test_picks_table_with_space(self):
+        info = [{"name": "Power Plant", "columns": [{"name": "id"}]}]
+        assert build_special_identifier_list(info) == ["Power Plant"]
+
+    def test_orders_longest_words_first(self):
+        info = [
+            {
+                "name": "t",
+                "columns": [
+                    {"name": "Net Generation MWh"},
+                    {"name": "Net Generation"},
+                ],
+            }
+        ]
+        assert build_special_identifier_list(info) == [
+            "Net Generation MWh",
+            "Net Generation",
+        ]
+
+    def test_no_spaces_returns_empty(self):
+        info = [{"name": "orders", "columns": [{"name": "id"}, {"name": "total"}]}]
+        assert build_special_identifier_list(info) == []
+
+    def test_dedupes_repeats_across_tables(self):
+        info = [
+            {"name": "a", "columns": [{"name": "Host Name"}]},
+            {"name": "b", "columns": [{"name": "Host Name"}]},
+        ]
+        assert build_special_identifier_list(info) == ["Host Name"]
+
+
+class TestQuoteSpecialIdentifiers:
+    def test_empty_list_returns_unchanged(self):
+        sql = "SELECT Host Name FROM hosts"
+        assert quote_special_identifiers(sql, []) == sql
+
+    def test_empty_sql_returns_unchanged(self):
+        assert quote_special_identifiers("", ["Host Name"]) == ""
+
+    def test_bare_two_word_name_quoted(self):
+        out = quote_special_identifiers("SELECT Host Name FROM hosts", ["Host Name"])
+        assert out == 'SELECT "Host Name" FROM hosts'
+
+    def test_multiple_occurrences_quoted(self):
+        out = quote_special_identifiers(
+            "SELECT Host Name FROM hosts WHERE Host Name = 'foo'", ["Host Name"]
+        )
+        assert out == 'SELECT "Host Name" FROM hosts WHERE "Host Name" = \'foo\''
+
+    def test_case_insensitive_match_uses_canonical_casing(self):
+        out = quote_special_identifiers("SELECT host name FROM hosts", ["Host Name"])
+        assert out == 'SELECT "Host Name" FROM hosts'
+
+    def test_string_literal_left_alone(self):
+        out = quote_special_identifiers("SELECT 'Host Name' AS label FROM hosts", ["Host Name"])
+        assert out == "SELECT 'Host Name' AS label FROM hosts"
+
+    def test_already_quoted_left_alone(self):
+        sql = 'SELECT "Host Name" FROM hosts'
+        assert quote_special_identifiers(sql, ["Host Name"]) == sql
+
+    def test_line_comment_left_alone(self):
+        out = quote_special_identifiers(
+            "SELECT Host Name -- pick Host Name\nFROM hosts", ["Host Name"]
+        )
+        assert "-- pick Host Name" in out
+        assert 'SELECT "Host Name"' in out
+
+    def test_block_comment_left_alone(self):
+        out = quote_special_identifiers(
+            "SELECT Host Name /* skip Host Name here */ FROM hosts", ["Host Name"]
+        )
+        assert "/* skip Host Name here */" in out
+        assert 'SELECT "Host Name"' in out
+
+    def test_three_word_name_quoted(self):
+        out = quote_special_identifiers(
+            "SELECT Net Generation MWh FROM gen", ["Net Generation MWh"]
+        )
+        assert out == 'SELECT "Net Generation MWh" FROM gen'
+
+    def test_longer_name_wins_over_prefix(self):
+        out = quote_special_identifiers(
+            "SELECT Net Generation MWh FROM gen",
+            ["Net Generation MWh", "Net Generation"],
+        )
+        assert '"Net Generation MWh"' in out
+        assert '"Net Generation" MWh' not in out
+
+    def test_qualified_column_quoted(self):
+        out = quote_special_identifiers("SELECT t.Host Name FROM hosts t", ["Host Name"])
+        # Qualified-form survives: t."Host Name" is legal.
+        assert 't."Host Name"' in out
+
+    def test_substring_inside_other_identifier_not_matched(self):
+        # `MyHost Name` should not match `Host Name` because the H is
+        # preceded by an identifier character.
+        out = quote_special_identifiers("SELECT MyHost Name FROM t", ["Host Name"])
+        assert out == "SELECT MyHost Name FROM t"
+
+    def test_no_match_returns_unchanged(self):
+        sql = "SELECT id FROM orders"
+        assert quote_special_identifiers(sql, ["Host Name"]) == sql

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -416,6 +416,34 @@ def test_create_llm_client_missing_api_key_raises_configuration_error():
             create_llm_client(provider, api_key="")
 
 
+class TestDefaultMaxOutputTokens:
+    """Per-provider one-shot output budget. GitHub Models has a tighter
+    cap (~8K) than the others, so we keep its default below that."""
+
+    def test_github_stays_under_cap(self):
+        from datasight.llm import default_max_output_tokens
+
+        # GitHub Models caps output around 8096; pick a default that won't
+        # collide with that limit.
+        assert default_max_output_tokens("github") <= 8096
+
+    def test_reasoning_friendly_providers_get_more_room(self):
+        """Anthropic / OpenAI / Ollama have no GitHub-style 8K cap and
+        run reasoning-heavy models, so their default is larger."""
+        from datasight.llm import default_max_output_tokens
+
+        github = default_max_output_tokens("github")
+        for p in ("anthropic", "openai", "ollama"):
+            assert default_max_output_tokens(p) > github
+
+    def test_unknown_provider_falls_back_safely(self):
+        """Unknown providers fall back to the conservative default —
+        better to fit within an unknown cap than blow through it."""
+        from datasight.llm import default_max_output_tokens
+
+        assert default_max_output_tokens("nope-not-real") <= 8096
+
+
 # NOTE: ``AsyncAnthropic.__init__`` does no network IO, so there's no
 # init-time ``APIConnectionError`` to wrap. The factory propagates any
 # ``AnthropicError`` from the constructor as-is (config problem, not


### PR DESCRIPTION
## Summary

Three independent robustness fixes that surfaced while testing against a dsgrid CSV. Each is a separate commit and could land alone.

- **Quote whitespace-containing identifiers across all dialects.** The Postgres-only `quote_mixed_case_identifiers` is now joined by `quote_special_identifiers`, a regex pre-pass that wraps bare references to multi-word names (e.g. `SELECT Net Generation MWh FROM t`) in double quotes — respecting string literals, already-quoted identifiers, and comments. Wired into DuckDB, EphemeralDuckDB, SQLite, and Postgres runners. Fixes the case where smaller Ollama models emit unquoted column names from CSV headers like `Net Generation MWh`.
- **Fall back to lenient CSV reads when the sniffer fails.** DuckDB's auto-sniffer chokes on files with mixed line endings (CRLF throughout but LF on the final line — a Windows-export quirk). The four CSV-import paths in `explore.py` now retry with `strict_mode=false` after a sniffer error, with a one-line warning explaining the relaxation. Other DuckDB errors propagate unchanged.
- **Fail loud and grant reasoning models a real budget in `generate`.** Two issues collapsed into one fix: (1) the 4096-token default truncated reasoning models that burn thousands of tokens on hidden `<think>` content; new per-provider defaults are 16384 for Anthropic / OpenAI / Ollama and 8000 for GitHub Models (under its ~8K cap), plus a `--max-tokens` override; (2) when the LLM returns empty / unparseable output, the command used to silently continue and leave a half-built project (no `schema_description.md` / `queries.yaml` but `schema.yaml`, `.env`, `database.duckdb`, etc. all written). Now validates the response before touching any files and emits a tailored error pointing at `--max-tokens` when `stop_reason == "max_tokens"`.

## Test plan

- [x] `pytest -m "not integration"` — 1434 pass (was 1420; +14 new)
- [x] `prek run --all-files` — ruff / format / ty / docs CLI drift all clean
- [x] End-to-end with the dsgrid `load_data.csv` (4104 rows × 28 cols, mixed CRLF/LF, qwen3.6 via Ollama):
  - `datasight inspect` succeeds via the lenient CSV fallback
  - `datasight generate --max-tokens 1000` exits non-zero with the actionable error and leaves **no** orphan project files
  - `datasight generate` (default 16384 budget for Ollama) produces all 7 project files including a real `schema_description.md` and `queries.yaml`
- [x] End-to-end with a synthetic `Plant Type` / `Net Generation MWh` schema: bare LLM-style SQL gets rewritten to the correctly quoted form before DuckDB sees it

🤖 Generated with [Claude Code](https://claude.com/claude-code)