### PR TITLE
Tidy review: web UI drawer + rework source disposition

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -748,6 +748,7 @@ datasight tidy review --from plan.json --apply-all
 datasight tidy review --from plan.json --dry-run
 datasight tidy review --out detector.json
 datasight tidy review --from plan.json --apply-all --drop-source
+datasight tidy review --from plan.json --apply-all --replace-source
 datasight tidy review --from plan.json --apply-all --rename-source sales_wide_raw
 ```
 
@@ -768,7 +769,8 @@ datasight tidy review [OPTIONS]
 | `--as` | Materialize the long form as a table or view (default: view). Default: `view`. |
 | `--keep-source` | Leave the source object (table/view) unchanged after the reshape (default). |
 | `--rename-source` | Rename the source object (table/view) to NAME after a successful reshape. Requires '--as table' — a view's body references its source by name. |
-| `--drop-source` | Drop the source after a successful reshape and rename the long-form table to take the source's old name. The long form replaces the source. Requires '--as table' — a view's body references its source by name. |
+| `--replace-source` | Drop the source after a successful reshape and rename the long-form table to take the source's old name. Downstream code that referenced the source keeps working without edits. Requires '--as table' — a view's body references its source by name. |
+| `--drop-source` | Drop the source after a successful reshape; the long form keeps its target name. Pick this when the new shape is the canonical one going forward and you don't need to preserve the source's name. Requires '--as table'. NOTE: previously this flag carried the semantics now moved to '--replace-source'; scripts depending on the old behavior should switch to '--replace-source'. |
 | `--sample` | Send N sample rows per candidate to the configured LLM provider (default 0). Sample values get sent over the network — opt in only when the LLM seeing the values is acceptable. |
 
 ### `datasight integrity`

--- a/docs/reference/web-ui.md
+++ b/docs/reference/web-ui.md
@@ -67,7 +67,7 @@ Toggle the sidebar with the hamburger button in the header or
 
 | Section | Purpose |
 |---------|---------|
-| **Tables** | Database tables, column types, preview rows, column stats |
+| **Tables** | Database tables, column types, preview rows, column stats. Per-table action chips: **Preview rows**, **Ask** (drops a question into chat), **Tidy** (DuckDB-only — opens the [Tidy review drawer](../use/how-to/curate-with-tidy-review.md#from-the-web-ui) for wide→long reshape proposals), **Insert** (in SQL view — drops the table or column name into the editor at the cursor) |
 | **Example queries** | From `queries.yaml`, filtered to the selected table |
 | **Recipes** | Schema-derived reusable prompts |
 | **Inspect** | Deterministic inspection flows (profile, measures, dimensions, quality, trends) |

--- a/docs/use/how-to/curate-with-tidy-review.md
+++ b/docs/use/how-to/curate-with-tidy-review.md
@@ -1,23 +1,106 @@
-# Curate datasets with `tidy review`
+# Curate datasets with Tidy review
 
 !!! warning "Experimental"
-    `tidy review` is experimental and its interface is subject to change.
-    Review every proposal carefully before applying, and use `--dry-run`
-    to preview changes. Back up your database before running `--apply-all`
-    for the first time.
+    Tidy review is experimental and its interface is subject to change.
+    Review every proposal carefully before applying, and back up your
+    database before running an apply for the first time. The CLI's
+    `--dry-run` is the safest way to preview changes.
 
-`datasight tidy review` is an LLM-augmented advisor for the project
-developer. It proposes reshapes that the regex-based detector
-(`tidy suggest`) cannot see — fuel-type-as-column, geography-as-column,
-scenario-as-column, multi-axis pivots — and lets you approve each one
-before it changes the database.
+Tidy review is an LLM-augmented advisor for the project developer. It
+proposes reshapes that the regex-based detector (`tidy suggest`) cannot
+see — fuel-type-as-column, geography-as-column, scenario-as-column,
+multi-axis pivots — and lets you approve each one before it changes the
+database.
 
 This is a **developer-side curation tool**. The intended workflow is:
-the project developer runs `tidy review` while preparing a dataset, then
+the project developer runs Tidy review while preparing a dataset, then
 end users ask questions through the read-only web UI against the tidy
-form. End users never see this command.
+form. End users never see this surface.
 
-## When to reach for `tidy review`
+Two ways to drive it:
+
+- **Web UI drawer** (`datasight run`) — point-and-click flow with a
+  visual melt diagram, per-card edits, live SQL preview, and inline row
+  preview. Best for interactive curation.
+- **CLI** (`datasight tidy review`) — scriptable, plan-file based.
+  Best for CI and reproducible dataset prep.
+
+Both surfaces share the same underlying engine, so a proposal you tweak
+in the drawer produces the same DDL the CLI would.
+
+## From the web UI
+
+Open a project with `datasight run`, click a table in the schema
+sidebar to expand it, and click the **Tidy** chip in the per-table
+action row. The chip is DuckDB-only — other backends don't get it
+because the apply pipeline opens a writable DuckDB connection.
+
+### What the drawer does
+
+The drawer slides in from the right and immediately runs the
+deterministic detector, showing any regex-matched proposals as cards.
+The LLM does not run automatically — the **Run agent** button at the
+top of the drawer fires the LLM advisor and appends its proposals to
+the list. This split is intentional: the deterministic step is free
+and instant, the LLM step costs a model call, and you should opt in
+explicitly.
+
+Per proposal you get:
+
+- A small SVG **melt diagram** showing source columns folding into the
+  long-form schema (id columns straight across, measure columns curved
+  into the value column, dimension columns annotated with their dtype).
+- Editable **target name**, **value column**, and **id columns**.
+- A **Keep rows with NULL values** checkbox (off by default — see
+  [Null handling](#null-handling) below).
+- A **Preview rows** button that samples 50 rows of the would-be long
+  form against the live database, no DDL.
+- A **Show SQL** toggle that renders the DDL the apply step would run,
+  reflecting your edits and the current view/table mode in real time.
+- A **Skip** toggle to exclude one proposal from the next apply (useful
+  when the agent returns alternatives you don't want).
+
+### Apply
+
+The footer holds the materialization controls and the Apply button:
+
+- **Materialize as** — `view` (default) or `table`. Views re-evaluate
+  against the source on every query; tables are physical copies.
+- **Source** — `Keep` (default), `Rename`, `Replace`, or `Drop`. See
+  [Source disposition](#source-disposition) below for what each one
+  means.
+- **Apply** — runs every non-skipped, non-already-applied proposal in
+  one batch. Each proposal goes through its own DuckDB transaction with
+  a row-count verify, so a mid-batch failure leaves prior successes
+  intact and rolls back only the failing one.
+
+After a successful apply, the schema sidebar refreshes so the new
+long-form objects show up immediately. If the project keeps a
+`schema.yaml` allowlist, the apply rewrites it so the new objects stay
+visible across restarts. If the project doesn't have one yet, the
+drawer creates it (the CLI keeps the no-op-when-absent default).
+
+### Drawer agent panel
+
+The **Sample rows sent to LLM** input in the agent panel controls
+how many rows of values per table go to the configured LLM provider.
+Default is 0 (schema-only). Bump it when column names are ambiguous
+and the agent isn't picking up obvious patterns from names alone (a
+typical sweet spot is 5–10). Values go over the network, so leave it
+at 0 for sensitive data — see [Sample rows: opt-in data
+exposure](#sample-rows-opt-in-data-exposure) for the rationale.
+
+## From the CLI
+
+The CLI exposes the same engine for scripting and CI. Reach for it when:
+
+- The web UI isn't running (e.g. headless dataset prep on a build box).
+- You want to capture the curation as a checked-in plan file that
+  replays deterministically across environments.
+- You need `--dry-run` to print every DDL statement without touching
+  the database.
+
+### When to reach for `tidy review`
 
 Use the deterministic commands first:
 
@@ -108,23 +191,43 @@ by emitting `UNION ALL` for views, but the SQL is more verbose.
 
 ## Source disposition
 
-After a successful reshape you have three options for what happens to
-the wide source table:
+After a successful reshape you have four options for what happens to
+the wide source table. They differ on the *final name* of the long
+form:
 
 ```bash
 # (default) Leave the source untouched alongside the new long form.
 datasight tidy review --keep-source
 
 # Rename the source — useful when end users only need the tidy form.
+# Long form lives at its target name (e.g. `generation_fuel_long`);
+# old wide table moves to `generation_fuel_wide_raw`.
 datasight tidy review --rename-source generation_fuel_wide_raw
 
-# Drop the source entirely.
+# Drop the source AND rename the long form into its slot.
+# Downstream code that referenced the source name keeps working —
+# `SELECT * FROM generation_fuel_wide` now returns the long form.
+datasight tidy review --replace-source
+
+# Drop the source. The long form keeps its target name
+# (`generation_fuel_long`). Downstream code referencing the source
+# name will break — pick this when the new shape is canonical.
 datasight tidy review --drop-source
 ```
+
+!!! warning "Breaking change in `--drop-source`"
+    `--drop-source` previously meant *replace* (drop the source and
+    rename the long form into its slot). The flag now means *bare drop*
+    (long form keeps its target name); use `--replace-source` for the
+    old behavior. Scripts that depended on the old `--drop-source`
+    should switch.
 
 The flags are mutually exclusive. The disposition runs *only after* the
 verify step passes; if anything fails, the entire transaction rolls back
 and the source remains in place.
+
+In the web UI these map to the **Source** radio group in the drawer
+footer: Keep, Rename, Replace, Drop.
 
 ## Sample rows: opt-in data exposure
 
@@ -139,6 +242,63 @@ datasight tidy review --sample 5
 The values in those rows go to your configured LLM provider over the
 network. Use this only when the data is not sensitive — research
 datasets, public datasets, or your own test data.
+
+## Null handling
+
+Each proposal carries an `include_nulls` flag (default `false`). When
+false, rows where the source value is `NULL` are dropped from the long
+form — matching DuckDB's native `UNPIVOT` behavior. When true, those
+rows survive and the long form has exactly
+`len(source) × len(column_mappings)` rows.
+
+The default is `false` because most NULLs in wide tables are
+*structural*: a NULL means "this combination doesn't apply" (e.g.,
+`lpg_lighting` in a fuel × end-use pivot, where LPG isn't typically
+used for lighting). Carrying those rows into the long form just inflates
+cardinality with no information value — analysts would filter them out
+as their first move anyway.
+
+Flip the toggle on for data where a NULL is a *real* missing observation
+you want to keep visible:
+
+- **Sensor data** with hourly columns where some hours had no reading.
+  NULL = "we tried to measure but no reading came in" — dropping loses
+  the gap.
+- **Survey data** with optional questions. NULL = "respondent didn't
+  answer" — dropping loses the non-response signal.
+
+In the web UI: the **Keep rows with NULL values** checkbox on each
+proposal card. In the CLI: edit the `include_nulls` field in a plan
+file and feed it back via `--from`.
+
+!!! info "Mode parity"
+    DuckDB 1.5.2 has no `INCLUDE NULLS` clause for `UNPIVOT`, so
+    applying the same proposal as a view vs. a table used to silently
+    produce different row counts. The current dispatcher avoids this by
+    routing through UNPIVOT only when `include_nulls=false` AND mode is
+    `table` AND it's a single-pivot proposal — every other combination
+    uses `UNION ALL` (with a `WHERE … IS NOT NULL` filter per branch
+    when `include_nulls=false`) so the two modes always line up.
+
+## Dimension dtypes
+
+Each dimension column carries a `dtype` so the long-form column doesn't
+inherit `VARCHAR` from the literal. The deterministic detector picks
+sensible defaults per period kind:
+
+| Kind                                   | Default dtype |
+|----------------------------------------|---------------|
+| `year`, `hour`, `day`, `month_num`     | `INTEGER`     |
+| `year_month`, `year_quarter`, `quarter`, `month` | `VARCHAR` |
+
+LLM-proposed and user-supplied dimensions default to `VARCHAR` unless
+the agent picks otherwise. The drawer shows the dtype next to each
+dimension name on the proposal card; in plan files it's the
+`dimensions[].dtype` field.
+
+Allowed values: `VARCHAR`, `INTEGER`, `BIGINT`, `SMALLINT`, `DOUBLE`,
+`DATE`, `TIMESTAMP`. Anything else is rejected at parse time so a
+plan can't smuggle SQL into the generated `CAST(...)` clause.
 
 ## Non-interactive workflows
 
@@ -194,16 +354,17 @@ you get a clean error rather than a half-applied reshape.
     {
       "table": "generation_fuel_wide",
       "dimensions": [
-        {"name": "fuel_type", "kind": "category"}
+        {"name": "fuel_type", "kind": "category", "dtype": "VARCHAR"}
       ],
       "id_columns": ["plant_id", "report_date"],
-      "value_column": "net_generation_mwh",
+      "value_column": "value",
       "target_object_name": "generation_fuel_long",
       "column_mappings": [
         {"column": "coal_mwh",    "dimension_values": {"fuel_type": "coal"}},
         {"column": "gas_mwh",     "dimension_values": {"fuel_type": "gas"}},
         {"column": "nuclear_mwh", "dimension_values": {"fuel_type": "nuclear"}}
       ],
+      "include_nulls": false,
       "confidence": "high",
       "source": "user",
       "rationale": "Fuel-type-as-column pivot."
@@ -218,8 +379,8 @@ For a multi-axis pivot, add more entries to `dimensions` and one
 ```json
 {
   "dimensions": [
-    {"name": "fuel_type", "kind": "category"},
-    {"name": "year", "kind": "date_period"}
+    {"name": "fuel_type", "kind": "category", "dtype": "VARCHAR"},
+    {"name": "year",      "kind": "date_period", "dtype": "INTEGER"}
   ],
   "column_mappings": [
     {"column": "coal_2020", "dimension_values": {"fuel_type": "coal", "year": "2020"}},
@@ -230,9 +391,19 @@ For a multi-axis pivot, add more entries to `dimensions` and one
 }
 ```
 
-Allowed `dimensions[].kind` values: `date_period`, `category`,
-`geography`, `scenario`, `other`. Allowed `confidence` values: `high`,
-`medium`, `low`.
+Field reference:
+
+- `dimensions[].kind` — one of `date_period`, `category`, `geography`,
+  `scenario`, `other`.
+- `dimensions[].dtype` — one of `VARCHAR`, `INTEGER`, `BIGINT`,
+  `SMALLINT`, `DOUBLE`, `DATE`, `TIMESTAMP`. Defaults to `VARCHAR` if
+  omitted.
+- `include_nulls` — `false` (default) drops rows where the value is
+  NULL; `true` keeps them. See [Null handling](#null-handling).
+- `value_column` — defaults to `value`. The agent and the deterministic
+  detector both prefer this generic name for predictability across
+  long-form tables.
+- `confidence` — `high`, `medium`, or `low`.
 
 ## Verify-before-dispose
 
@@ -250,14 +421,28 @@ table and the count it expected.
 
 ## Recipes
 
-### Curate one wide table for end users
+### Curate one wide table from the web UI
+
+1. `datasight run` and open the project.
+2. Click the table in the schema sidebar, then click **Tidy**.
+3. Review the deterministic proposals; click **Run agent** to ask the
+   LLM for additional candidates.
+4. Skip anything you don't want, edit target/value names if needed.
+5. Footer: pick **Materialize as Table** + **Source: Replace** if you
+   want the long form to take over the source's name (downstream
+   queries keep working). Click **Apply**.
+6. Mention the new tidy table in your `schema_description.md` so the
+   agent prefers it for future questions.
+
+### Curate one wide table from the CLI
 
 ```bash
 # 1. Inspect what the regex finds.
 datasight tidy suggest --table generation_fuel_wide
 
 # 2. Walk through LLM proposals. Apply the good ones, edit names if needed.
-datasight tidy review --table generation_fuel_wide --as table --drop-source
+#    --replace-source = drop source, long form takes over its name.
+datasight tidy review --table generation_fuel_wide --as table --replace-source
 
 # 3. Mention the new tidy table in your schema_description.md so the agent
 #    prefers it.

--- a/frontend/e2e/tidy.spec.ts
+++ b/frontend/e2e/tidy.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Drawer E2E.
+ *
+ * The CI server is launched without a project, so we mock the boot
+ * endpoints so the app believes a project is loaded with one wide table.
+ * Tidy endpoints are stubbed via page.route so this never depends on a
+ * real DuckDB or LLM provider.
+ */
+
+const SCHEMA_PAYLOAD = {
+  tables: [
+    {
+      name: "sales",
+      row_count: 2,
+      columns: [
+        { name: "region", dtype: "VARCHAR" },
+        { name: "sales_2020", dtype: "INTEGER" },
+        { name: "sales_2021", dtype: "INTEGER" },
+        { name: "sales_2022", dtype: "INTEGER" },
+        { name: "sales_2023", dtype: "INTEGER" },
+      ],
+    },
+  ],
+};
+
+const PROPOSAL = {
+  pattern: "date_in_column_names",
+  table: "sales",
+  dimensions: [{ name: "year", kind: "year" }],
+  column_mappings: [
+    { column: "sales_2020", dimension_values: { year: "2020" } },
+    { column: "sales_2021", dimension_values: { year: "2021" } },
+    { column: "sales_2022", dimension_values: { year: "2022" } },
+    { column: "sales_2023", dimension_values: { year: "2023" } },
+  ],
+  id_columns: ["region"],
+  value_column: "sales",
+  target_object_name: "sales_long",
+  rationale: "Looks like a wide-by-year table.",
+  reshape_sql: "CREATE OR REPLACE TABLE sales_long AS ...",
+  confidence: "high",
+  source: "deterministic",
+  preview_sql: "SELECT region, year, sales FROM sales LIMIT 50",
+  reshape_sql_view: "CREATE OR REPLACE VIEW sales_long AS ...",
+  reshape_sql_table: "CREATE OR REPLACE TABLE sales_long AS ...",
+};
+
+async function mockBoot(page: import("@playwright/test").Page) {
+  await page.route("**/api/project", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        loaded: true,
+        path: "/tmp/mock_project",
+        name: "mock_project",
+        is_ephemeral: false,
+        has_time_series: false,
+        sql_dialect: "duckdb",
+      }),
+    });
+  });
+  await page.route("**/api/settings", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        confirm_sql: false,
+        explain_sql: false,
+        clarify_sql: false,
+        show_provenance: false,
+        show_cost: true,
+        max_history_pairs: 10,
+      }),
+    });
+  });
+  await page.route("**/api/settings/llm", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+        base_url: "",
+        has_api_key: true,
+        connected: true,
+        env_keys: {},
+        env_models: {},
+      }),
+    });
+  });
+  await page.route("**/api/schema", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(SCHEMA_PAYLOAD),
+    });
+  });
+  // Endpoints that App.onProjectReady fans out to. Each has its own response
+  // shape — returning `[]` or `{}` would crash the sidebar's destructuring.
+  const emptyShapes: Array<[string, Record<string, unknown>]> = [
+    ["**/api/queries", { queries: [] }],
+    ["**/api/recipes", { examples: [], recipes: [] }],
+    ["**/api/bookmarks", { bookmarks: [] }],
+    ["**/api/reports", { reports: [] }],
+    ["**/api/conversations", { conversations: [] }],
+    [
+      "**/api/dashboard*",
+      { items: [], columns: 0, filters: [] },
+    ],
+    [
+      "**/api/measures/editor/catalog",
+      { ok: true, measures: [] },
+    ],
+  ];
+  for (const [path, body] of emptyShapes) {
+    await page.route(path, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+    });
+  }
+  // Per-conversation restore endpoint. App.onMount calls loadConversation
+  // with the current session id; if it 404s the boot finally still runs,
+  // but stubbing here keeps the flow deterministic.
+  await page.route(/\/api\/conversations\/[^/]+$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ events: [], dashboard: { items: [], columns: 0, filters: [] } }),
+    });
+  });
+  // Optional sidebar/health endpoints — return empty objects so they don't 404.
+  await page.route("**/api/project-health", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ checks: [] }),
+    });
+  });
+}
+
+test.describe("Tidy review drawer", () => {
+  test("opens, shows deterministic proposals, and runs the agent on demand", async ({
+    page,
+  }) => {
+    await mockBoot(page);
+
+    // /api/tidy/detect — synchronous, returns deterministic hits.
+    await page.route("**/api/tidy/detect*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ proposals: [PROPOSAL], error: null }),
+      });
+    });
+
+    // /api/tidy/propose — fired only when the user clicks "Run agent".
+    let proposeCalls = 0;
+    await page.route("**/api/tidy/propose", async (route) => {
+      proposeCalls += 1;
+      const llmProposal = {
+        ...PROPOSAL,
+        source: "llm",
+        target_object_name: "sales_long_llm",
+        rationale: "Agent-derived alternative reshape.",
+      };
+      const body = [
+        `event: llm_started\ndata: {}\n\n`,
+        `event: llm_proposals\ndata: ${JSON.stringify({
+          proposals: [llmProposal],
+          parse_warnings: [],
+        })}\n\n`,
+        `event: done\ndata: {}\n\n`,
+      ].join("");
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body,
+      });
+    });
+
+    await page.goto("/");
+
+    // Expand the sales table row in the schema inspector.
+    const tableRow = page.locator("button.table-header-btn", {
+      hasText: "sales",
+    });
+    await expect(tableRow).toBeVisible({ timeout: 5000 });
+    await tableRow.click();
+
+    const tidyBtn = page.locator("button", { hasText: /^Tidy$/ });
+    await expect(tidyBtn).toBeVisible();
+    await tidyBtn.click();
+
+    const drawer = page.getByRole("dialog", { name: "Tidy review" });
+    await expect(drawer).toBeVisible();
+
+    // Deterministic proposal should be visible immediately, without the
+    // LLM having been called.
+    await expect(
+      drawer.locator("text=sales → sales_long").first(),
+    ).toBeVisible();
+    await expect(drawer.locator("text=regex").first()).toBeVisible();
+    expect(proposeCalls).toBe(0);
+
+    // The agent panel offers an explicit Run button.
+    const runBtn = drawer.getByRole("button", { name: "Run agent" });
+    await expect(runBtn).toBeVisible();
+    await runBtn.click();
+
+    // After Run, an LLM proposal arrives and the propose endpoint was hit.
+    await expect(
+      drawer.locator("text=sales → sales_long_llm").first(),
+    ).toBeVisible();
+    expect(proposeCalls).toBe(1);
+    // The button now offers a re-run.
+    await expect(
+      drawer.getByRole("button", { name: "Run again" }),
+    ).toBeVisible();
+
+    // Esc closes the drawer.
+    await page.keyboard.press("Escape");
+    await expect(drawer).not.toBeVisible();
+  });
+});

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import SqlView from "$lib/components/SqlView.svelte";
   import Sidebar from "$lib/components/Sidebar.svelte";
   import MeasureEditorModal from "$lib/components/MeasureEditorModal.svelte";
+  import TidyDrawer from "$lib/components/TidyDrawer.svelte";
   import SaveProjectModal from "$lib/components/SaveProjectModal.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
   import ShortcutsModal from "$lib/components/ShortcutsModal.svelte";
@@ -24,6 +25,7 @@
   import { queriesStore } from "$lib/stores/queries.svelte";
   import { sqlEditorStore } from "$lib/stores/sql_editor.svelte";
   import { paletteStore } from "$lib/stores/palette.svelte";
+  import { tidyStore } from "$lib/stores/tidy.svelte";
   import { exitExploreSession, getProjectStatus } from "$lib/api/projects";
   import { loadSettings, loadLlmConfig } from "$lib/api/settings";
   import { loadSchema, loadQueries, loadRecipes } from "$lib/api/schema";
@@ -285,7 +287,9 @@
     /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
 
   function handleEscape() {
-    if (dashboardStore.fullscreenCardId !== null) {
+    if (tidyStore.open) {
+      tidyStore.close();
+    } else if (dashboardStore.fullscreenCardId !== null) {
       dashboardStore.fullscreenCardId = null;
     } else if (shortcutsOpen) {
       shortcutsOpen = false;
@@ -599,4 +603,5 @@
   open={shortcutsOpen}
   onClose={() => (shortcutsOpen = false)}
 />
+<TidyDrawer />
 <Toast />

--- a/frontend/src/lib/api/tidy.ts
+++ b/frontend/src/lib/api/tidy.ts
@@ -1,0 +1,230 @@
+/** API client for the per-table Tidy review drawer.
+ *
+ * - detectTidy: GET /api/tidy/detect, returns deterministic proposals.
+ *   Cheap, schema-only, fires automatically when the drawer opens.
+ * - proposeTidy: SSE stream to /api/tidy/propose, runs the LLM advisor.
+ *   Caller-driven (the drawer's "Run agent" button) so the model call
+ *   only fires on explicit opt-in.
+ * - previewTidy: POST /api/tidy/preview, returns a 50-row sample of the
+ *   long-form result without materializing it.
+ * - applyTidy: POST /api/tidy/apply, runs the reshape DDL and returns the
+ *   updated schema_info so the caller can refresh the sidebar.
+ */
+
+import { fetchJson, postJson } from "$lib/api/client";
+import type { TableInfo } from "$lib/stores/schema.svelte";
+
+export interface TidyDimension {
+  name: string;
+  kind: string;
+  /** SQL dtype for the long-form dimension column (VARCHAR, INTEGER, …).
+   * Set by the deterministic detector for known period kinds; the LLM may
+   * also propose one. The drawer treats this as read-only in v1. */
+  dtype: string;
+}
+
+export interface TidyColumnMapping {
+  column: string;
+  dimension_values: Record<string, string>;
+}
+
+/** A single tidy-reshape proposal (deterministic or LLM-derived).
+ *
+ * Mirrors `TidySuggestion.to_dict()` plus three convenience fields the
+ * server adds for the drawer (`preview_sql`, `reshape_sql_view`,
+ * `reshape_sql_table`).
+ */
+export interface TidyProposal {
+  pattern: string;
+  table: string;
+  dimensions: TidyDimension[];
+  column_mappings: TidyColumnMapping[];
+  id_columns: string[];
+  value_column: string;
+  target_object_name: string;
+  rationale: string;
+  reshape_sql: string;
+  confidence: "high" | "medium" | "low";
+  source: "deterministic" | "llm" | "user";
+  /** When true, rows where the source value is NULL survive the reshape.
+   * Default false drops them — most NULLs in wide tables are structural
+   * placeholders for combinations that don't apply. Toggle on for data
+   * where NULL is a meaningful "missing observation" you want to keep. */
+  include_nulls: boolean;
+  preview_sql?: string;
+  reshape_sql_view?: string;
+  reshape_sql_table?: string;
+}
+
+export type TidyMaterializeMode = "view" | "table";
+
+export type TidyDispositionMode = "keep" | "rename" | "replace" | "drop";
+
+export interface TidyDisposition {
+  mode: TidyDispositionMode;
+  new_name?: string;
+}
+
+export interface TidyApplyResult {
+  table: string;
+  target_object_name: string;
+  final_target_name: string;
+  object_type: TidyMaterializeMode;
+  affected_columns: string[];
+  row_count_source: number;
+  row_count_target: number;
+  source_disposition: TidyDispositionMode;
+  source_renamed_to: string | null;
+  dry_run: boolean;
+}
+
+export interface TidyApplyResponse {
+  success: boolean;
+  result?: TidyApplyResult;
+  schema_info?: TableInfo[];
+  error?: string;
+}
+
+export interface TidyPreviewResponse {
+  html: string | null;
+  row_count: number;
+  error: string | null;
+}
+
+export interface TidyDetectResponse {
+  proposals: TidyProposal[];
+  error: string | null;
+}
+
+export async function detectTidy(table: string): Promise<TidyDetectResponse> {
+  const url = `/api/tidy/detect?table=${encodeURIComponent(table)}`;
+  return fetchJson<TidyDetectResponse>(url);
+}
+
+export interface ProposeCallbacks {
+  onLlmStarted?: () => void;
+  onLlmProposals?: (
+    proposals: TidyProposal[],
+    parseWarnings: string[],
+  ) => void;
+  onLlmError?: (error: string) => void;
+  onError?: (error: string) => void;
+  onDone?: () => void;
+}
+
+export interface ProposeOptions extends ProposeCallbacks {
+  table: string;
+  sampleRows?: number;
+  signal?: AbortSignal;
+}
+
+export async function proposeTidy(opts: ProposeOptions): Promise<void> {
+  const body = JSON.stringify({
+    table: opts.table,
+    sample_rows: opts.sampleRows ?? 0,
+  });
+
+  const resp = await fetch("/api/tidy/propose", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    signal: opts.signal,
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Tidy propose failed: HTTP ${resp.status}`);
+  }
+
+  const reader = resp.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let eventType = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+
+    for (const line of lines) {
+      if (line.startsWith("event: ")) {
+        eventType = line.slice(7).trim();
+      } else if (line.startsWith("data: ")) {
+        let data: unknown;
+        try {
+          data = JSON.parse(line.slice(6));
+        } catch {
+          eventType = "";
+          continue;
+        }
+        dispatchProposeEvent(eventType, data, opts);
+        eventType = "";
+      }
+    }
+  }
+}
+
+function dispatchProposeEvent(
+  eventType: string,
+  data: unknown,
+  cb: ProposeCallbacks,
+): void {
+  const payload = data as Record<string, unknown>;
+  switch (eventType) {
+    case "llm_started":
+      cb.onLlmStarted?.();
+      break;
+    case "llm_proposals":
+      cb.onLlmProposals?.(
+        (payload.proposals as TidyProposal[]) ?? [],
+        (payload.parse_warnings as string[]) ?? [],
+      );
+      break;
+    case "llm_error":
+      cb.onLlmError?.(String(payload.error ?? "LLM error"));
+      break;
+    case "error":
+      cb.onError?.(String(payload.error ?? "Tidy propose error"));
+      break;
+    case "done":
+      cb.onDone?.();
+      break;
+    default:
+      // Unknown event types are ignored — keeps the contract forward-compatible.
+      break;
+  }
+}
+
+export async function previewTidy(
+  proposal: TidyProposal,
+): Promise<TidyPreviewResponse> {
+  return postJson<TidyPreviewResponse>("/api/tidy/preview", { proposal });
+}
+
+export interface TidyRenderSqlResponse {
+  sql: string;
+  error: string | null;
+}
+
+/** Re-render the reshape DDL for a proposal in the requested mode.
+ *
+ * Used by the Show SQL panel so the displayed DDL reflects the user's
+ * current edits and the global view/table toggle, not the frozen
+ * snapshot baked at detect time.
+ */
+export async function renderTidySql(args: {
+  proposal: TidyProposal;
+  mode: TidyMaterializeMode;
+}): Promise<TidyRenderSqlResponse> {
+  return postJson<TidyRenderSqlResponse>("/api/tidy/render-sql", args);
+}
+
+export async function applyTidy(args: {
+  proposal: TidyProposal;
+  mode: TidyMaterializeMode;
+  disposition: TidyDisposition;
+}): Promise<TidyApplyResponse> {
+  return postJson<TidyApplyResponse>("/api/tidy/apply", args);
+}

--- a/frontend/src/lib/components/SchemaInspector.svelte
+++ b/frontend/src/lib/components/SchemaInspector.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { schemaStore } from "$lib/stores/schema.svelte";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  import { sessionStore } from "$lib/stores/session.svelte";
   import { sqlEditorStore } from "$lib/stores/sql_editor.svelte";
+  import { tidyStore } from "$lib/stores/tidy.svelte";
   import { sendMessage } from "$lib/api/chat";
   import { loadPreview, loadColumnStats } from "$lib/api/schema";
   import { getVisibleSchemaEntries } from "$lib/utils/search";
@@ -81,6 +83,10 @@
 
   function insertIntoEditor(text: string) {
     sqlEditorStore.pendingInsert = text;
+  }
+
+  function startTidyReview(tableName: string) {
+    void tidyStore.start(tableName);
   }
 </script>
 
@@ -162,6 +168,20 @@
               >
                 Ask
               </button>
+              {#if sessionStore.sqlDialect === "duckdb"}
+                <button
+                  class="cursor-pointer transition-all duration-150
+                    hover:text-teal hover:border-teal"
+                  style="border: 1px solid var(--border);
+                         background: color-mix(in srgb, var(--surface) 82%, var(--bg));
+                         border-radius: 999px; padding: 2px 8px; font-family: inherit;
+                         font-size: 0.67rem; color: var(--text-secondary);"
+                  onclick={() => startTidyReview(table.name)}
+                  title="LLM-augmented advisor that proposes wide→long reshapes"
+                >
+                  Tidy
+                </button>
+              {/if}
               {#if dashboardStore.currentView === "sql"}
                 <button
                   class="cursor-pointer transition-all duration-150

--- a/frontend/src/lib/components/TidyDrawer.svelte
+++ b/frontend/src/lib/components/TidyDrawer.svelte
@@ -31,7 +31,7 @@
       tidyStore.proposals.some((p) => p.proposal.source === "llm"),
   );
 
-  let llmDisabledForViewMode = $derived(tidyStore.mode === "view");
+  let dispositionDisabledForViewMode = $derived(tidyStore.mode === "view");
 
   // Reload the schema sidebar after each successful apply so the new
   // long-form object shows up immediately. Wired here (not in the store)
@@ -235,8 +235,8 @@
 
           <fieldset
             class="seg"
-            class:disabled={llmDisabledForViewMode}
-            title={llmDisabledForViewMode
+            class:disabled={dispositionDisabledForViewMode}
+            title={dispositionDisabledForViewMode
               ? "Rename, Replace, and Drop require Materialize as Table — a view references its source by name."
               : ""}
           >
@@ -256,7 +256,7 @@
                 type="radio"
                 name="tidy-disp"
                 value="rename"
-                disabled={llmDisabledForViewMode}
+                disabled={dispositionDisabledForViewMode}
                 checked={tidyStore.dispositionMode === "rename"}
                 onchange={() => (tidyStore.dispositionMode = "rename")}
               />
@@ -267,7 +267,7 @@
                 type="radio"
                 name="tidy-disp"
                 value="replace"
-                disabled={llmDisabledForViewMode}
+                disabled={dispositionDisabledForViewMode}
                 checked={tidyStore.dispositionMode === "replace"}
                 onchange={() => (tidyStore.dispositionMode = "replace")}
               />
@@ -278,7 +278,7 @@
                 type="radio"
                 name="tidy-disp"
                 value="drop"
-                disabled={llmDisabledForViewMode}
+                disabled={dispositionDisabledForViewMode}
                 checked={tidyStore.dispositionMode === "drop"}
                 onchange={() => (tidyStore.dispositionMode = "drop")}
               />

--- a/frontend/src/lib/components/TidyDrawer.svelte
+++ b/frontend/src/lib/components/TidyDrawer.svelte
@@ -1,0 +1,684 @@
+<script lang="ts">
+  import { tidyStore } from "$lib/stores/tidy.svelte";
+  import { toastStore } from "$lib/stores/toast.svelte";
+  import { schemaStore, type TableInfo } from "$lib/stores/schema.svelte";
+  import TidyProposalCard from "./TidyProposalCard.svelte";
+
+  let renameValid = $derived(
+    tidyStore.dispositionMode !== "rename" ||
+      tidyStore.dispositionRenameTo.trim().length > 0,
+  );
+
+  let canApply = $derived(
+    tidyStore.pendingCount > 0 &&
+      renameValid &&
+      tidyStore.status !== "loading_deterministic" &&
+      tidyStore.status !== "loading_llm",
+  );
+
+  let isDetectLoading = $derived(
+    tidyStore.status === "loading_deterministic",
+  );
+  let isLlmLoading = $derived(tidyStore.status === "loading_llm");
+  let isLoading = $derived(isDetectLoading || isLlmLoading);
+  let canRunAgent = $derived(
+    tidyStore.table !== null &&
+      !isLoading &&
+      tidyStore.status !== "error",
+  );
+  let llmAlreadyRan = $derived(
+    tidyStore.status === "loaded_with_llm" ||
+      tidyStore.proposals.some((p) => p.proposal.source === "llm"),
+  );
+
+  let llmDisabledForViewMode = $derived(tidyStore.mode === "view");
+
+  // Reload the schema sidebar after each successful apply so the new
+  // long-form object shows up immediately. Wired here (not in the store)
+  // to avoid a circular import between tidyStore and schemaStore.
+  $effect(() => {
+    tidyStore.setAppliedHook((schemaInfo) => {
+      if (Array.isArray(schemaInfo)) {
+        schemaStore.schemaData = schemaInfo as TableInfo[];
+      }
+    });
+    return () => tidyStore.setAppliedHook(null);
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      tidyStore.close();
+    }
+  }
+
+  async function handleApply() {
+    const { applied, failed } = await tidyStore.applyAll();
+    if (applied > 0) {
+      toastStore.show(
+        `Applied ${applied} proposal${applied === 1 ? "" : "s"}`,
+        "success",
+      );
+    }
+    if (failed > 0) {
+      toastStore.show(
+        `${failed} proposal${failed === 1 ? "" : "s"} failed to apply`,
+        "error",
+      );
+    }
+  }
+
+  function handleSampleRowsBlur(value: string) {
+    const n = parseInt(value, 10);
+    tidyStore.sampleRows = Number.isFinite(n) ? n : 0;
+  }
+
+  async function handleRunAgent() {
+    await tidyStore.runAgent();
+  }
+</script>
+
+{#if tidyStore.open}
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="drawer-root"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Tidy review"
+    tabindex="-1"
+    onkeydown={handleKeydown}
+  >
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="backdrop" onclick={() => tidyStore.close()}></div>
+
+    <aside class="panel">
+      <header class="panel-head">
+        <div>
+          <h3>Tidy review</h3>
+          <p>
+            {#if tidyStore.table}
+              <code>{tidyStore.table}</code>
+            {:else}
+              &nbsp;
+            {/if}
+          </p>
+        </div>
+        <button class="close-btn" onclick={() => tidyStore.close()} title="Close (Esc)">
+          ×
+        </button>
+      </header>
+
+      <div class="panel-body">
+        <!-- Run-agent panel: configure + trigger the LLM advisor -->
+        <section class="agent-panel" class:agent-panel-running={isLlmLoading}>
+          <div class="agent-head">
+            <div>
+              <h4>
+                {#if isLlmLoading}
+                  <span class="dot-flash" aria-hidden="true"></span>
+                  Agent is reviewing the schema…
+                {:else if llmAlreadyRan}
+                  Agent reviewed the schema
+                {:else}
+                  Run the LLM agent for more candidates
+                {/if}
+              </h4>
+              <p>
+                {#if isLlmLoading}
+                  This usually takes 5–30 seconds. You can cancel without
+                  losing the deterministic results below.
+                {:else if llmAlreadyRan}
+                  Re-run if you tweak the sample-rows count or want a
+                  different set of suggestions.
+                {:else}
+                  The deterministic detector ran instantly. Click Run to
+                  ask the configured LLM for additional reshape candidates
+                  the regex misses (fuel-as-column, geography-as-column,
+                  multi-axis pivots).
+                {/if}
+              </p>
+            </div>
+            {#if isLlmLoading}
+              <button class="btn ghost" onclick={() => tidyStore.cancel()}>
+                Cancel
+              </button>
+            {:else}
+              <button
+                class="btn primary"
+                disabled={!canRunAgent}
+                onclick={handleRunAgent}
+              >
+                {llmAlreadyRan ? "Run again" : "Run agent"}
+              </button>
+            {/if}
+          </div>
+          <label class="agent-sample">
+            <span>Sample rows sent to LLM</span>
+            <input
+              type="number"
+              min="0"
+              max="500"
+              value={tidyStore.sampleRows}
+              onblur={(e) => handleSampleRowsBlur(e.currentTarget.value)}
+              disabled={isLoading}
+              title="Values are sent over the network. 0 = schema-only."
+            />
+            <small>Values are sent over the network. 0 = schema-only.</small>
+          </label>
+        </section>
+
+        <!-- Status banner: errors only (loading is shown in the agent panel) -->
+        {#if isDetectLoading}
+          <p class="banner">Detecting untidy patterns…</p>
+        {:else if tidyStore.status === "error"}
+          <p class="banner banner-err">
+            {tidyStore.errorMessage ?? "Failed to load proposals"}
+          </p>
+        {/if}
+
+        {#if tidyStore.parseWarnings.length > 0}
+          <ul class="warnings">
+            {#each tidyStore.parseWarnings as w}
+              <li>{w}</li>
+            {/each}
+          </ul>
+        {/if}
+
+        <!-- Proposal cards -->
+        {#if tidyStore.proposals.length === 0 && (tidyStore.status === "loaded_deterministic" || tidyStore.status === "loaded_with_llm")}
+          <p class="empty">
+            {tidyStore.status === "loaded_with_llm"
+              ? "Agent found no additional candidates. The deterministic detector also came up empty."
+              : "No deterministic patterns detected. Try Run agent for LLM-derived candidates."}
+          </p>
+        {:else}
+          <div class="cards">
+            {#each tidyStore.proposals as p (p.id)}
+              <TidyProposalCard card={p} />
+            {/each}
+            {#if isLlmLoading}
+              <div class="thinking-card" aria-live="polite">
+                <span class="dot-flash" aria-hidden="true"></span>
+                Agent is thinking…
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+      <!-- Footer with batch controls -->
+      <footer class="panel-foot">
+        <div class="foot-row">
+          <fieldset class="seg">
+            <legend>Materialize as</legend>
+            <label>
+              <input
+                type="radio"
+                name="tidy-mode"
+                value="view"
+                checked={tidyStore.mode === "view"}
+                onchange={() => (tidyStore.mode = "view")}
+              />
+              <span>View</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="tidy-mode"
+                value="table"
+                checked={tidyStore.mode === "table"}
+                onchange={() => (tidyStore.mode = "table")}
+              />
+              <span>Table</span>
+            </label>
+          </fieldset>
+
+          <fieldset
+            class="seg"
+            class:disabled={llmDisabledForViewMode}
+            title={llmDisabledForViewMode
+              ? "Rename, Replace, and Drop require Materialize as Table — a view references its source by name."
+              : ""}
+          >
+            <legend>Source</legend>
+            <label title="Source and long form coexist (default).">
+              <input
+                type="radio"
+                name="tidy-disp"
+                value="keep"
+                checked={tidyStore.dispositionMode === "keep"}
+                onchange={() => (tidyStore.dispositionMode = "keep")}
+              />
+              <span>Keep</span>
+            </label>
+            <label title="Rename the source; long form lives at the target name.">
+              <input
+                type="radio"
+                name="tidy-disp"
+                value="rename"
+                disabled={llmDisabledForViewMode}
+                checked={tidyStore.dispositionMode === "rename"}
+                onchange={() => (tidyStore.dispositionMode = "rename")}
+              />
+              <span>Rename</span>
+            </label>
+            <label title="Drop the source; long form takes over the source's name. Downstream code that referenced the source keeps working.">
+              <input
+                type="radio"
+                name="tidy-disp"
+                value="replace"
+                disabled={llmDisabledForViewMode}
+                checked={tidyStore.dispositionMode === "replace"}
+                onchange={() => (tidyStore.dispositionMode = "replace")}
+              />
+              <span>Replace</span>
+            </label>
+            <label title="Drop the source; long form keeps its target name. Downstream references to the source name will break.">
+              <input
+                type="radio"
+                name="tidy-disp"
+                value="drop"
+                disabled={llmDisabledForViewMode}
+                checked={tidyStore.dispositionMode === "drop"}
+                onchange={() => (tidyStore.dispositionMode = "drop")}
+              />
+              <span>Drop</span>
+            </label>
+          </fieldset>
+        </div>
+
+        {#if tidyStore.dispositionMode === "rename"}
+          <label class="rename-input">
+            <span>Rename source to</span>
+            <input
+              type="text"
+              value={tidyStore.dispositionRenameTo}
+              oninput={(e) =>
+                (tidyStore.dispositionRenameTo = e.currentTarget.value)}
+              placeholder="e.g. sales_wide_raw"
+            />
+          </label>
+        {/if}
+
+        <div class="apply-row">
+          <span class="apply-count">
+            {tidyStore.pendingCount} to apply
+          </span>
+          <button class="btn primary" disabled={!canApply} onclick={handleApply}>
+            Apply
+          </button>
+        </div>
+      </footer>
+    </aside>
+  </div>
+{/if}
+
+<style>
+  .drawer-root {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+  }
+
+  .panel {
+    position: relative;
+    width: min(720px, 96vw);
+    height: 100%;
+    background: var(--surface);
+    border-left: 1px solid color-mix(in srgb, var(--teal) 20%, var(--border));
+    display: flex;
+    flex-direction: column;
+    box-shadow: -16px 0 40px rgba(0, 0, 0, 0.28);
+    animation: slide-in 0.18s ease-out;
+  }
+
+  @keyframes slide-in {
+    from {
+      transform: translateX(8%);
+      opacity: 0.6;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 18px;
+    border-bottom: 1px solid var(--border);
+    background:
+      linear-gradient(180deg,
+        color-mix(in srgb, var(--teal) 10%, var(--surface)),
+        color-mix(in srgb, var(--surface) 96%, var(--bg)));
+  }
+  .panel-head h3 {
+    margin: 0 0 2px;
+    font-size: 1rem;
+    color: var(--text);
+  }
+  .panel-head p {
+    margin: 0;
+    font-size: 0.74rem;
+    color: var(--text-secondary);
+  }
+  .panel-head code {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.78rem;
+    color: var(--text);
+  }
+
+  .close-btn {
+    border: none;
+    background: none;
+    color: var(--text-secondary);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 2px 8px;
+    border-radius: 6px;
+    transition: background 0.15s, color 0.15s;
+  }
+  .close-btn:hover {
+    background: color-mix(in srgb, var(--bg) 60%, var(--surface));
+    color: var(--text);
+  }
+
+  .panel-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 14px 18px;
+    display: grid;
+    gap: 12px;
+  }
+
+  .agent-panel {
+    display: grid;
+    gap: 10px;
+    padding: 12px 14px;
+    border: 1px solid color-mix(in srgb, var(--teal) 22%, var(--border));
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--teal) 5%, var(--surface));
+    transition: background 0.2s, border-color 0.2s;
+  }
+  .agent-panel-running {
+    border-color: color-mix(in srgb, var(--orange) 50%, var(--border));
+    background: color-mix(in srgb, var(--orange) 7%, var(--surface));
+  }
+  .agent-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .agent-head h4 {
+    margin: 0 0 4px;
+    font-size: 0.86rem;
+    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .agent-head p {
+    margin: 0;
+    max-width: 52ch;
+    font-size: 0.74rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+  }
+  .agent-sample {
+    display: grid;
+    grid-template-columns: auto 72px;
+    align-items: center;
+    gap: 6px 10px;
+    font-size: 0.74rem;
+    color: var(--text-secondary);
+  }
+  .agent-sample > span {
+    grid-column: 1;
+  }
+  .agent-sample > input {
+    grid-column: 2;
+    width: 72px;
+    padding: 4px 6px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface);
+    color: var(--text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.78rem;
+  }
+  .agent-sample > input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .agent-sample > small {
+    grid-column: 1 / -1;
+    font-size: 0.68rem;
+    color: var(--text-secondary);
+    opacity: 0.85;
+  }
+
+  /* Pulsing-dot indicator used inside the agent panel header and the
+     thinking-placeholder card while the LLM call is in flight. */
+  .dot-flash {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--orange) 80%, var(--teal));
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--orange) 40%, transparent);
+    animation: dot-flash-pulse 1.1s ease-in-out infinite;
+  }
+  @keyframes dot-flash-pulse {
+    0% {
+      transform: scale(0.85);
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--orange) 50%, transparent);
+    }
+    70% {
+      transform: scale(1.1);
+      box-shadow: 0 0 0 8px color-mix(in srgb, var(--orange) 0%, transparent);
+    }
+    100% {
+      transform: scale(0.85);
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--orange) 0%, transparent);
+    }
+  }
+
+  .thinking-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px;
+    border: 1px dashed color-mix(in srgb, var(--orange) 50%, var(--border));
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--orange) 5%, var(--surface));
+    color: var(--text-secondary);
+    font-size: 0.84rem;
+    font-style: italic;
+  }
+
+  .banner {
+    margin: 0;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--teal) 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--teal) 26%, var(--border));
+    font-size: 0.78rem;
+    color: var(--text);
+  }
+  .banner-err {
+    background: color-mix(in srgb, #ef4444 8%, var(--surface));
+    border-color: color-mix(in srgb, #ef4444 36%, var(--border));
+    color: color-mix(in srgb, #ef4444 80%, var(--text));
+  }
+
+  .warnings {
+    margin: 0;
+    padding: 8px 16px 8px 28px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--orange) 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--orange) 30%, var(--border));
+    font-size: 0.74rem;
+    color: var(--text);
+  }
+  .warnings li {
+    margin: 0;
+    padding: 1px 0;
+  }
+
+  .empty {
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.84rem;
+    font-style: italic;
+    padding: 28px 0;
+  }
+
+  .cards {
+    display: grid;
+    gap: 12px;
+  }
+
+  .panel-foot {
+    border-top: 1px solid var(--border);
+    padding: 12px 18px 14px;
+    display: grid;
+    gap: 10px;
+    background: color-mix(in srgb, var(--bg) 36%, var(--surface));
+  }
+
+  .foot-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .seg {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 4px 10px 8px;
+    margin: 0;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 2px;
+    background: var(--surface);
+  }
+  .seg.disabled {
+    opacity: 0.55;
+  }
+  .seg legend {
+    padding: 0 4px;
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    font-weight: 700;
+  }
+  .seg label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--text);
+    cursor: pointer;
+  }
+  .seg input[type="radio"] {
+    accent-color: var(--teal);
+    cursor: pointer;
+  }
+  .seg input[type="radio"]:disabled + span {
+    color: var(--text-secondary);
+    cursor: not-allowed;
+  }
+  .seg :global(label:has(input:disabled)) {
+    cursor: not-allowed;
+  }
+
+  .rename-input {
+    display: grid;
+    gap: 4px;
+    font-size: 0.74rem;
+  }
+  .rename-input span {
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.66rem;
+    font-weight: 700;
+  }
+  .rename-input input {
+    padding: 6px 9px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.8rem;
+    background: var(--surface);
+    color: var(--text);
+  }
+  .rename-input input:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--teal) 50%, var(--border));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--teal) 14%, transparent);
+  }
+
+  .apply-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .apply-count {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+  }
+
+  .btn {
+    padding: 8px 14px;
+    border-radius: 8px;
+    font: inherit;
+    font-size: 0.84rem;
+    font-weight: 600;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  }
+  .btn.ghost {
+    background: var(--surface);
+    color: var(--text);
+  }
+  .btn.ghost:hover {
+    background: color-mix(in srgb, var(--teal) 6%, var(--surface));
+    border-color: color-mix(in srgb, var(--teal) 30%, var(--border));
+  }
+  .btn.primary {
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--teal) 84%, #1f8f88),
+      color-mix(in srgb, var(--orange) 22%, var(--teal))
+    );
+    border-color: transparent;
+    color: white;
+    box-shadow: 0 6px 14px color-mix(in srgb, var(--teal) 22%, transparent);
+  }
+  .btn.primary:hover {
+    opacity: 0.95;
+  }
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/src/lib/components/TidyMeltDiagram.svelte
+++ b/frontend/src/lib/components/TidyMeltDiagram.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import type { TidyProposal } from "$lib/api/tidy";
+
+  interface Props {
+    proposal: TidyProposal;
+    /** Cap row count so the SVG stays compact on big reshapes. */
+    maxRows?: number;
+  }
+
+  let { proposal, maxRows = 6 }: Props = $props();
+
+  // Layout constants. Tiles stack the column name (top) above the
+  // dimension-value sub-label (bottom) so long names don't collide with
+  // the sub the way they did when both shared a single line.
+  const TILE_W = 160;
+  const TILE_H = 24;
+  const ROW_H = 30;
+  const PAD_TOP = 26;
+  const COL_LEFT_X = 12;
+  const W = COL_LEFT_X * 2 + TILE_W * 2 + 80; // tiles + 80px connector gutter
+  const COL_RIGHT_X = W - COL_LEFT_X;
+  const LABEL_DX = 6;
+
+  let columnMappings = $derived(proposal.column_mappings ?? []);
+  let dimensions = $derived(proposal.dimensions ?? []);
+  let idColumns = $derived(proposal.id_columns ?? []);
+  let truncated = $derived(columnMappings.length > maxRows);
+  let visibleMappings = $derived(
+    truncated ? columnMappings.slice(0, maxRows) : columnMappings,
+  );
+
+  // Right-hand long-form columns: id columns first, then dimensions, then
+  // the value column. Drawing them as a single label string keeps the
+  // diagram compact while still naming the resulting schema.
+  let longColumns = $derived([
+    ...idColumns.map((c) => ({ name: c, kind: "id" })),
+    ...dimensions.map((d) => ({ name: d.name, kind: "dim" })),
+    { name: proposal.value_column, kind: "value" },
+  ]);
+
+  let leftRows = $derived([
+    ...idColumns.map((c) => ({ kind: "id" as const, label: c, sub: "" })),
+    ...visibleMappings.map((m) => ({
+      kind: "measure" as const,
+      label: m.column,
+      sub: dimensions.map((d) => m.dimension_values[d.name]).join(" / "),
+    })),
+  ]);
+
+  let rightRows = $derived(longColumns);
+
+  let height = $derived(
+    PAD_TOP + Math.max(leftRows.length, rightRows.length) * ROW_H + 18,
+  );
+
+  function leftY(index: number): number {
+    return PAD_TOP + index * ROW_H;
+  }
+
+  function rightY(index: number): number {
+    return PAD_TOP + index * ROW_H;
+  }
+
+  function valueRowIndex(): number {
+    return rightRows.length - 1;
+  }
+
+  // Curved connector from a left source column to the long-form value
+  // column. Uses a cubic Bezier so the curve scales with the vertical
+  // delta — flat for adjacent rows, more pronounced when the source row
+  // is far from the value row.
+  function curvePath(srcY: number, dstY: number): string {
+    const x1 = COL_LEFT_X + TILE_W;
+    const x2 = COL_RIGHT_X - TILE_W;
+    const cx1 = (x1 + x2) / 2;
+    return `M ${x1} ${srcY} C ${cx1} ${srcY}, ${cx1} ${dstY}, ${x2} ${dstY}`;
+  }
+
+  function straightPath(srcY: number, dstY: number): string {
+    const x1 = COL_LEFT_X + TILE_W;
+    const x2 = COL_RIGHT_X - TILE_W;
+    return `M ${x1} ${srcY} L ${x2} ${dstY}`;
+  }
+
+  // Connector anchor sits at the visual middle of the row (between
+  // stacked label and sub).
+  function rowAnchorY(row_y: number): number {
+    return row_y + 1;
+  }
+</script>
+
+<svg
+  class="melt-diagram"
+  viewBox="0 0 {W} {height}"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label="Wide-to-long reshape diagram for {proposal.table}"
+>
+  <!-- Column headers -->
+  <text x={COL_LEFT_X} y={12} class="hdr">{proposal.table} (wide)</text>
+  <text x={COL_RIGHT_X} y={12} text-anchor="end" class="hdr">
+    {proposal.target_object_name} (long)
+  </text>
+
+  <!-- Connector lines: id columns straight across, measures curve into the value column -->
+  {#each leftRows as row, i (row.label + i)}
+    {#if row.kind === "id"}
+      <path
+        d={straightPath(rowAnchorY(leftY(i)), rowAnchorY(rightY(i)))}
+        class="conn conn-id"
+        fill="none"
+      />
+    {:else}
+      <path
+        d={curvePath(
+          rowAnchorY(leftY(i)),
+          rowAnchorY(rightY(valueRowIndex())),
+        )}
+        class="conn conn-measure"
+        fill="none"
+      />
+    {/if}
+  {/each}
+
+  <!-- Left column tiles. Label sits on the top half of the tile, sub on
+       the bottom half so long names don't fight the dimension-value sub
+       for horizontal space. -->
+  {#each leftRows as row, i (row.label + i)}
+    <g transform="translate({COL_LEFT_X} {leftY(i)})">
+      <title>{row.label}{row.sub ? ` → ${row.sub}` : ""}</title>
+      <rect
+        x={0}
+        y={-(TILE_H / 2) + 2}
+        width={TILE_W}
+        height={TILE_H}
+        rx={5}
+        class={row.kind === "id" ? "tile tile-id" : "tile tile-measure"}
+      />
+      {#if row.sub}
+        <text x={LABEL_DX} y={-2} class="lbl">{row.label}</text>
+        <text x={LABEL_DX} y={10} class="sub">{row.sub}</text>
+      {:else}
+        <text x={LABEL_DX} y={4} class="lbl">{row.label}</text>
+      {/if}
+    </g>
+  {/each}
+
+  {#if truncated}
+    <text
+      x={COL_LEFT_X + LABEL_DX}
+      y={leftY(visibleMappings.length + idColumns.length) + 4}
+      class="more"
+    >
+      … and {columnMappings.length - visibleMappings.length} more
+    </text>
+  {/if}
+
+  <!-- Right column tiles. Same stacked layout — kind ("dim", "value")
+       sits below the column name. -->
+  {#each rightRows as row, i (row.name)}
+    <g transform="translate({COL_RIGHT_X - TILE_W} {rightY(i)})">
+      <title>{row.name} ({row.kind})</title>
+      <rect
+        x={0}
+        y={-(TILE_H / 2) + 2}
+        width={TILE_W}
+        height={TILE_H}
+        rx={5}
+        class={
+          row.kind === "id"
+            ? "tile tile-id"
+            : row.kind === "dim"
+              ? "tile tile-dim"
+              : "tile tile-value"
+        }
+      />
+      {#if row.kind === "id"}
+        <text x={LABEL_DX} y={4} class="lbl">{row.name}</text>
+      {:else}
+        <text x={LABEL_DX} y={-2} class="lbl">{row.name}</text>
+        <text x={LABEL_DX} y={10} class="sub">{row.kind}</text>
+      {/if}
+    </g>
+  {/each}
+</svg>
+
+<style>
+  .melt-diagram {
+    display: block;
+    width: 100%;
+    max-width: 520px;
+    height: auto;
+    font-family: inherit;
+  }
+
+  .hdr {
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    fill: var(--text-secondary);
+  }
+
+  .lbl {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 9.5px;
+    fill: var(--text);
+    dominant-baseline: middle;
+  }
+
+  .sub {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 8px;
+    fill: var(--text-secondary);
+    dominant-baseline: middle;
+  }
+
+  .more {
+    font-size: 9px;
+    font-style: italic;
+    fill: var(--text-secondary);
+    dominant-baseline: middle;
+  }
+
+  .tile {
+    stroke: var(--border);
+    stroke-width: 0.6;
+  }
+  .tile-id {
+    fill: color-mix(in srgb, var(--text-secondary) 8%, var(--surface));
+  }
+  .tile-measure {
+    fill: color-mix(in srgb, var(--orange) 10%, var(--surface));
+    stroke: color-mix(in srgb, var(--orange) 30%, var(--border));
+  }
+  .tile-dim {
+    fill: color-mix(in srgb, var(--teal) 12%, var(--surface));
+    stroke: color-mix(in srgb, var(--teal) 36%, var(--border));
+  }
+  .tile-value {
+    fill: color-mix(in srgb, var(--orange) 18%, var(--surface));
+    stroke: color-mix(in srgb, var(--orange) 44%, var(--border));
+  }
+
+  .conn {
+    stroke-width: 1;
+    opacity: 0.7;
+  }
+  .conn-id {
+    stroke: color-mix(in srgb, var(--text-secondary) 50%, transparent);
+    stroke-dasharray: 3 2;
+  }
+  .conn-measure {
+    stroke: color-mix(in srgb, var(--orange) 60%, transparent);
+  }
+</style>

--- a/frontend/src/lib/components/TidyProposalCard.svelte
+++ b/frontend/src/lib/components/TidyProposalCard.svelte
@@ -1,0 +1,633 @@
+<script lang="ts">
+  import { tidyStore, type ProposalState } from "$lib/stores/tidy.svelte";
+  import { renderTidySql, type TidyProposal } from "$lib/api/tidy";
+  import TidyMeltDiagram from "./TidyMeltDiagram.svelte";
+
+  interface Props {
+    card: ProposalState;
+  }
+
+  let { card }: Props = $props();
+
+  let showSql = $state(false);
+  let renderedSql = $state<string | null>(null);
+  let renderingSql = $state(false);
+  let sqlError = $state<string | null>(null);
+
+  // Build the proposal that the apply step would actually use — base
+  // proposal merged with the user's current edits. Same merge as
+  // tidyStore.applyAll, kept inline so the SQL preview tracks edits live.
+  let editedProposal = $derived<TidyProposal>({
+    ...card.proposal,
+    target_object_name: card.edits.target_object_name,
+    value_column: card.edits.value_column,
+    id_columns: [...card.edits.id_columns],
+    include_nulls: card.edits.include_nulls,
+  });
+
+  // Re-render SQL whenever the panel is open and any of (mode, edits)
+  // changes. The pre-baked reshape_sql_view/reshape_sql_table fields on
+  // the proposal are frozen at detect time and don't reflect edits, so
+  // we fetch a fresh build from the server.
+  $effect(() => {
+    if (!showSql) return;
+    // Capture the deps Svelte should track for change detection.
+    const proposal = editedProposal;
+    const mode = tidyStore.mode;
+    let cancelled = false;
+
+    renderingSql = true;
+    sqlError = null;
+    renderTidySql({ proposal, mode })
+      .then((resp) => {
+        if (cancelled) return;
+        renderedSql = resp.sql || null;
+        sqlError = resp.error;
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        sqlError = (err as Error).message ?? "Failed to render SQL";
+      })
+      .finally(() => {
+        if (!cancelled) renderingSql = false;
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  let badgeLabel = $derived(
+    card.proposal.source === "deterministic"
+      ? "regex"
+      : card.proposal.source === "llm"
+        ? "LLM"
+        : card.proposal.source,
+  );
+
+  let confidenceLabel = $derived(card.proposal.confidence);
+
+  let mappingsCount = $derived(card.proposal.column_mappings.length);
+
+  let dimensionsLabel = $derived(
+    card.proposal.dimensions
+      .map((d) => `${d.name} (${d.kind}, ${d.dtype})`)
+      .join(", "),
+  );
+
+  let idColumnsText = $derived(card.edits.id_columns.join(", "));
+
+  let appliedDetail = $derived(() => {
+    const r = card.applyResult;
+    if (!r) return "";
+    return `${r.row_count_target.toLocaleString()} rows in ${r.final_target_name}`;
+  });
+
+  function handleIdColumnsChange(value: string) {
+    const parts = value
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    tidyStore.editProposal(card.id, { id_columns: parts });
+  }
+
+  async function handlePreviewClick() {
+    if (card.preview.open && (card.preview.html || card.preview.error)) {
+      tidyStore.togglePreviewOpen(card.id);
+      return;
+    }
+    await tidyStore.loadPreview(card.id);
+  }
+</script>
+
+<div
+  class="card"
+  class:skipped={card.skipped}
+  class:applied={card.status === "applied"}
+  class:apply-error={card.status === "apply_error"}
+>
+  <header class="card-head">
+    <div class="card-title">
+      <span class="badge badge-{card.proposal.source}">{badgeLabel}</span>
+      <span class="badge badge-conf badge-conf-{confidenceLabel}">
+        {confidenceLabel}
+      </span>
+      <strong>
+        {card.proposal.table} → {card.edits.target_object_name}
+      </strong>
+    </div>
+    {#if card.status !== "applied"}
+      <button
+        type="button"
+        class="skip-btn"
+        class:skip-btn-active={card.skipped}
+        onclick={() => tidyStore.toggleSkip(card.id)}
+        disabled={card.status === "applying"}
+        title={card.skipped
+          ? "This proposal will be skipped on Apply. Click to include it."
+          : "Exclude this proposal from the next Apply."}
+      >
+        {card.skipped ? "Skipped" : "Skip"}
+      </button>
+    {/if}
+  </header>
+
+  {#if card.proposal.rationale}
+    <p class="rationale">{card.proposal.rationale}</p>
+  {/if}
+
+  <div class="diagram-wrap">
+    <TidyMeltDiagram proposal={card.proposal} />
+  </div>
+
+  <dl class="meta">
+    <div>
+      <dt>Pattern</dt>
+      <dd>{card.proposal.pattern}</dd>
+    </div>
+    <div>
+      <dt>Dimensions</dt>
+      <dd>{dimensionsLabel}</dd>
+    </div>
+    <div>
+      <dt>Mapped columns</dt>
+      <dd>{mappingsCount}</dd>
+    </div>
+  </dl>
+
+  <fieldset class="edits">
+    <legend>Edits</legend>
+    <label class="field">
+      <span>Target name</span>
+      <input
+        type="text"
+        value={card.edits.target_object_name}
+        oninput={(e) =>
+          tidyStore.editProposal(card.id, {
+            target_object_name: e.currentTarget.value,
+          })}
+        disabled={card.status === "applied" || card.status === "applying"}
+      />
+    </label>
+    <label class="field">
+      <span>Value column</span>
+      <input
+        type="text"
+        value={card.edits.value_column}
+        oninput={(e) =>
+          tidyStore.editProposal(card.id, {
+            value_column: e.currentTarget.value,
+          })}
+        disabled={card.status === "applied" || card.status === "applying"}
+      />
+    </label>
+    <label class="field field-wide">
+      <span>Id columns (comma-separated)</span>
+      <input
+        type="text"
+        value={idColumnsText}
+        oninput={(e) => handleIdColumnsChange(e.currentTarget.value)}
+        disabled={card.status === "applied" || card.status === "applying"}
+        placeholder="region, country"
+      />
+    </label>
+    <label class="field field-wide field-checkbox">
+      <input
+        type="checkbox"
+        checked={card.edits.include_nulls}
+        onchange={(e) =>
+          tidyStore.editProposal(card.id, {
+            include_nulls: e.currentTarget.checked,
+          })}
+        disabled={card.status === "applied" || card.status === "applying"}
+      />
+      <span>Keep rows with NULL values</span>
+      <small>
+        Off by default — wide-table NULLs are usually structural
+        placeholders. Turn on for data where NULL is a real missing
+        observation (sensor outage, optional answer) you want to keep.
+      </small>
+    </label>
+  </fieldset>
+
+  <div class="actions">
+    <button class="btn ghost" onclick={handlePreviewClick}>
+      {card.preview.open ? "Hide preview" : "Preview rows"}
+    </button>
+    <button class="btn ghost" onclick={() => (showSql = !showSql)}>
+      {showSql ? "Hide SQL" : "Show SQL"}
+    </button>
+  </div>
+
+  {#if card.preview.open}
+    <div class="preview">
+      {#if card.preview.loading}
+        <p class="muted">Loading sample…</p>
+      {:else if card.preview.error}
+        <p class="error">Preview failed: {card.preview.error}</p>
+      {:else if card.preview.html}
+        <p class="muted">
+          {card.preview.rowCount} sample row{card.preview.rowCount === 1
+            ? ""
+            : "s"}
+        </p>
+        <div class="preview-table">
+          {@html card.preview.html}
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if showSql}
+    <div class="sql-wrap">
+      <div class="sql-head">
+        <span class="sql-mode-badge">mode: {tidyStore.mode}</span>
+        {#if renderingSql}
+          <span class="sql-status">rendering…</span>
+        {/if}
+      </div>
+      {#if sqlError}
+        <p class="sql-error">SQL render failed: {sqlError}</p>
+      {:else if renderedSql !== null}
+        <pre class="sql">{renderedSql}</pre>
+      {:else if !renderingSql}
+        <p class="sql-status">No SQL yet — toggle Show SQL to render.</p>
+      {/if}
+    </div>
+  {/if}
+
+  {#if card.status === "applied"}
+    <p class="status status-ok">Applied · {appliedDetail()}</p>
+  {:else if card.status === "apply_error" && card.applyError}
+    <p class="status status-err">Apply failed: {card.applyError}</p>
+  {:else if card.status === "applying"}
+    <p class="status status-pending">Applying…</p>
+  {/if}
+</div>
+
+<style>
+  .card {
+    display: grid;
+    gap: 12px;
+    padding: 14px 16px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--surface);
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .card.skipped {
+    border-style: dashed;
+    background: color-mix(in srgb, var(--bg) 70%, var(--surface));
+    opacity: 0.65;
+  }
+  .card.applied {
+    border-color: color-mix(in srgb, var(--teal) 70%, var(--border));
+    background: color-mix(in srgb, var(--teal) 9%, var(--surface));
+  }
+  .card.apply-error {
+    border-color: color-mix(in srgb, #ef4444 60%, var(--border));
+    background: color-mix(in srgb, #ef4444 6%, var(--surface));
+  }
+
+  .card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .card-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.88rem;
+    color: var(--text);
+  }
+  .card-title strong {
+    font-weight: 600;
+  }
+
+  .badge {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 999px;
+  }
+  .badge-deterministic {
+    background: color-mix(in srgb, var(--text-secondary) 14%, transparent);
+    color: var(--text-secondary);
+  }
+  .badge-llm {
+    background: color-mix(in srgb, var(--teal) 22%, transparent);
+    color: color-mix(in srgb, var(--teal) 80%, var(--text));
+  }
+  .badge-user {
+    background: color-mix(in srgb, var(--orange) 22%, transparent);
+    color: color-mix(in srgb, var(--orange) 78%, var(--text));
+  }
+
+  .badge-conf {
+    background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
+    color: var(--text-secondary);
+  }
+  .badge-conf-high {
+    background: color-mix(in srgb, var(--teal) 18%, transparent);
+    color: color-mix(in srgb, var(--teal) 75%, var(--text));
+  }
+  .badge-conf-low {
+    background: color-mix(in srgb, #ef4444 18%, transparent);
+    color: color-mix(in srgb, #ef4444 80%, var(--text));
+  }
+
+  /* Skip toggle in the card header. Default state is a quiet ghost
+     button that nudges away the active proposal; once skipped, the
+     button takes a stronger style so it's obviously the toggle that
+     re-enables the card. */
+  .skip-btn {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: 0.74rem;
+    padding: 4px 10px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .skip-btn:hover {
+    background: color-mix(in srgb, var(--text-secondary) 8%, var(--surface));
+    color: var(--text);
+  }
+  .skip-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .skip-btn-active {
+    background: color-mix(in srgb, var(--text-secondary) 18%, transparent);
+    border-color: color-mix(in srgb, var(--text-secondary) 36%, var(--border));
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .rationale {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .diagram-wrap {
+    display: flex;
+    justify-content: center;
+    padding: 4px 0;
+    background: color-mix(in srgb, var(--bg) 60%, var(--surface));
+    border-radius: 8px;
+  }
+
+  .meta {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    font-size: 0.72rem;
+  }
+  .meta div {
+    display: grid;
+    gap: 2px;
+  }
+  .meta dt {
+    color: var(--text-secondary);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+  }
+  .meta dd {
+    margin: 0;
+    color: var(--text);
+    font-size: 0.78rem;
+    word-break: break-word;
+  }
+
+  .edits {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 12px 12px;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    background: color-mix(in srgb, var(--bg) 50%, var(--surface));
+  }
+  .edits legend {
+    padding: 0 6px;
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+  }
+
+  .field {
+    display: grid;
+    gap: 4px;
+    font-size: 0.74rem;
+  }
+  .field-wide {
+    grid-column: 1 / -1;
+  }
+  .field span {
+    color: var(--text-secondary);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .field input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 9px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bg) 94%, white);
+    color: var(--text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.78rem;
+  }
+  .field input:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--teal) 50%, var(--border));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--teal) 14%, transparent);
+  }
+  .field input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  /* Checkbox-style edit row: the input is inline, the label and helper
+     text wrap around it instead of stacking like the text inputs above. */
+  .field-checkbox {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 4px 10px;
+  }
+  .field-checkbox input[type="checkbox"] {
+    width: auto;
+    grid-row: 1;
+    grid-column: 1;
+    accent-color: var(--teal);
+    transform: scale(1.1);
+    cursor: pointer;
+  }
+  .field-checkbox > span {
+    grid-row: 1;
+    grid-column: 2;
+    font-size: 0.78rem;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text);
+    font-weight: 500;
+  }
+  .field-checkbox > small {
+    grid-row: 2;
+    grid-column: 1 / -1;
+    font-size: 0.68rem;
+    line-height: 1.4;
+    color: var(--text-secondary);
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .btn {
+    padding: 6px 12px;
+    border-radius: 6px;
+    font: inherit;
+    font-size: 0.76rem;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .btn.ghost {
+    background: var(--surface);
+    color: var(--text);
+  }
+  .btn.ghost:hover {
+    background: color-mix(in srgb, var(--teal) 6%, var(--surface));
+    border-color: color-mix(in srgb, var(--teal) 30%, var(--border));
+  }
+
+  .preview {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--bg) 92%, var(--surface));
+    padding: 10px;
+    display: grid;
+    gap: 6px;
+    overflow: hidden;
+  }
+  .preview .muted {
+    margin: 0;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+  }
+  .preview .error {
+    margin: 0;
+    font-size: 0.78rem;
+    color: #ef4444;
+  }
+  .preview-table {
+    overflow: auto;
+    max-height: 240px;
+    font-size: 0.72rem;
+  }
+  .preview-table :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .preview-table :global(th),
+  .preview-table :global(td) {
+    padding: 4px 8px;
+    border-top: 1px solid var(--border);
+    text-align: left;
+  }
+  .preview-table :global(th) {
+    background: var(--surface);
+    font-weight: 600;
+  }
+
+  .sql-wrap {
+    display: grid;
+    gap: 6px;
+  }
+  .sql-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+  }
+  .sql-mode-badge {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--teal) 14%, transparent);
+    color: color-mix(in srgb, var(--teal) 75%, var(--text));
+    font-size: 0.64rem;
+  }
+  .sql-status {
+    font-style: italic;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+  }
+  .sql-error {
+    margin: 0;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: color-mix(in srgb, #ef4444 10%, transparent);
+    color: color-mix(in srgb, #ef4444 80%, var(--text));
+    font-size: 0.74rem;
+  }
+
+  .sql {
+    margin: 0;
+    padding: 10px 12px;
+    background: color-mix(in srgb, var(--bg) 98%, black);
+    color: var(--text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.72rem;
+    line-height: 1.55;
+    border-radius: 8px;
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    white-space: pre;
+  }
+
+  .status {
+    margin: 0;
+    font-size: 0.78rem;
+    padding: 6px 10px;
+    border-radius: 6px;
+  }
+  .status-ok {
+    background: color-mix(in srgb, var(--teal) 14%, transparent);
+    color: color-mix(in srgb, var(--teal) 80%, var(--text));
+  }
+  .status-err {
+    background: color-mix(in srgb, #ef4444 12%, transparent);
+    color: color-mix(in srgb, #ef4444 84%, var(--text));
+  }
+  .status-pending {
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+</style>

--- a/frontend/src/lib/stores/tidy.svelte.ts
+++ b/frontend/src/lib/stores/tidy.svelte.ts
@@ -1,0 +1,460 @@
+/** Per-table Tidy review drawer state.
+ *
+ * The drawer is a per-table, per-session ceremony: open → load
+ * proposals → user edits / skips unwanted ones → apply all → close.
+ * State here is intentionally ephemeral; nothing persists to localStorage.
+ *
+ * Each proposal carries a stable `id` (its index) so per-card preview
+ * results, edits, approval state, and apply errors map back without
+ * risking duplicates if the LLM returns proposals with identical
+ * target_object_names.
+ */
+
+import {
+  applyTidy,
+  detectTidy,
+  previewTidy,
+  proposeTidy,
+  type TidyApplyResult,
+  type TidyDisposition,
+  type TidyDispositionMode,
+  type TidyMaterializeMode,
+  type TidyProposal,
+} from "$lib/api/tidy";
+
+export type ProposalStatus =
+  | "pending"
+  | "applying"
+  | "applied"
+  | "apply_error";
+
+export interface ProposalEdits {
+  target_object_name: string;
+  value_column: string;
+  id_columns: string[];
+  include_nulls: boolean;
+}
+
+export interface ProposalState {
+  id: string;
+  proposal: TidyProposal;
+  edits: ProposalEdits;
+  /** Opt-out flag. Default false = the proposal is applied when the user
+   * clicks Apply. The card surfaces a Skip toggle so unwanted proposals
+   * (typically among LLM-derived alternatives) can be excluded without
+   * an upfront approve step on the common case. */
+  skipped: boolean;
+  status: ProposalStatus;
+  applyError: string | null;
+  applyResult: TidyApplyResult | null;
+  preview: {
+    loading: boolean;
+    html: string | null;
+    rowCount: number;
+    error: string | null;
+    open: boolean;
+  };
+}
+
+export type DrawerStatus =
+  | "idle"
+  | "loading_deterministic"
+  | "loaded_deterministic"
+  | "loading_llm"
+  | "loaded_with_llm"
+  | "error";
+
+function makeId(table: string, index: number, source: string): string {
+  return `${table}::${source}::${index}`;
+}
+
+function buildEdits(p: TidyProposal): ProposalEdits {
+  return {
+    target_object_name: p.target_object_name,
+    value_column: p.value_column,
+    id_columns: [...p.id_columns],
+    // Falls back to false when the server payload omits it, matching the
+    // backend default — structural NAs in wide tables are usually not
+    // information you want to carry into the long form.
+    include_nulls: p.include_nulls ?? false,
+  };
+}
+
+function makeState(p: TidyProposal, id: string): ProposalState {
+  return {
+    id,
+    proposal: p,
+    edits: buildEdits(p),
+    skipped: false,
+    status: "pending",
+    applyError: null,
+    applyResult: null,
+    preview: {
+      loading: false,
+      html: null,
+      rowCount: 0,
+      error: null,
+      open: false,
+    },
+  };
+}
+
+function applyEdits(p: TidyProposal, edits: ProposalEdits): TidyProposal {
+  return {
+    ...p,
+    target_object_name: edits.target_object_name,
+    value_column: edits.value_column,
+    id_columns: [...edits.id_columns],
+    include_nulls: edits.include_nulls,
+  };
+}
+
+function createTidyStore() {
+  let open = $state(false);
+  let table = $state<string | null>(null);
+  let status = $state<DrawerStatus>("idle");
+  let errorMessage = $state<string | null>(null);
+  let parseWarnings = $state<string[]>([]);
+  let proposals = $state<ProposalState[]>([]);
+  let mode = $state<TidyMaterializeMode>("view");
+  let dispositionMode = $state<TidyDispositionMode>("keep");
+  let dispositionRenameTo = $state("");
+  let sampleRows = $state(0);
+  let abortController = $state<AbortController | null>(null);
+
+  // The store keeps its own onApplied hook so callers (App.svelte) can
+  // reload the schema sidebar without introducing a circular import
+  // between tidyStore and schemaStore.
+  let appliedHook: ((schemaInfo: unknown) => void) | null = null;
+
+  function reset(): void {
+    abortController?.abort();
+    abortController = null;
+    table = null;
+    status = "idle";
+    errorMessage = null;
+    parseWarnings = [];
+    proposals = [];
+    mode = "view";
+    dispositionMode = "keep";
+    dispositionRenameTo = "";
+    sampleRows = 0;
+  }
+
+  return {
+    get open() {
+      return open;
+    },
+    get table() {
+      return table;
+    },
+    get status() {
+      return status;
+    },
+    get errorMessage() {
+      return errorMessage;
+    },
+    get parseWarnings() {
+      return parseWarnings;
+    },
+    get proposals() {
+      return proposals;
+    },
+    get mode() {
+      return mode;
+    },
+    set mode(v: TidyMaterializeMode) {
+      mode = v;
+      // The CLI safety rule: rename/drop with view leaves a dangling view.
+      // When the user flips back to view, force keep so the disposition
+      // picker can't end up in an invalid combination.
+      if (v === "view" && dispositionMode !== "keep") {
+        dispositionMode = "keep";
+        dispositionRenameTo = "";
+      }
+    },
+    get dispositionMode() {
+      return dispositionMode;
+    },
+    set dispositionMode(v: TidyDispositionMode) {
+      dispositionMode = v;
+      if (v !== "rename") dispositionRenameTo = "";
+    },
+    get dispositionRenameTo() {
+      return dispositionRenameTo;
+    },
+    set dispositionRenameTo(v: string) {
+      dispositionRenameTo = v;
+    },
+    get sampleRows() {
+      return sampleRows;
+    },
+    set sampleRows(v: number) {
+      sampleRows = Math.max(0, Math.floor(v));
+    },
+    /** How many proposals will run on the next Apply click — anything
+     * not skipped and not already applied. Drives the footer label and
+     * disables the Apply button when zero. */
+    get pendingCount() {
+      return proposals.filter((p) => !p.skipped && p.status !== "applied")
+        .length;
+    },
+
+    setAppliedHook(fn: ((schemaInfo: unknown) => void) | null): void {
+      appliedHook = fn;
+    },
+
+    /** Open the drawer and load deterministic proposals only.
+     *
+     * The LLM advisor is intentionally NOT run here — that's a paid call
+     * and the user should opt in via :func:`runAgent`. Deterministic hits
+     * are cheap and instant; showing them up front gives the user
+     * something to look at while they decide whether to engage the agent.
+     */
+    async start(tableName: string): Promise<void> {
+      reset();
+      open = true;
+      table = tableName;
+      status = "loading_deterministic";
+
+      try {
+        const resp = await detectTidy(tableName);
+        if (resp.error) {
+          errorMessage = resp.error;
+          status = "error";
+          return;
+        }
+        proposals = resp.proposals.map((p, i) =>
+          makeState(p, makeId(tableName, i, "deterministic")),
+        );
+        status = "loaded_deterministic";
+      } catch (err) {
+        errorMessage = (err as Error).message ?? "Failed to load proposals";
+        status = "error";
+      }
+    },
+
+    /** Engage the LLM advisor. Appends LLM-derived proposals to the list
+     * and respects the current ``sampleRows`` setting. Idempotent in the
+     * happy case — re-running just appends more proposals (LLM output is
+     * non-deterministic, so the user can hit Run again to retry).
+     */
+    async runAgent(): Promise<void> {
+      if (table === null) return;
+      const tableName = table;
+      status = "loading_llm";
+
+      const controller = new AbortController();
+      abortController = controller;
+
+      try {
+        await proposeTidy({
+          table: tableName,
+          sampleRows,
+          signal: controller.signal,
+          onLlmStarted: () => {
+            status = "loading_llm";
+          },
+          onLlmProposals: (list, warnings) => {
+            const baseLen = proposals.length;
+            const llmStates = list.map((p, i) =>
+              makeState(p, makeId(tableName, baseLen + i, "llm")),
+            );
+            proposals = [...proposals, ...llmStates];
+            parseWarnings = warnings;
+          },
+          onLlmError: (msg) => {
+            // Non-fatal — deterministic results stay; surface as a warning.
+            parseWarnings = [...parseWarnings, `LLM advisor failed: ${msg}`];
+          },
+          onError: (msg) => {
+            errorMessage = msg;
+            status = "error";
+          },
+          onDone: () => {
+            if (status !== "error") status = "loaded_with_llm";
+          },
+        });
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {
+          // Cancelled mid-flight: drop back to the post-detect state so
+          // the user can run again without reopening the drawer.
+          status = "loaded_deterministic";
+          return;
+        }
+        errorMessage = (err as Error).message ?? "Failed to run agent";
+        status = "error";
+      }
+    },
+
+    cancel(): void {
+      abortController?.abort();
+      abortController = null;
+      if (status === "loading_llm") {
+        status = "loaded_deterministic";
+      }
+    },
+
+    close(): void {
+      reset();
+      open = false;
+    },
+
+    toggleSkip(id: string): void {
+      proposals = proposals.map((p) =>
+        p.id === id ? { ...p, skipped: !p.skipped } : p,
+      );
+    },
+
+    editProposal(id: string, edits: Partial<ProposalEdits>): void {
+      proposals = proposals.map((p) =>
+        p.id === id ? { ...p, edits: { ...p.edits, ...edits } } : p,
+      );
+    },
+
+    togglePreviewOpen(id: string): void {
+      proposals = proposals.map((p) =>
+        p.id === id
+          ? { ...p, preview: { ...p.preview, open: !p.preview.open } }
+          : p,
+      );
+    },
+
+    async loadPreview(id: string): Promise<void> {
+      const target = proposals.find((p) => p.id === id);
+      if (!target) return;
+      const merged = applyEdits(target.proposal, target.edits);
+
+      proposals = proposals.map((p) =>
+        p.id === id
+          ? {
+              ...p,
+              preview: {
+                ...p.preview,
+                loading: true,
+                error: null,
+                open: true,
+              },
+            }
+          : p,
+      );
+
+      try {
+        const resp = await previewTidy(merged);
+        proposals = proposals.map((p) =>
+          p.id === id
+            ? {
+                ...p,
+                preview: {
+                  loading: false,
+                  html: resp.html,
+                  rowCount: resp.row_count,
+                  error: resp.error,
+                  open: true,
+                },
+              }
+            : p,
+        );
+      } catch (err) {
+        const message = (err as Error).message ?? "Preview failed";
+        proposals = proposals.map((p) =>
+          p.id === id
+            ? {
+                ...p,
+                preview: {
+                  ...p.preview,
+                  loading: false,
+                  error: message,
+                  open: true,
+                },
+              }
+            : p,
+        );
+      }
+    },
+
+    /** Apply every non-skipped, non-already-applied proposal in order;
+     * stop on first failure.
+     *
+     * Sequential, not parallel: each apply mutates the database and the
+     * subsequent ones depend on the latest schema_info (e.g., a proposal
+     * that targets `sales_long` would collide with the prior one).
+     */
+    async applyAll(): Promise<{ applied: number; failed: number }> {
+      const queue = proposals
+        .filter((p) => !p.skipped && p.status !== "applied")
+        .map((p) => p.id);
+      let applied = 0;
+      let failed = 0;
+      let lastSchema: unknown = null;
+
+      const disposition: TidyDisposition = {
+        mode: dispositionMode,
+        new_name:
+          dispositionMode === "rename" ? dispositionRenameTo.trim() : undefined,
+      };
+
+      for (const id of queue) {
+        const target = proposals.find((p) => p.id === id);
+        if (!target) continue;
+        const merged = applyEdits(target.proposal, target.edits);
+
+        proposals = proposals.map((p) =>
+          p.id === id
+            ? { ...p, status: "applying", applyError: null, applyResult: null }
+            : p,
+        );
+
+        try {
+          const resp = await applyTidy({
+            proposal: merged,
+            mode,
+            disposition,
+          });
+          if (resp.success) {
+            applied += 1;
+            lastSchema = resp.schema_info ?? lastSchema;
+            proposals = proposals.map((p) =>
+              p.id === id
+                ? {
+                    ...p,
+                    status: "applied",
+                    applyResult: resp.result ?? null,
+                  }
+                : p,
+            );
+          } else {
+            failed += 1;
+            proposals = proposals.map((p) =>
+              p.id === id
+                ? {
+                    ...p,
+                    status: "apply_error",
+                    applyError: resp.error ?? "Apply failed",
+                  }
+                : p,
+            );
+            break;
+          }
+        } catch (err) {
+          failed += 1;
+          const message = (err as Error).message ?? "Apply failed";
+          proposals = proposals.map((p) =>
+            p.id === id
+              ? { ...p, status: "apply_error", applyError: message }
+              : p,
+          );
+          break;
+        }
+      }
+
+      if (lastSchema !== null && appliedHook) {
+        appliedHook(lastSchema);
+      }
+
+      return { applied, failed };
+    },
+  };
+}
+
+export const tidyStore = createTidyStore();

--- a/frontend/tests/tidy.test.ts
+++ b/frontend/tests/tidy.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { tidyStore } from "$lib/stores/tidy.svelte";
+import type { TidyProposal } from "$lib/api/tidy";
+
+function sseStream(events: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const e of events) controller.enqueue(encoder.encode(e));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function makeProposal(overrides: Partial<TidyProposal> = {}): TidyProposal {
+  const dim = { name: "year", kind: "year", dtype: "INTEGER" };
+  return {
+    pattern: "date_in_column_names",
+    table: "sales",
+    dimensions: [dim],
+    column_mappings: [
+      { column: "sales_2020", dimension_values: { year: "2020" } },
+      { column: "sales_2021", dimension_values: { year: "2021" } },
+    ],
+    id_columns: ["region"],
+    value_column: "sales",
+    target_object_name: "sales_long",
+    rationale: "Looks like wide-by-year",
+    reshape_sql: "CREATE OR REPLACE TABLE sales_long AS ...",
+    confidence: "high",
+    source: "deterministic",
+    include_nulls: true,
+    preview_sql: "SELECT 1",
+    reshape_sql_view: "CREATE OR REPLACE VIEW sales_long AS ...",
+    reshape_sql_table: "CREATE OR REPLACE TABLE sales_long AS ...",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Reset store between tests by closing it (clears all state).
+  tidyStore.close();
+});
+
+function detectResponse(proposals: TidyProposal[], error: string | null = null): Response {
+  return new Response(JSON.stringify({ proposals, error }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("tidyStore.start", () => {
+  it("loads deterministic proposals from /api/tidy/detect without firing the LLM", async () => {
+    const det = makeProposal({ source: "deterministic" });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(detectResponse([det]));
+
+    await tidyStore.start("sales");
+
+    expect(tidyStore.status).toBe("loaded_deterministic");
+    expect(tidyStore.proposals).toHaveLength(1);
+    expect(tidyStore.proposals[0].proposal.source).toBe("deterministic");
+    // Edits default to the proposal's own values.
+    expect(tidyStore.proposals[0].edits.target_object_name).toBe("sales_long");
+    // Only the detect endpoint was hit — propose stays untouched until Run.
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes("/api/tidy/detect"))).toBe(true);
+    expect(calls.some((u) => u.includes("/api/tidy/propose"))).toBe(false);
+  });
+
+  it("transitions to error status when /api/tidy/detect returns an error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      detectResponse([], "No dataset loaded"),
+    );
+
+    await tidyStore.start("sales");
+
+    expect(tidyStore.status).toBe("error");
+    expect(tidyStore.errorMessage).toBe("No dataset loaded");
+  });
+});
+
+describe("tidyStore.runAgent", () => {
+  it("appends llm proposals to the existing deterministic list", async () => {
+    const det = makeProposal({ source: "deterministic" });
+    const llm = makeProposal({
+      source: "llm",
+      target_object_name: "sales_long_llm",
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(detectResponse([det]))
+      .mockResolvedValueOnce(
+        sseStream([
+          "event: llm_started\ndata: {}\n\n",
+          `event: llm_proposals\ndata: ${JSON.stringify({
+            proposals: [llm],
+            parse_warnings: [],
+          })}\n\n`,
+          "event: done\ndata: {}\n\n",
+        ]),
+      );
+
+    await tidyStore.start("sales");
+    expect(tidyStore.proposals).toHaveLength(1);
+
+    await tidyStore.runAgent();
+
+    expect(tidyStore.status).toBe("loaded_with_llm");
+    expect(tidyStore.proposals).toHaveLength(2);
+    expect(tidyStore.proposals[1].proposal.source).toBe("llm");
+  });
+
+  it("surfaces llm errors as non-fatal warnings and stays in loaded_with_llm", async () => {
+    const det = makeProposal();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(detectResponse([det]))
+      .mockResolvedValueOnce(
+        sseStream([
+          "event: llm_started\ndata: {}\n\n",
+          'event: llm_error\ndata: {"error":"provider-down"}\n\n',
+          "event: done\ndata: {}\n\n",
+        ]),
+      );
+
+    await tidyStore.start("sales");
+    await tidyStore.runAgent();
+
+    expect(tidyStore.status).toBe("loaded_with_llm");
+    expect(tidyStore.parseWarnings).toHaveLength(1);
+    expect(tidyStore.parseWarnings[0]).toContain("provider-down");
+    // Deterministic proposal stays.
+    expect(tidyStore.proposals).toHaveLength(1);
+  });
+});
+
+describe("tidyStore mutations", () => {
+  it("toggles skip and counts only non-skipped, non-applied proposals", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      detectResponse([makeProposal()]),
+    );
+    await tidyStore.start("sales");
+    const id = tidyStore.proposals[0].id;
+
+    // Default: every proposal is pending and counts toward Apply.
+    expect(tidyStore.pendingCount).toBe(1);
+    tidyStore.toggleSkip(id);
+    expect(tidyStore.pendingCount).toBe(0);
+    expect(tidyStore.proposals[0].skipped).toBe(true);
+    tidyStore.toggleSkip(id);
+    expect(tidyStore.pendingCount).toBe(1);
+    expect(tidyStore.proposals[0].skipped).toBe(false);
+  });
+
+  it("editProposal merges edits without losing other fields", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      detectResponse([makeProposal()]),
+    );
+    await tidyStore.start("sales");
+    const id = tidyStore.proposals[0].id;
+
+    tidyStore.editProposal(id, { target_object_name: "renamed_long" });
+    expect(tidyStore.proposals[0].edits.target_object_name).toBe("renamed_long");
+    expect(tidyStore.proposals[0].edits.value_column).toBe("sales");
+    expect(tidyStore.proposals[0].edits.id_columns).toEqual(["region"]);
+  });
+
+  it("flipping mode back to view forces disposition to keep", () => {
+    tidyStore.mode = "table";
+    tidyStore.dispositionMode = "drop";
+    expect(tidyStore.dispositionMode).toBe("drop");
+    tidyStore.mode = "view";
+    expect(tidyStore.dispositionMode).toBe("keep");
+  });
+
+  it("edits.include_nulls defaults from the proposal and survives toggling", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      detectResponse([makeProposal({ include_nulls: true })]),
+    );
+    await tidyStore.start("sales");
+    const id = tidyStore.proposals[0].id;
+
+    expect(tidyStore.proposals[0].edits.include_nulls).toBe(true);
+    tidyStore.editProposal(id, { include_nulls: false });
+    expect(tidyStore.proposals[0].edits.include_nulls).toBe(false);
+    // Other edits remain.
+    expect(tidyStore.proposals[0].edits.target_object_name).toBe("sales_long");
+  });
+});
+
+describe("tidyStore.applyAll", () => {
+  async function loadOne(): Promise<string> {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      detectResponse([makeProposal()]),
+    );
+    await tidyStore.start("sales");
+    return tidyStore.proposals[0].id;
+  }
+
+  it("posts pending proposals and marks them applied on success", async () => {
+    // No skip toggle needed — proposals default to pending.
+    await loadOne();
+
+    const applyMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: {
+            table: "sales",
+            target_object_name: "sales_long",
+            final_target_name: "sales_long",
+            object_type: "view",
+            affected_columns: ["sales_2020", "sales_2021"],
+            row_count_source: 2,
+            row_count_target: 4,
+            source_disposition: "keep",
+            source_renamed_to: null,
+            dry_run: false,
+          },
+          schema_info: [{ name: "sales_long" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await tidyStore.applyAll();
+
+    expect(result).toEqual({ applied: 1, failed: 0 });
+    expect(tidyStore.proposals[0].status).toBe("applied");
+    expect(tidyStore.proposals[0].applyResult?.row_count_target).toBe(4);
+
+    const applyCall = applyMock.mock.calls.find(
+      (c) => c[0] === "/api/tidy/apply",
+    );
+    expect(applyCall).toBeDefined();
+    const body = JSON.parse((applyCall![1] as RequestInit).body as string);
+    expect(body.mode).toBe("view");
+    expect(body.disposition.mode).toBe("keep");
+    // The proposal carries include_nulls so the backend can route through
+    // the right SQL builder.
+    expect(body.proposal.include_nulls).toBe(true);
+  });
+
+  it("forwards the edited include_nulls flag in the apply payload", async () => {
+    const id = await loadOne();
+    tidyStore.editProposal(id, { include_nulls: false });
+
+    const applyMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: {
+            table: "sales",
+            target_object_name: "sales_long",
+            final_target_name: "sales_long",
+            object_type: "view",
+            affected_columns: ["sales_2020", "sales_2021"],
+            row_count_source: 2,
+            row_count_target: 3,
+            source_disposition: "keep",
+            source_renamed_to: null,
+            dry_run: false,
+          },
+          schema_info: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await tidyStore.applyAll();
+
+    const applyCall = applyMock.mock.calls.find(
+      (c) => c[0] === "/api/tidy/apply",
+    );
+    const body = JSON.parse((applyCall![1] as RequestInit).body as string);
+    expect(body.proposal.include_nulls).toBe(false);
+  });
+
+  it("skipped proposals are excluded from the apply queue", async () => {
+    // Two proposals: one default (pending), one user-skipped.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      detectResponse([
+        makeProposal({ target_object_name: "sales_long_v1" }),
+        makeProposal({ target_object_name: "sales_long_v2" }),
+      ]),
+    );
+    await tidyStore.start("sales");
+    const skipId = tidyStore.proposals[1].id;
+    tidyStore.toggleSkip(skipId);
+    expect(tidyStore.pendingCount).toBe(1);
+
+    const applyMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: {
+            table: "sales",
+            target_object_name: "sales_long_v1",
+            final_target_name: "sales_long_v1",
+            object_type: "view",
+            affected_columns: ["sales_2020", "sales_2021"],
+            row_count_source: 2,
+            row_count_target: 4,
+            source_disposition: "keep",
+            source_renamed_to: null,
+            dry_run: false,
+          },
+          schema_info: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await tidyStore.applyAll();
+    expect(result).toEqual({ applied: 1, failed: 0 });
+    // Only one apply call was made — the skipped proposal stayed pending.
+    const applyCalls = applyMock.mock.calls.filter(
+      (c) => c[0] === "/api/tidy/apply",
+    );
+    expect(applyCalls).toHaveLength(1);
+    expect(tidyStore.proposals[0].status).toBe("applied");
+    expect(tidyStore.proposals[1].status).toBe("pending");
+    expect(tidyStore.proposals[1].skipped).toBe(true);
+  });
+
+  it("marks the proposal apply_error and stops the queue on failure", async () => {
+    await loadOne();
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ success: false, error: "schema mismatch" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await tidyStore.applyAll();
+
+    expect(result).toEqual({ applied: 0, failed: 1 });
+    expect(tidyStore.proposals[0].status).toBe("apply_error");
+    expect(tidyStore.proposals[0].applyError).toContain("schema mismatch");
+  });
+});

--- a/src/datasight/cli_commands/tidy.py
+++ b/src/datasight/cli_commands/tidy.py
@@ -371,6 +371,7 @@ def tidy_table(project_dir, source_table, dry_run):
             datasight tidy review --from plan.json --dry-run
             datasight tidy review --out detector.json
             datasight tidy review --from plan.json --apply-all --drop-source
+            datasight tidy review --from plan.json --apply-all --replace-source
             datasight tidy review --from plan.json --apply-all --rename-source sales_wide_raw
         """
     ),
@@ -432,14 +433,29 @@ def tidy_table(project_dir, source_table, dry_run):
     ),
 )
 @click.option(
+    "--replace-source",
+    "replace_source",
+    is_flag=True,
+    default=False,
+    help=(
+        "Drop the source after a successful reshape and rename the long-form "
+        "table to take the source's old name. Downstream code that referenced "
+        "the source keeps working without edits. Requires '--as table' — a "
+        "view's body references its source by name."
+    ),
+)
+@click.option(
     "--drop-source",
     "drop_source",
     is_flag=True,
     default=False,
     help=(
-        "Drop the source after a successful reshape and rename the long-form "
-        "table to take the source's old name. The long form replaces the source. "
-        "Requires '--as table' — a view's body references its source by name."
+        "Drop the source after a successful reshape; the long form keeps its "
+        "target name. Pick this when the new shape is the canonical one going "
+        "forward and you don't need to preserve the source's name. Requires "
+        "'--as table'. NOTE: previously this flag carried the semantics now "
+        "moved to '--replace-source'; scripts depending on the old behavior "
+        "should switch to '--replace-source'."
     ),
 )
 @click.option(
@@ -463,6 +479,7 @@ def tidy_review(
     as_mode,
     keep_source,
     rename_source,
+    replace_source,
     drop_source,
     sample_rows,
 ):
@@ -481,26 +498,37 @@ def tidy_review(
     Calls the configured LLM provider whenever ``--from`` is not set.
     """
     try:
-        disposition = resolve_source_disposition(keep_source, rename_source, drop_source)
+        disposition = resolve_source_disposition(
+            keep_source, rename_source, replace_source, drop_source
+        )
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
 
     # ``--as view`` is only safe with ``--keep-source``: a view's body
-    # references its source by name, so renaming or dropping the source
-    # leaves the view dangling — and for ``drop`` (which also renames the
-    # long form into the source's slot), DuckDB rejects subsequent SELECTs
-    # with "infinite recursion detected". Catch the bad combo before any
-    # work runs, including before the LLM call when ``--from`` is omitted.
-    if as_mode == "view" and disposition.mode in ("rename", "drop"):
-        action = "drop" if disposition.mode == "drop" else "rename"
-        gerund = "dropping" if disposition.mode == "drop" else "renaming"
+    # references its source by name, so renaming/replacing/dropping the
+    # source leaves the view dangling — and for ``replace`` (which also
+    # renames the long form into the source's slot), DuckDB rejects
+    # subsequent SELECTs with "infinite recursion detected". Catch the
+    # bad combo before any work runs, including before the LLM call when
+    # ``--from`` is omitted.
+    if as_mode == "view" and disposition.mode != "keep":
+        flag = {
+            "rename": "--rename-source",
+            "replace": "--replace-source",
+            "drop": "--drop-source",
+        }[disposition.mode]
+        gerund = {
+            "rename": "renaming",
+            "replace": "replacing",
+            "drop": "dropping",
+        }[disposition.mode]
         consequence = (
             "recursively self-referencing."
-            if disposition.mode == "drop"
+            if disposition.mode == "replace"
             else "pointing at a missing object."
         )
         raise click.UsageError(
-            f"--{action}-source requires '--as table'. A view references "
+            f"{flag} requires '--as table'. A view references "
             f"its source by name, so {gerund} the source would leave "
             f"the long-form view {consequence}"
         )

--- a/src/datasight/tidy.py
+++ b/src/datasight/tidy.py
@@ -313,20 +313,16 @@ def _build_unpivot_sql(
     dimension: Dimension,
     value_column: str,
     target_object_name: str,
-    mode: str,
 ) -> str:
     """Build a single-pivot ``CREATE OR REPLACE TABLE`` using ``UNPIVOT``.
 
-    Only used by the dispatcher when ``include_nulls=False`` and ``mode==
-    'table'`` and there's a single dimension — UNPIVOT silently drops
-    rows where the value is NULL (DuckDB 1.5.2 has no ``INCLUDE NULLS``
-    clause), which lines up with the explicit drop-nulls request. View
-    mode also stays out of this path because the Python duckdb 1.5.2
-    binding has a regression where UNPIVOT inside a view fails to re-bind
-    on a fresh connection.
-
-    Multi-pivot reshapes never use this builder — UNPIVOT emits a single
-    name column, so it doesn't extend to multiple dimensions.
+    Always emits table mode — that's the only path the dispatcher routes
+    here. UNPIVOT silently drops rows where the value is NULL (DuckDB
+    1.5.2 has no ``INCLUDE NULLS`` clause), which lines up with the
+    ``include_nulls=False`` request. View mode and multi-pivot stay out
+    of this path: the Python duckdb 1.5.2 binding has a regression where
+    UNPIVOT inside a view fails to re-bind on a fresh connection, and
+    UNPIVOT emits a single name column so it can't represent multi-pivot.
 
     The ``SELECT * REPLACE`` wrapper applies the dimension's target dtype
     so the long-form column doesn't inherit VARCHAR from the literal.
@@ -418,28 +414,36 @@ def _build_union_all_sql(
             )
     body = "\n".join(branches)
 
-    # Surface the reason this builder is the default path so a reader
-    # tracing the generated DDL knows why UNION ALL appears instead of
-    # the more compact UNPIVOT form.
-    if mode == "view" and len(dimensions) == 1 and include_nulls:
+    # Surface the reason this builder ran instead of the more compact
+    # UNPIVOT form so a reader tracing the generated DDL understands
+    # what's going on. The conditions below mirror the dispatcher's
+    # routing rules: any of the three triggers UNION ALL.
+    if len(dimensions) > 1:
+        header = (
+            "-- UNPIVOT only emits one name column, so multi-pivot reshapes use\n"
+            "-- UNION ALL with one literal per dimension on each branch.\n"
+        )
+    elif mode == "view":
+        # View mode forces UNION ALL regardless of include_nulls — the
+        # Python duckdb 1.5.2 binding has a regression where UNPIVOT
+        # inside a view fails to re-bind on a fresh connection.
         header = (
             "-- Python `duckdb` 1.5.2 fails to re-bind UNPIVOT inside views on a fresh\n"
             "-- connection (Binder Error: UNPIVOT name count mismatch), so we use\n"
             "-- UNION ALL here. `tidy table` with include_nulls=false keeps the\n"
             "-- cleaner UNPIVOT form because materialized tables don't re-bind.\n"
         )
-    elif include_nulls and len(dimensions) == 1:
+    elif include_nulls:
+        # Single-pivot table mode + include_nulls=True: UNPIVOT in 1.5.2
+        # would silently drop NULLs, so UNION ALL preserves them.
         header = (
             "-- UNION ALL preserves NULL values; DuckDB 1.5.2 UNPIVOT has no\n"
             "-- INCLUDE NULLS clause, so UNPIVOT is reserved for the explicit\n"
             "-- drop-nulls case.\n"
         )
-    elif len(dimensions) > 1:
-        header = (
-            "-- UNPIVOT only emits one name column, so multi-pivot reshapes use\n"
-            "-- UNION ALL with one literal per dimension on each branch.\n"
-        )
     else:
+        # Single-pivot + table + drop-nulls would have used UNPIVOT;
+        # we shouldn't reach this branch from the dispatcher.
         header = ""
 
     return (
@@ -479,7 +483,6 @@ def _build_reshape_sql(
             dimensions[0],
             value_column,
             target_object_name,
-            mode,
         )
     return _build_union_all_sql(
         table,

--- a/src/datasight/tidy.py
+++ b/src/datasight/tidy.py
@@ -14,19 +14,30 @@ one-dimension case. The deterministic detector emits single-pivot
 proposals only; multi-pivot proposals come from the ``tidy review``
 LLM-augmented advisor.
 
-The DDL emitted depends on the target object and the dimension count:
+The DDL emitted depends on the target object, the dimension count, and
+whether the suggestion preserves NULL values:
 
-- Single-pivot, ``CREATE OR REPLACE TABLE`` — DuckDB ``UNPIVOT``. This
-  is the canonical, terse form.
-- Single-pivot, ``CREATE OR REPLACE VIEW`` — ``UNION ALL`` branches.
-  Workaround for a regression in the Python ``duckdb`` 1.5.2 binding:
-  UNPIVOT stored inside a view fails to re-bind on a fresh connection
-  (``Binder Error: UNPIVOT name count mismatch``). The standalone
-  ``duckdb`` CLI 1.5.1 isn't affected, but every datasight query path
-  uses the Python binding, so views need a form that survives re-bind.
-- Multi-pivot, table or view — ``UNION ALL`` with N dimension literals
-  per branch. UNPIVOT only emits one name column, so it doesn't extend
-  cleanly to multiple dimensions.
+- Single-pivot, ``CREATE OR REPLACE TABLE``, ``include_nulls=False`` (the
+  default) — DuckDB ``UNPIVOT``. This is the only path where UNPIVOT
+  applies; it's the terse form and DuckDB's native UNPIVOT silently
+  drops NULL rows, which matches the typical wide-table reshape where
+  NULLs are structural placeholders rather than real observations.
+- Everything else — ``UNION ALL`` with one branch per pivoted column.
+  Required for multi-pivot (UNPIVOT only emits one name column), for
+  view mode (the Python ``duckdb`` 1.5.2 binding has a regression where
+  UNPIVOT stored inside a view fails to re-bind on a fresh connection —
+  ``Binder Error: UNPIVOT name count mismatch``), and for the opt-in
+  ``include_nulls=True`` case (DuckDB 1.5.2 has no ``INCLUDE NULLS``
+  clause, so UNION ALL preserves NULLs naturally). When
+  ``include_nulls=False`` and we're forced onto the UNION ALL path, each
+  branch carries a ``WHERE col IS NOT NULL`` filter so the result still
+  matches UNPIVOT's drop behavior.
+
+Each :class:`Dimension` carries a ``dtype`` so the long-form column
+doesn't inherit VARCHAR from the literal — year-like kinds default to
+INTEGER, string-shaped period codes (``q1``, ``Jan``, ``2020-01``) stay
+VARCHAR. The literals in the generated SQL are wrapped in ``CAST(... AS
+dtype)`` when the dtype isn't VARCHAR.
 
 Detection is deterministic and purely structural (column names plus
 dtypes plus row count), so it runs without issuing extra SQL. The DDL is
@@ -145,6 +156,25 @@ _PERIOD_DIMENSION_NAMES: dict[str, str] = {
     "day": "day",
 }
 
+# Default SQL dtype for the dimension column produced by each period kind.
+# Without this, the long-form column inherits VARCHAR from the literal,
+# which forces awkward casts in downstream filters (``WHERE year >= 2022``
+# fails). Numeric kinds map to INTEGER; string-shaped period codes (e.g.
+# ``2020-01``, ``q1``, ``Jan``) stay VARCHAR so they preserve the original
+# encoding.
+_PERIOD_DIMENSION_DTYPES: dict[str, str] = {
+    "year": "INTEGER",
+    "year_month": "VARCHAR",
+    "year_quarter": "VARCHAR",
+    "year_month_word": "VARCHAR",
+    "month_year": "VARCHAR",
+    "quarter": "VARCHAR",
+    "month": "VARCHAR",
+    "month_num": "INTEGER",
+    "hour": "INTEGER",
+    "day": "INTEGER",
+}
+
 
 # Allowed dimension kinds. ``date_period`` covers any time-axis pivot (year,
 # month, quarter, hour, day). The remaining kinds are used by LLM-proposed
@@ -159,10 +189,19 @@ CONFIDENCE_LEVELS: frozenset[str] = frozenset({"high", "medium", "low"})
 
 @dataclass
 class Dimension:
-    """One axis of a tidy reshape (e.g., year, fuel_type)."""
+    """One axis of a tidy reshape (e.g., year, fuel_type).
+
+    ``dtype`` is the SQL type the long-form dimension column will carry.
+    Without this hint the column inherits VARCHAR from the literal in the
+    generated SQL, which forces casts in downstream filters. The
+    deterministic detector picks INTEGER for numeric period kinds (year,
+    hour, day, month_num); LLM and user-supplied dimensions default to
+    VARCHAR.
+    """
 
     name: str
     kind: str
+    dtype: str = "VARCHAR"
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -194,6 +233,15 @@ class TidySuggestion:
     ``source`` and ``confidence`` exist so deterministic and LLM-proposed
     suggestions share one rendering path. The deterministic detector
     always emits ``source="deterministic"`` and ``confidence="high"``.
+
+    ``include_nulls`` controls whether rows where the value column is NULL
+    survive the reshape. Default ``False`` because most NULLs in wide
+    tables are *structural* — placeholders for combinations that don't
+    apply (e.g. ``lpg_lighting`` in an end-use × fuel pivot) — and
+    keeping them just inflates the long form with rows analysts would
+    filter out anyway. Flip to ``True`` for data where NULLs represent
+    real missing observations (sensor outages, optional survey answers)
+    and you want to preserve the gap.
     """
 
     pattern: str
@@ -207,6 +255,7 @@ class TidySuggestion:
     reshape_sql: str
     confidence: str = "high"
     source: str = "deterministic"
+    include_nulls: bool = False
 
     def build_sql(self, mode: str = "table") -> str:
         """Return DDL that materializes this suggestion as a table or view."""
@@ -220,6 +269,7 @@ class TidySuggestion:
             self.value_column,
             self.target_object_name,
             mode=mode,
+            include_nulls=self.include_nulls,
         )
 
     @property
@@ -240,6 +290,7 @@ class TidySuggestion:
             "reshape_sql": self.reshape_sql,
             "confidence": self.confidence,
             "source": self.source,
+            "include_nulls": self.include_nulls,
         }
 
 
@@ -264,28 +315,38 @@ def _build_unpivot_sql(
     target_object_name: str,
     mode: str,
 ) -> str:
-    """Build a single-pivot ``CREATE OR REPLACE TABLE|VIEW`` using ``UNPIVOT``.
+    """Build a single-pivot ``CREATE OR REPLACE TABLE`` using ``UNPIVOT``.
 
-    Only safe for ``mode='table'``. The Python ``duckdb`` 1.5.2 binding has a
-    regression where UNPIVOT stored inside a view fails to re-bind on a fresh
-    connection (the standalone CLI 1.5.1 is unaffected). ``_build_reshape_sql``
-    routes view mode to ``_build_union_all_sql`` instead.
+    Only used by the dispatcher when ``include_nulls=False`` and ``mode==
+    'table'`` and there's a single dimension — UNPIVOT silently drops
+    rows where the value is NULL (DuckDB 1.5.2 has no ``INCLUDE NULLS``
+    clause), which lines up with the explicit drop-nulls request. View
+    mode also stays out of this path because the Python duckdb 1.5.2
+    binding has a regression where UNPIVOT inside a view fails to re-bind
+    on a fresh connection.
 
-    Multi-pivot reshapes never use this builder — UNPIVOT emits a single name
-    column, so it doesn't extend to multiple dimensions.
+    Multi-pivot reshapes never use this builder — UNPIVOT emits a single
+    name column, so it doesn't extend to multiple dimensions.
+
+    The ``SELECT * REPLACE`` wrapper applies the dimension's target dtype
+    so the long-form column doesn't inherit VARCHAR from the literal.
     """
-    keyword = "TABLE" if mode == "table" else "VIEW"
     on_clause = ",\n    ".join(
         f"{_quote_identifier(m.column)} AS '{m.dimension_values[dimension.name].replace(chr(39), chr(39) * 2)}'"
         for m in column_mappings
     )
+    quoted_dim = _quote_identifier(dimension.name)
+    if dimension.dtype.upper() != "VARCHAR":
+        projection = f"SELECT * REPLACE (CAST({quoted_dim} AS {dimension.dtype}) AS {quoted_dim})"
+    else:
+        projection = "SELECT *"
     return (
-        f"CREATE OR REPLACE {keyword} {_quote_identifier(target_object_name)} AS\n"
-        f"SELECT * FROM (\n"
+        f"CREATE OR REPLACE TABLE {_quote_identifier(target_object_name)} AS\n"
+        f"{projection} FROM (\n"
         f"  UNPIVOT {_quote_identifier(table)}\n"
         f"  ON {on_clause}\n"
         f"  INTO\n"
-        f"    NAME {_quote_identifier(dimension.name)}\n"
+        f"    NAME {quoted_dim}\n"
         f"    VALUE {_quote_identifier(value_column)}\n"
         f");"
     )
@@ -299,18 +360,26 @@ def _build_union_all_sql(
     value_column: str,
     target_object_name: str,
     mode: str,
+    include_nulls: bool = False,
 ) -> str:
     """Build a ``CREATE OR REPLACE TABLE|VIEW`` using ``UNION ALL`` branches.
 
-    This is the unified path for:
+    This is the default path for everything except the single-pivot
+    drop-nulls table case, which uses :func:`_build_unpivot_sql`. UNION
+    ALL is required for:
 
-    - Single-pivot view mode (workaround for the duckdb 1.5.2 view-binding
-      bug; see module docstring).
-    - Multi-pivot, both table and view mode (UNPIVOT can't emit multiple
-      dimension columns).
+    - Single-pivot view mode (the duckdb 1.5.2 view-binding bug — see
+      module docstring).
+    - Multi-pivot, any mode (UNPIVOT only emits one name column).
+    - Any mode where ``include_nulls=True`` (DuckDB 1.5.2 UNPIVOT has no
+      ``INCLUDE NULLS`` clause; UNION ALL keeps NULLs naturally).
 
     Each affected column becomes one branch with N dimension literals plus
-    the value, in dimension-declaration order.
+    the value, in dimension-declaration order. When ``include_nulls`` is
+    False, every branch carries a ``WHERE <col> IS NOT NULL`` filter so
+    the result mirrors UNPIVOT's drop behavior. Dimension literals are
+    cast to the dimension's target dtype when it isn't VARCHAR so the
+    long-form columns don't all inherit VARCHAR.
     """
     keyword = "TABLE" if mode == "table" else "VIEW"
     quoted_table = _quote_identifier(table)
@@ -318,40 +387,52 @@ def _build_union_all_sql(
     id_select = ", ".join(_quote_identifier(c) for c in id_columns)
     id_prefix = f"{id_select}, " if id_select else ""
 
+    def _dim_literal(d: Dimension, value: str, *, with_alias: bool) -> str:
+        escaped = value.replace(chr(39), chr(39) * 2)
+        literal = f"'{escaped}'"
+        if d.dtype.upper() != "VARCHAR":
+            literal = f"CAST({literal} AS {d.dtype})"
+        if with_alias:
+            return f"{literal} AS {_quote_identifier(d.name)}"
+        return literal
+
     branches: list[str] = []
     for index, mapping in enumerate(column_mappings):
         dim_literals_first = ", ".join(
-            f"'{mapping.dimension_values[d.name].replace(chr(39), chr(39) * 2)}' "
-            f"AS {_quote_identifier(d.name)}"
-            for d in dimensions
+            _dim_literal(d, mapping.dimension_values[d.name], with_alias=True) for d in dimensions
         )
         dim_literals_subsequent = ", ".join(
-            f"'{mapping.dimension_values[d.name].replace(chr(39), chr(39) * 2)}'"
-            for d in dimensions
+            _dim_literal(d, mapping.dimension_values[d.name], with_alias=False) for d in dimensions
         )
         quoted_col = _quote_identifier(mapping.column)
+        where_clause = f" WHERE {quoted_col} IS NOT NULL" if not include_nulls else ""
         if index == 0:
             branches.append(
                 f"SELECT {id_prefix}{dim_literals_first}, "
-                f"{quoted_col} AS {quoted_value} FROM {quoted_table}"
+                f"{quoted_col} AS {quoted_value} FROM {quoted_table}{where_clause}"
             )
         else:
             branches.append(
                 f"UNION ALL SELECT {id_prefix}{dim_literals_subsequent}, "
-                f"{quoted_col} FROM {quoted_table}"
+                f"{quoted_col} FROM {quoted_table}{where_clause}"
             )
     body = "\n".join(branches)
 
-    # The single-pivot view case is the historical reason this builder
-    # exists — the comment surfaces that in the generated DDL so a reader
-    # tracing the file knows why UNION ALL appears instead of UNPIVOT.
-    if mode == "view" and len(dimensions) == 1:
+    # Surface the reason this builder is the default path so a reader
+    # tracing the generated DDL knows why UNION ALL appears instead of
+    # the more compact UNPIVOT form.
+    if mode == "view" and len(dimensions) == 1 and include_nulls:
         header = (
             "-- Python `duckdb` 1.5.2 fails to re-bind UNPIVOT inside views on a fresh\n"
             "-- connection (Binder Error: UNPIVOT name count mismatch), so we use\n"
-            "-- UNION ALL here. `tidy table` keeps the cleaner UNPIVOT form because\n"
-            "-- materialized tables don't re-bind. The standalone duckdb CLI 1.5.1\n"
-            "-- is unaffected.\n"
+            "-- UNION ALL here. `tidy table` with include_nulls=false keeps the\n"
+            "-- cleaner UNPIVOT form because materialized tables don't re-bind.\n"
+        )
+    elif include_nulls and len(dimensions) == 1:
+        header = (
+            "-- UNION ALL preserves NULL values; DuckDB 1.5.2 UNPIVOT has no\n"
+            "-- INCLUDE NULLS clause, so UNPIVOT is reserved for the explicit\n"
+            "-- drop-nulls case.\n"
         )
     elif len(dimensions) > 1:
         header = (
@@ -374,18 +455,24 @@ def _build_reshape_sql(
     value_column: str,
     target_object_name: str,
     mode: str = "table",
+    include_nulls: bool = False,
 ) -> str:
     """Build the DDL for one tidy reshape.
 
     Dispatch:
 
-    - single-pivot + ``mode='table'`` → UNPIVOT (canonical DuckDB form).
-    - single-pivot + ``mode='view'`` → UNION ALL (duckdb 1.5.2 view bug).
-    - multi-pivot, any mode → UNION ALL (UNPIVOT can't emit N name columns).
+    - single-pivot + ``mode='table'`` + ``include_nulls=False`` (the
+      default) → UNPIVOT. DuckDB drops NULLs natively, which matches the
+      common case of structural NAs in wide tables.
+    - everything else → UNION ALL with optional ``WHERE … IS NOT NULL``
+      branches when ``include_nulls=False``. Required for view mode (the
+      duckdb 1.5.2 view-binding bug), multi-pivot (UNPIVOT can only emit
+      one name column), and the opt-in ``include_nulls=True`` case
+      (DuckDB 1.5.2 has no INCLUDE NULLS clause).
     """
     if mode not in ("view", "table"):
         raise ValueError(f"mode must be 'view' or 'table', got {mode!r}")
-    if len(dimensions) == 1 and mode == "table":
+    if len(dimensions) == 1 and mode == "table" and not include_nulls:
         return _build_unpivot_sql(
             table,
             column_mappings,
@@ -402,6 +489,7 @@ def _build_reshape_sql(
         value_column,
         target_object_name,
         mode,
+        include_nulls=include_nulls,
     )
 
 
@@ -435,7 +523,8 @@ def _build_period_suggestion(
             f"the {period_kind} dimension appears to be encoded in column headers."
         )
 
-    dimensions = [Dimension(name=dimension_name, kind="date_period")]
+    dimension_dtype = _PERIOD_DIMENSION_DTYPES.get(period_kind, "VARCHAR")
+    dimensions = [Dimension(name=dimension_name, kind="date_period", dtype=dimension_dtype)]
     column_mappings = [
         ColumnMapping(column=col, dimension_values={dimension_name: token})
         for col, token in column_period_pairs

--- a/src/datasight/tidy_llm.py
+++ b/src/datasight/tidy_llm.py
@@ -109,8 +109,12 @@ PROPOSE_RESHAPES_TOOL: dict[str, Any] = {
                         "value_column": {
                             "type": "string",
                             "description": (
-                                "Snake_case name for the new measure column, "
-                                "e.g., 'net_generation_mwh'."
+                                "Snake_case name for the new measure column. "
+                                "Default to 'value' for predictability across "
+                                "long-form tables — do NOT bake units "
+                                "(`load_mwh`, `capacity_kw`) or measure names "
+                                "into this field unless an extremely obvious "
+                                "domain-specific name is unavoidable."
                             ),
                         },
                         "id_columns": {
@@ -201,11 +205,25 @@ A reshape is NOT appropriate when:
 When unsure, prefer to omit the proposal — the developer reviews
 everything you return.
 
-Always use snake_case for new column names. Prefer domain-meaningful
-names (`fuel_type`, `net_generation_mwh`) over generic ones (`category`,
-`value`) when the column names give you enough signal. Make `id_columns`
-the columns whose values identify a row in the original wide form
-(plant_id, region, report_date) — never include columns you are pivoting.
+Always use snake_case for new column names. Naming rules differ for
+dimensions vs. the value column:
+
+- **Dimension columns**: prefer domain-meaningful names (`fuel_type`,
+  `region`, `scenario`) over generic ones (`category`, `dim_1`) when the
+  column names give you enough signal. The dimension is what the long
+  form lets users *group by*, so a descriptive name pays off in queries.
+- **Value column**: always use `value` unless an extremely obvious
+  domain-specific name is unavoidable (rare). Predictability matters
+  more than descriptiveness here — analysts and downstream queries
+  consistently reference the same column name across all long-form
+  tables, so resist the urge to bake units (`load_mwh`, `capacity_kw`)
+  or measures (`generation`, `revenue`) into the column name. The unit
+  belongs in a separate metadata field or in the table's documentation,
+  not in the value column itself.
+
+Make `id_columns` the columns whose values identify a row in the
+original wide form (plant_id, region, report_date) — never include
+columns you are pivoting.
 
 Call the `propose_reshapes` tool exactly once. Pass an empty list if no
 reshapes are warranted.

--- a/src/datasight/tidy_review.py
+++ b/src/datasight/tidy_review.py
@@ -54,16 +54,29 @@ from datasight.tidy import (
 PLAN_VERSION = 1
 
 
-SourceDispositionMode = Literal["keep", "rename", "drop"]
+SourceDispositionMode = Literal["keep", "rename", "replace", "drop"]
 
 
 @dataclass
 class SourceDisposition:
     """What to do with the source table after a successful reshape.
 
-    ``mode='rename'`` requires ``new_name``. The other two modes ignore it.
-    ``--keep-source`` is the default; it leaves the source untouched so a
-    developer can compare wide and long forms side by side.
+    Four modes, each producing a different end state:
+
+    - ``keep`` (default) — source stays put. Long form lives at
+      ``target_object_name`` alongside it. Useful for comparing wide and
+      long forms.
+    - ``rename`` — source is renamed to ``new_name``. Long form lives at
+      ``target_object_name``. Requires ``new_name``.
+    - ``replace`` — source is dropped, then the long form is renamed to
+      take over the source's old name. Downstream code that referenced
+      the source keeps working without edits. The chosen
+      ``target_object_name`` is effectively a temporary intermediate
+      name.
+    - ``drop`` — source is dropped. The long form keeps its
+      ``target_object_name``. Downstream code that referenced the source
+      will break; pick this when the new shape is the canonical one
+      going forward.
     """
 
     mode: SourceDispositionMode = "keep"
@@ -85,7 +98,7 @@ class ApplyResult:
 
     ``final_target_name`` is the name the long-form object goes by *after*
     the disposition step. It differs from ``target_object_name`` only when
-    ``source_disposition == "drop"``, in which case the long form takes
+    ``source_disposition == "replace"``, in which case the long form takes
     over the source's old name (the source is dropped first).
     """
 
@@ -173,6 +186,7 @@ def _suggestion_to_proposal_dict(s: TidySuggestion) -> dict[str, Any]:
         "confidence": s.confidence,
         "source": s.source,
         "rationale": s.rationale,
+        "include_nulls": s.include_nulls,
     }
 
 
@@ -224,6 +238,13 @@ def _parse_proposal(p: Any, *, index: int) -> TidySuggestion:
     if not isinstance(pattern, str):
         raise ValueError(f"{where}: 'pattern' must be a string")
 
+    # Default False matches TidySuggestion's default — most NULLs in wide
+    # tables are structural placeholders, not real missing observations.
+    include_nulls_raw = p.get("include_nulls", False)
+    if not isinstance(include_nulls_raw, bool):
+        raise ValueError(f"{where}: 'include_nulls' must be a boolean")
+    include_nulls = include_nulls_raw
+
     reshape_sql = _build_reshape_sql(
         table=table,
         id_columns=list(id_columns_raw),
@@ -232,6 +253,7 @@ def _parse_proposal(p: Any, *, index: int) -> TidySuggestion:
         value_column=value_column,
         target_object_name=target_object_name,
         mode="table",
+        include_nulls=include_nulls,
     )
     return TidySuggestion(
         pattern=pattern,
@@ -245,6 +267,7 @@ def _parse_proposal(p: Any, *, index: int) -> TidySuggestion:
         reshape_sql=reshape_sql,
         confidence=confidence,
         source=source,
+        include_nulls=include_nulls,
     )
 
 
@@ -274,11 +297,34 @@ def _parse_dimensions(raw: Any, where: str) -> list[Dimension]:
             raise ValueError(
                 f"{sub}: 'kind' must be one of {sorted(DIMENSION_KINDS)}, got {kind!r}"
             )
-        dimensions.append(Dimension(name=name, kind=kind))
+        dtype = d_dict.get("dtype", "VARCHAR")
+        if not isinstance(dtype, str) or dtype.upper() not in _ALLOWED_DTYPES:
+            raise ValueError(
+                f"{sub}: 'dtype' must be one of {sorted(_ALLOWED_DTYPES)}, got {dtype!r}"
+            )
+        dimensions.append(Dimension(name=name, kind=kind, dtype=dtype.upper()))
     names = [d.name for d in dimensions]
     if len(set(names)) != len(names):
         raise ValueError(f"{where}: duplicate dimension names {names}")
     return dimensions
+
+
+# Whitelist of dimension column dtypes. Restricted because the value lands
+# inside a generated CAST clause, so accepting arbitrary strings would let
+# a hand-crafted plan inject SQL. Covers the period kinds the deterministic
+# detector emits (year/hour/day → INTEGER) plus the common LLM-friendly
+# string/date/numeric options.
+_ALLOWED_DTYPES: frozenset[str] = frozenset(
+    {
+        "VARCHAR",
+        "INTEGER",
+        "BIGINT",
+        "SMALLINT",
+        "DOUBLE",
+        "DATE",
+        "TIMESTAMP",
+    }
+)
 
 
 def _parse_column_mappings(raw: Any, dim_names: list[str], where: str) -> list[ColumnMapping]:
@@ -390,10 +436,16 @@ def apply_proposal(
 
        - ``keep`` — no-op.
        - ``rename`` — ``ALTER TABLE/VIEW … RENAME TO`` the source.
-       - ``drop`` — drop the source, then rename the long-form target to
-         the source's old name. The long form replaces the source so
+       - ``replace`` — drop the source, then rename the long-form target
+         to the source's old name. The long form replaces the source so
          downstream consumers (and any ``schema.yaml`` allowlist) keep
-         working without manual edits.
+         working without manual edits. The user-chosen
+         ``target_object_name`` is effectively a transient intermediate
+         here.
+       - ``drop`` — drop the source, leave the long form at its
+         ``target_object_name``. Pick this when the new shape is the
+         canonical one going forward and you don't need to preserve the
+         source's name.
 
     Source / target may be either tables or views (e.g. a view backed by a
     CSV). The DDL keyword is chosen per object via ``duckdb_views()``.
@@ -405,28 +457,31 @@ def apply_proposal(
     """
     if mode not in ("table", "view"):
         raise ValueError(f"mode must be 'view' or 'table', got {mode!r}")
-    # A view's body references its source by name. Renaming or dropping the
-    # source while the long form is a view leaves a dangling reference (or,
-    # for ``drop`` after the long form is renamed into the source's slot, an
-    # *infinite recursion* on bind). Force ``--as table`` so the long form
-    # is a self-contained materialization before we touch the source.
-    if mode == "view" and source_disposition.mode in ("rename", "drop"):
-        action = "drop" if source_disposition.mode == "drop" else "rename"
-        gerund = "dropping" if source_disposition.mode == "drop" else "renaming"
-        consequence = (
-            "recursively self-referencing"
-            if source_disposition.mode == "drop"
-            else "pointing at a missing object"
-        )
+    # A view's body references its source by name. Renaming or dropping
+    # the source while the long form is a view leaves a dangling reference
+    # — or, for ``replace`` (which renames the long form into the source's
+    # slot), an *infinite recursion* on bind. ``keep`` is the only mode
+    # that leaves the source untouched, so anything else needs ``--as
+    # table`` to materialize the long form before we modify the source.
+    if mode == "view" and source_disposition.mode != "keep":
+        if source_disposition.mode == "replace":
+            consequence = "recursively self-referencing"
+        else:
+            consequence = "pointing at a missing object"
+        verb = {
+            "rename": "renaming",
+            "replace": "replacing",
+            "drop": "dropping",
+        }[source_disposition.mode]
         raise ValueError(
-            f"--{action}-source requires --as table: a view references its "
-            f"source by name, so {gerund} the source would leave the view "
-            f"{consequence}."
+            f"source disposition {source_disposition.mode!r} requires --as "
+            f"table: a view references its source by name, so {verb} "
+            f"the source would leave the view {consequence}."
         )
     ddl = suggestion.build_sql(mode)
 
     final_target_name = (
-        suggestion.table if source_disposition.mode == "drop" else suggestion.target_object_name
+        suggestion.table if source_disposition.mode == "replace" else suggestion.target_object_name
     )
 
     if dry_run:
@@ -453,14 +508,29 @@ def apply_proposal(
         conn.execute(ddl)
         target_rows = _query_count(conn, suggestion.target_object_name)
         expected = source_rows * len(suggestion.column_mappings)
-        if target_rows != expected:
-            raise RuntimeError(
-                f"Reshape verification failed for {suggestion.target_object_name!r}: "
-                f"expected {expected} rows ({source_rows} source rows × "
-                f"{len(suggestion.column_mappings)} mapped columns), got {target_rows}. "
-                f"This usually means id_columns omits a column whose values "
-                f"duplicate or drop rows."
-            )
+        # When the proposal preserves NULLs, the row count must be exact:
+        # source_rows × mapped columns. id_column omissions or dropped
+        # rows show up here loud and clear. When the proposal drops NULLs
+        # we can't predict the count without an extra scan; the only
+        # invariant left is that the target sits within [0, expected].
+        # Anything outside that range still indicates a builder bug.
+        if suggestion.include_nulls:
+            if target_rows != expected:
+                raise RuntimeError(
+                    f"Reshape verification failed for {suggestion.target_object_name!r}: "
+                    f"expected {expected} rows ({source_rows} source rows × "
+                    f"{len(suggestion.column_mappings)} mapped columns), got {target_rows}. "
+                    f"This usually means id_columns omits a column whose values "
+                    f"duplicate or drop rows."
+                )
+        else:
+            if target_rows < 0 or target_rows > expected:
+                raise RuntimeError(
+                    f"Reshape verification failed for {suggestion.target_object_name!r}: "
+                    f"got {target_rows} rows, but with include_nulls=False the result "
+                    f"must sit between 0 and {expected} (source × mapped columns). "
+                    f"An out-of-range count signals a builder bug."
+                )
         source_renamed_to: str | None = None
         if source_disposition.mode == "rename":
             assert source_disposition.new_name is not None
@@ -470,16 +540,23 @@ def apply_proposal(
                 f"RENAME TO {_quote_identifier(source_disposition.new_name)}"
             )
             source_renamed_to = source_disposition.new_name
-        elif source_disposition.mode == "drop":
+        elif source_disposition.mode == "replace":
+            # Drop the source, then rename the long form into its slot so
+            # downstream consumers (and any schema.yaml allowlist) keep
+            # working without manual edits.
             source_kw = _drop_keyword(conn, suggestion.table)
             conn.execute(f"DROP {source_kw} {_quote_identifier(suggestion.table)}")
-            # The long form takes over the source's name so downstream
-            # consumers (and any schema.yaml allowlist) keep working.
             target_kw = _alter_keyword(conn, suggestion.target_object_name)
             conn.execute(
                 f"ALTER {target_kw} {_quote_identifier(suggestion.target_object_name)} "
                 f"RENAME TO {_quote_identifier(suggestion.table)}"
             )
+        elif source_disposition.mode == "drop":
+            # Bare drop: the long form keeps its target_object_name. Any
+            # downstream code that referenced the source by name will need
+            # to update its references.
+            source_kw = _drop_keyword(conn, suggestion.table)
+            conn.execute(f"DROP {source_kw} {_quote_identifier(suggestion.table)}")
         conn.execute("COMMIT")
     except Exception:
         conn.execute("ROLLBACK")
@@ -546,38 +623,58 @@ def update_schema_yaml_for_apply(
     target_table: str,
     disposition_mode: str,
     rename_to: str | None = None,
+    create_if_absent: bool = False,
 ) -> bool:
     """Sync ``schema.yaml`` with what just changed in the database.
 
-    No-op when ``schema.yaml`` is absent — the project doesn't maintain an
-    allowlist, so live introspection already exposes whatever's there. When
-    it is present, the goal is to keep the file aligned with the database
-    so introspected tables don't silently disappear from the UI:
+    By default this is a no-op when ``schema.yaml`` is absent — the project
+    doesn't maintain an allowlist, so live introspection already exposes
+    whatever's there. The CLI relies on this default so a one-off
+    ``tidy review`` doesn't side-effect a project that never had an
+    allowlist. Pass ``create_if_absent=True`` from contexts where the user
+    explicitly opted in to persisting the reshape (e.g. the web Apply
+    button) — the helper will materialize a fresh ``schema.yaml`` listing
+    both the source and the new long-form object.
+
+    When the file is present (or being created), the goal is to keep it
+    aligned with the database so introspected tables don't silently
+    disappear from the UI:
 
     - ``keep`` — append a new entry for ``target_table`` so the long form
       shows up alongside the source.
     - ``rename`` — rename the existing source entry to ``rename_to`` and
       append a new entry for ``target_table``.
-    - ``drop`` — leave the source entry's *name* in place (the long form
-      took it over), but clear any ``columns`` / ``excluded_columns``
-      filter on it, since the long form has a different shape and an old
-      filter would hide the new columns.
+    - ``replace`` — leave the source entry's *name* in place (the long
+      form took it over), but clear any ``columns`` /
+      ``excluded_columns`` filter on it since the long form has a
+      different shape and an old filter would hide the new columns.
+    - ``drop`` — remove the source entry entirely and append a new entry
+      for ``target_table``. Downstream code referencing the source by
+      name will break; the allowlist reflects that.
 
-    Returns ``True`` when the file was rewritten. Comments and original
-    formatting in the YAML are not preserved — the file is round-tripped
-    through ``yaml.safe_dump``.
+    Returns ``True`` when the file was rewritten (or freshly written).
+    Comments and original formatting in the YAML are not preserved — the
+    file is round-tripped through ``yaml.safe_dump``.
     """
     path = Path(project_dir) / "schema.yaml"
     if not path.exists():
-        return False
-    try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError as exc:
-        logger.warning(f"schema.yaml: not updated (parse error: {exc})")
-        return False
-    if not isinstance(data, dict):
-        logger.warning(f"schema.yaml: not updated (expected mapping, got {type(data).__name__})")
-        return False
+        if not create_if_absent:
+            return False
+        # Seed with the source table so the long-form append below has the
+        # same starting point as the existing-file path. Without this seed,
+        # a freshly created allowlist would silently exclude the source.
+        data: dict[str, Any] = {"tables": [{"name": source_table}]}
+    else:
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            logger.warning(f"schema.yaml: not updated (parse error: {exc})")
+            return False
+        if not isinstance(data, dict):
+            logger.warning(
+                f"schema.yaml: not updated (expected mapping, got {type(data).__name__})"
+            )
+            return False
     raw_tables = data.get("tables")
     if raw_tables is not None and not isinstance(raw_tables, list):
         logger.warning("schema.yaml: 'tables' must be a list, ignoring the file")
@@ -591,10 +688,11 @@ def update_schema_yaml_for_apply(
             break
 
     match disposition_mode:
-        case "drop":
+        case "replace":
+            # Long form took over the source's name: same slot, different
+            # columns. Clear any old column filter so the new columns
+            # surface.
             if source_entry is not None:
-                # Long form replaces source: same name, different columns. Drop
-                # any old column filter so the new columns surface.
                 source_entry.pop("columns", None)
                 source_entry.pop("excluded_columns", None)
             else:
@@ -603,6 +701,14 @@ def update_schema_yaml_for_apply(
             tables = [
                 e for e in tables if not (isinstance(e, dict) and e.get("name") == target_table)
             ]
+        case "drop":
+            # Bare drop: source goes away entirely, long form lives at
+            # target_table.
+            tables = [
+                e for e in tables if not (isinstance(e, dict) and e.get("name") == source_table)
+            ]
+            if not _has_table_entry(tables, target_table):
+                tables.append({"name": target_table})
         case "rename":
             if source_entry is not None and rename_to:
                 source_entry["name"] = rename_to
@@ -624,19 +730,33 @@ def _has_table_entry(tables: list[Any], name: str) -> bool:
     return any(isinstance(e, dict) and e.get("name") == name for e in tables)
 
 
-def resolve_source_disposition(keep: bool, rename_to: str | None, drop: bool) -> SourceDisposition:
-    """Translate the three CLI flags into a :class:`SourceDisposition`.
+def resolve_source_disposition(
+    keep: bool,
+    rename_to: str | None,
+    replace: bool,
+    drop: bool,
+) -> SourceDisposition:
+    """Translate the four CLI flags into a :class:`SourceDisposition`.
 
-    Enforces mutual exclusion: at most one of the three may be active.
-    The default (no flag set) is ``keep`` to match the documented behavior.
+    Enforces mutual exclusion: at most one of the four may be active. The
+    default (no flag set) is ``keep`` to match the documented behavior.
+
+    ``replace`` corresponds to ``--replace-source`` (drop source, long form
+    takes over the source's name). ``drop`` corresponds to
+    ``--drop-source`` (drop source, long form keeps its target name) — a
+    breaking change from the prior CLI semantics where ``--drop-source``
+    meant what ``--replace-source`` now means.
     """
-    active = sum([keep, rename_to is not None, drop])
+    active = sum([keep, rename_to is not None, replace, drop])
     if active > 1:
         raise ValueError(
-            "--keep-source, --rename-source, and --drop-source are mutually exclusive"
+            "--keep-source, --rename-source, --replace-source, and "
+            "--drop-source are mutually exclusive"
         )
     if rename_to is not None:
         return SourceDisposition(mode="rename", new_name=rename_to)
+    if replace:
+        return SourceDisposition(mode="replace")
     if drop:
         return SourceDisposition(mode="drop")
     return SourceDisposition(mode="keep")

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -98,6 +98,15 @@ from datasight.settings import (
     restore_original_env,
 )
 from datasight.sql_validation import build_measure_rule_map, build_schema_map, validate_sql
+from datasight.tidy import _detect_period_groups, analyze_tidy_patterns
+from datasight.tidy_llm import propose_reshapes
+from datasight.tidy_review import (
+    SourceDisposition,
+    _parse_proposal,
+    apply_proposal,
+    update_schema_yaml_for_apply,
+    validate_against_schema,
+)
 
 # ---------------------------------------------------------------------------
 # App setup
@@ -2992,6 +3001,410 @@ async def sql_format(request: Request, state: AppState = Depends(get_state)):
         return {"formatted": formatted, "error": None}
     except Exception as e:
         return {"formatted": sql, "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Tidy review endpoints
+# ---------------------------------------------------------------------------
+#
+# Three endpoints back the per-table Tidy drawer in the UI. They mirror the
+# pieces of ``datasight tidy review`` that map to the drawer's flow:
+#
+# - POST /api/tidy/propose  — SSE stream. Emits the deterministic detector's
+#   hits immediately, then invokes the LLM advisor. Lets the drawer render
+#   regex-derived candidates while the model is still working.
+# - POST /api/tidy/preview  — Run the proposal's reshape SQL with LIMIT 50
+#   on a read-only connection so the user can sanity-check the long form
+#   before applying. No DDL.
+# - POST /api/tidy/apply    — Materialize the long form, verify the row
+#   count, optionally reshape the source via SourceDisposition, sync
+#   schema.yaml, and re-introspect so the sidebar reflects the new objects.
+#
+# All three reject non-DuckDB modes — ``apply_proposal`` opens a writable
+# DuckDB connection, and the deterministic builders emit DuckDB-specific DDL.
+
+
+def _tidy_select_body(suggestion: Any) -> str:
+    """Extract the SELECT body from a tidy CREATE OR REPLACE ... AS <body>; DDL.
+
+    The reshape DDL produced by ``TidySuggestion.build_sql`` always wraps a
+    plain SELECT in ``CREATE OR REPLACE TABLE|VIEW <name> AS\\n<body>;``.
+    For preview we want just the body so it can run on a read-only
+    connection without materializing the target.
+    """
+    ddl = suggestion.build_sql("table")
+    match = re.search(r'CREATE OR REPLACE (?:TABLE|VIEW) "[^"]+" AS\n', ddl)
+    if not match:
+        raise ValueError("Could not extract SELECT body from reshape DDL")
+    body = ddl[match.end() :].rstrip()
+    if body.endswith(";"):
+        body = body[:-1]
+    return body
+
+
+def _serialize_tidy_suggestion(s: Any) -> dict[str, Any]:
+    """Add ``preview_sql`` and reshape DDL variants to the wire shape.
+
+    The drawer renders the SELECT for the inline SQL preview and records the
+    full DDL for the eventual apply, so emitting both up front lets the UI
+    avoid a separate round trip.
+    """
+    payload = s.to_dict()
+    try:
+        payload["preview_sql"] = _tidy_select_body(s)
+    except ValueError:
+        payload["preview_sql"] = ""
+    payload["reshape_sql_view"] = s.build_sql("view")
+    payload["reshape_sql_table"] = s.build_sql("table")
+    return payload
+
+
+def _sse_error(message: str) -> "StreamingResponse":
+    """Return an SSE stream containing a single error event."""
+    payload = json.dumps({"error": message})
+    return StreamingResponse(
+        iter([f"event: error\ndata: {payload}\n\n"]),
+        media_type="text/event-stream",
+    )
+
+
+@app.get("/api/tidy/detect")
+async def tidy_detect(table: str = "", state: AppState = Depends(get_state)):
+    """Return deterministic tidy proposals for one table — no LLM call.
+
+    Cheap, schema-only, instant. The Tidy drawer hits this on open so the
+    user sees regex-detected candidates immediately. The LLM advisor fires
+    only when the user clicks "Run agent", which calls
+    :func:`tidy_propose`.
+    """
+    if state.sql_runner is None or not state.schema_info:
+        return {"proposals": [], "error": "No dataset loaded"}
+    if state.sql_dialect != "duckdb":
+        return {"proposals": [], "error": "Tidy review requires DuckDB"}
+    table_name = table.strip()
+    if not table_name:
+        return {"proposals": [], "error": "Missing 'table' parameter"}
+
+    table_info = next((t for t in state.schema_info if t["name"] == table_name), None)
+    if table_info is None:
+        return {"proposals": [], "error": f"Table {table_name!r} not found"}
+
+    deterministic = _detect_period_groups(table_info)
+    return {
+        "proposals": [_serialize_tidy_suggestion(s) for s in deterministic],
+        "error": None,
+    }
+
+
+@app.post("/api/tidy/propose")
+async def tidy_propose(request: Request, state: AppState = Depends(get_state)):
+    """Stream LLM-augmented tidy proposals for one table.
+
+    Body: ``{table: str, sample_rows?: int}``. ``sample_rows > 0`` opts the
+    user into sending N values per LLM call (off by default — values go
+    over the network).
+
+    Deterministic detector hits are not emitted here — the drawer fetches
+    those separately via :func:`tidy_detect` so the LLM call only fires on
+    explicit user opt-in.
+    """
+    body = await request.json()
+    table = str(body.get("table") or "").strip()
+    try:
+        sample_rows = max(0, int(body.get("sample_rows") or 0))
+    except (TypeError, ValueError):
+        sample_rows = 0
+
+    if state.sql_runner is None or not state.schema_info:
+        return _sse_error("No dataset loaded")
+    if state.sql_dialect != "duckdb":
+        return _sse_error("Tidy review requires DuckDB")
+    if not table:
+        return _sse_error("Missing 'table' parameter")
+
+    table_info = next((t for t in state.schema_info if t["name"] == table), None)
+    if table_info is None:
+        return _sse_error(f"Table {table!r} not found")
+
+    async def generate():
+        try:
+            if state.llm_client is None:
+                yield 'event: error\ndata: {"error":"LLM not initialized"}\n\n'
+                return
+
+            samples: dict[str, list[dict[str, Any]]] | None = None
+            if sample_rows > 0:
+                assert state.sql_runner is not None
+                df = await state.sql_runner.run_sql(f'SELECT * FROM "{table}" LIMIT {sample_rows}')
+                samples = {table: df.to_dict(orient="records")}
+
+            schema_subset = [table_info]
+            tidy_data = analyze_tidy_patterns(schema_subset)
+            deterministic_hits = tidy_data["suggestions"]
+
+            yield "event: llm_started\ndata: {}\n\n"
+            try:
+                result = await propose_reshapes(
+                    state.llm_client,
+                    model=state.model,
+                    schema_info=schema_subset,
+                    deterministic_hits=deterministic_hits,
+                    samples=samples,
+                )
+            except Exception as exc:
+                logger.exception("Tidy LLM proposal failed")
+                yield (f"event: llm_error\ndata: {json.dumps({'error': str(exc)})}\n\n")
+                yield "event: done\ndata: {}\n\n"
+                return
+
+            yield (
+                "event: llm_proposals\n"
+                f"data: {json.dumps({'proposals': [_serialize_tidy_suggestion(s) for s in result.suggestions], 'parse_warnings': list(result.parse_warnings)})}\n\n"
+            )
+            yield "event: done\ndata: {}\n\n"
+        except Exception as exc:
+            logger.exception("Tidy propose error")
+            yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+@app.post("/api/tidy/preview")
+async def tidy_preview(request: Request, state: AppState = Depends(get_state)):
+    """Sample 50 rows of the proposed long form without materializing it."""
+    body = await request.json()
+    proposal_dict = body.get("proposal") or {}
+
+    if state.sql_runner is None:
+        return {"html": None, "row_count": 0, "error": "Database not connected"}
+    if state.sql_dialect != "duckdb":
+        return {"html": None, "row_count": 0, "error": "Tidy review requires DuckDB"}
+
+    try:
+        suggestion = _parse_proposal(proposal_dict, index=0)
+    except ValueError as exc:
+        return {"html": None, "row_count": 0, "error": f"Invalid proposal: {exc}"}
+
+    # Re-run the schema cross-check, but ignore the target-name collision
+    # rule — preview doesn't materialize the target, so a same-named existing
+    # object is fine here. Apply still enforces the rule.
+    problems = [
+        p
+        for p in validate_against_schema(suggestion, state.schema_info)
+        if "would collide" not in p and "already exists" not in p
+    ]
+    if problems:
+        return {"html": None, "row_count": 0, "error": "; ".join(problems)}
+
+    try:
+        select_body = _tidy_select_body(suggestion)
+    except ValueError as exc:
+        return {"html": None, "row_count": 0, "error": str(exc)}
+
+    sample_sql = f"SELECT * FROM (\n{select_body}\n) _tidy_preview LIMIT 50"
+    try:
+        df = await state.sql_runner.run_sql(sample_sql)
+    except Exception as exc:
+        return {"html": None, "row_count": 0, "error": str(exc)}
+
+    return {
+        "html": df_to_html_table(df),
+        "row_count": int(len(df)),
+        "error": None,
+    }
+
+
+@app.post("/api/tidy/render-sql")
+async def tidy_render_sql(request: Request, state: AppState = Depends(get_state)):
+    """Render the reshape DDL for a proposal in the requested mode.
+
+    The drawer shows pre-baked ``reshape_sql_view`` / ``reshape_sql_table``
+    on the proposal payload, but those are frozen at detect time and don't
+    reflect user edits (target name, value column, id columns,
+    include_nulls). This endpoint re-runs the builder against the current
+    proposal so the Show SQL panel stays accurate as the user tweaks
+    fields and toggles ``view`` vs ``table``.
+    """
+    body = await request.json()
+    proposal_dict = body.get("proposal") or {}
+    mode = str(body.get("mode") or "view")
+    if mode not in ("view", "table"):
+        return {"sql": "", "error": f"mode must be 'view' or 'table', got {mode!r}"}
+    try:
+        suggestion = _parse_proposal(proposal_dict, index=0)
+    except ValueError as exc:
+        return {"sql": "", "error": f"Invalid proposal: {exc}"}
+    return {"sql": suggestion.build_sql(mode), "error": None}
+
+
+@app.post("/api/tidy/apply")
+async def tidy_apply(request: Request, state: AppState = Depends(get_state)):
+    """Apply one tidy proposal and refresh schema state.
+
+    Mirrors ``datasight tidy review --apply-all`` for a single proposal:
+    swap the read-only runner for a writable connection, run the reshape +
+    optional source disposition under one transaction, then reopen the
+    runner read-only and re-introspect.
+    """
+    body = await request.json()
+    proposal_dict = body.get("proposal") or {}
+    mode = str(body.get("mode") or "view")
+    disposition_in = body.get("disposition") or {"mode": "keep"}
+
+    if state.sql_runner is None:
+        return {"success": False, "error": "Database not connected"}
+    if state.sql_dialect != "duckdb":
+        return {"success": False, "error": "Tidy review requires DuckDB"}
+    if mode not in ("view", "table"):
+        return {
+            "success": False,
+            "error": f"mode must be 'view' or 'table', got {mode!r}",
+        }
+
+    try:
+        suggestion = _parse_proposal(proposal_dict, index=0)
+    except ValueError as exc:
+        return {"success": False, "error": f"Invalid proposal: {exc}"}
+
+    disp_mode = str(disposition_in.get("mode") or "keep")
+    if disp_mode not in ("keep", "rename", "replace", "drop"):
+        return {
+            "success": False,
+            "error": (
+                "disposition.mode must be 'keep', 'rename', 'replace', or "
+                f"'drop', got {disp_mode!r}"
+            ),
+        }
+    new_name = disposition_in.get("new_name") or None
+    if disp_mode == "rename" and not new_name:
+        return {
+            "success": False,
+            "error": "disposition.new_name is required when mode == 'rename'",
+        }
+    # Mirror the safety rule from apply_proposal: only ``keep`` is safe in
+    # view mode. rename/replace/drop all touch the source, which a view
+    # references by name — the long-form view would dangle (or, for
+    # replace, infinitely self-reference after the rename-into-source-slot).
+    if mode == "view" and disp_mode != "keep":
+        return {
+            "success": False,
+            "error": (
+                f"disposition '{disp_mode}' requires mode='table'. A view "
+                "references its source by name, so modifying the source "
+                "would leave the long-form view dangling."
+            ),
+        }
+
+    # disp_mode is constrained above; cast for ty's narrowing (Literal type).
+    from typing import cast as _cast
+
+    disposition = SourceDisposition(mode=_cast(Any, disp_mode), new_name=new_name)
+
+    problems = validate_against_schema(suggestion, state.schema_info)
+    if problems:
+        return {
+            "success": False,
+            "error": "Plan failed schema cross-check: " + "; ".join(problems),
+        }
+
+    from datasight.runner import DuckDBRunner
+
+    runner = state.sql_runner
+    if isinstance(runner, CachingSqlRunner):
+        runner = runner._inner
+    if not isinstance(runner, DuckDBRunner):
+        return {
+            "success": False,
+            "error": "Tidy apply requires a project DuckDB runner",
+        }
+
+    db_path = runner._database_path
+
+    async with state.state_lock:
+        # Cached DataFrames can keep DuckDB buffers alive and block the
+        # read-write reopen of the same file; drop them before closing.
+        # See /api/add-files for the same dance.
+        state.clear_sql_cache()
+        runner.close()
+        import gc
+
+        gc.collect()
+
+        import duckdb as _duckdb
+
+        write_conn = _duckdb.connect(db_path, read_only=False)
+        try:
+            try:
+                result = await asyncio.to_thread(
+                    apply_proposal,
+                    write_conn,
+                    suggestion,
+                    mode=mode,
+                    source_disposition=disposition,
+                    dry_run=False,
+                )
+            except Exception as exc:
+                logger.exception("Tidy apply failed")
+                try:
+                    write_conn.close()
+                except Exception:
+                    pass
+                runner._connect()
+                return {"success": False, "error": str(exc)}
+            try:
+                write_conn.close()
+            except Exception:
+                pass
+        finally:
+            # Always restore the read-only runner so subsequent requests work
+            # even if the apply errored out before write_conn.close().
+            if runner._conn is None:
+                runner._connect()
+
+        # Sync schema.yaml. Pass create_if_absent=True so projects without
+        # an existing allowlist still get the long-form table persisted —
+        # the user clicked Apply, so the reshape should survive a restart.
+        # The CLI keeps the no-op-when-absent default. Failures are logged
+        # but don't fail the request: the database mutation already
+        # succeeded.
+        if state.project_dir:
+            try:
+                update_schema_yaml_for_apply(
+                    state.project_dir,
+                    source_table=suggestion.table,
+                    target_table=suggestion.target_object_name,
+                    disposition_mode=result.source_disposition,
+                    rename_to=result.source_renamed_to,
+                    create_if_absent=True,
+                )
+            except OSError as exc:
+                logger.warning(f"schema.yaml not updated: {exc}")
+
+        # Re-introspect so the schema sidebar reflects the new long-form
+        # object (and any rename/drop of the source).
+        tables = await introspect_schema(state.sql_runner.run_sql, runner=state.sql_runner)
+        state.schema_info = [
+            {
+                "name": t.name,
+                "row_count": t.row_count,
+                "columns": [
+                    {"name": c.name, "dtype": c.dtype, "nullable": c.nullable} for c in t.columns
+                ],
+            }
+            for t in tables
+        ]
+        state.schema_text = format_schema_context(
+            tables,
+            user_description=None if state.is_ephemeral else _load_user_description(state),
+        )
+        state.schema_map = build_schema_map(state.schema_info)
+        state.rebuild_system_prompt()
+
+    return {
+        "success": True,
+        "result": result.to_dict(),
+        "schema_info": state.schema_info,
+    }
 
 
 @app.get("/api/measures/editor")

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -3007,21 +3007,30 @@ async def sql_format(request: Request, state: AppState = Depends(get_state)):
 # Tidy review endpoints
 # ---------------------------------------------------------------------------
 #
-# Three endpoints back the per-table Tidy drawer in the UI. They mirror the
+# Five endpoints back the per-table Tidy drawer in the UI. They mirror the
 # pieces of ``datasight tidy review`` that map to the drawer's flow:
 #
-# - POST /api/tidy/propose  — SSE stream. Emits the deterministic detector's
-#   hits immediately, then invokes the LLM advisor. Lets the drawer render
-#   regex-derived candidates while the model is still working.
-# - POST /api/tidy/preview  — Run the proposal's reshape SQL with LIMIT 50
-#   on a read-only connection so the user can sanity-check the long form
-#   before applying. No DDL.
-# - POST /api/tidy/apply    — Materialize the long form, verify the row
+# - GET  /api/tidy/detect     — Synchronous, returns the deterministic
+#   detector's hits as JSON. Cheap and instant; the drawer fires this on
+#   open so users see something immediately without paying for a model
+#   call.
+# - POST /api/tidy/propose    — SSE stream that runs the LLM advisor.
+#   Emits ``llm_started`` → ``llm_proposals`` → ``done`` (or
+#   ``llm_error``). Caller-driven: only fires when the user clicks Run
+#   agent in the drawer.
+# - POST /api/tidy/preview    — Run the proposal's reshape SQL with
+#   LIMIT 50 on a read-only connection so the user can sanity-check the
+#   long form before applying. No DDL.
+# - POST /api/tidy/render-sql — Re-build the reshape DDL from the
+#   current edits + view/table mode, used by the Show SQL panel so the
+#   displayed DDL stays accurate as the user tweaks fields.
+# - POST /api/tidy/apply      — Materialize the long form, verify the row
 #   count, optionally reshape the source via SourceDisposition, sync
 #   schema.yaml, and re-introspect so the sidebar reflects the new objects.
 #
-# All three reject non-DuckDB modes — ``apply_proposal`` opens a writable
-# DuckDB connection, and the deterministic builders emit DuckDB-specific DDL.
+# All endpoints reject non-DuckDB modes — ``apply_proposal`` opens a
+# writable DuckDB connection, and the deterministic builders emit
+# DuckDB-specific DDL.
 
 
 def _tidy_select_body(suggestion: Any) -> str:

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -3357,12 +3357,19 @@ async def tidy_apply(request: Request, state: AppState = Depends(get_state)):
                 try:
                     write_conn.close()
                 except Exception:
+                    # The apply already failed; swallow any close-time
+                    # error so it doesn't mask the original cause. The
+                    # finally block below still restores the read-only
+                    # runner.
                     pass
                 runner._connect()
                 return {"success": False, "error": str(exc)}
             try:
                 write_conn.close()
             except Exception:
+                # Best-effort close on the happy path. A close-time
+                # error here is non-fatal — the apply already committed
+                # — so we drop it rather than poison the response.
                 pass
         finally:
             # Always restore the read-only runner so subsequent requests work

--- a/tests/test_tidy.py
+++ b/tests/test_tidy.py
@@ -121,7 +121,9 @@ def test_detects_year_columns_with_shared_prefix():
     assert len(out["suggestions"]) == 1
     s = out["suggestions"][0]
     assert s["pattern"] == "repeated_prefix_period"
-    assert s["dimensions"] == [{"name": "year", "kind": "date_period"}]
+    # Year-kind dimensions default to INTEGER so downstream filters like
+    # ``WHERE year >= 2022`` work without an explicit cast.
+    assert s["dimensions"] == [{"name": "year", "kind": "date_period", "dtype": "INTEGER"}]
     assert [m["column"] for m in s["column_mappings"]] == [
         "sales_2020",
         "sales_2021",
@@ -139,8 +141,15 @@ def test_detects_year_columns_with_shared_prefix():
     assert s["target_object_name"] == "sales_wide_long"
     assert s["confidence"] == "high"
     assert s["source"] == "deterministic"
+    # Default is include_nulls=False (most NULLs in wide tables are
+    # structural placeholders); single-pivot table mode routes through
+    # the terse UNPIVOT builder.
+    assert s["include_nulls"] is False
     assert "UNPIVOT" in s["reshape_sql"]
     assert "CREATE OR REPLACE TABLE" in s["reshape_sql"]
+    # The dimension column gets cast to INTEGER per the dtype default —
+    # in UNPIVOT mode the cast is wrapped via SELECT * REPLACE.
+    assert 'CAST("year" AS INTEGER)' in s["reshape_sql"]
 
 
 def test_detects_hour_columns_no_prefix():
@@ -156,7 +165,7 @@ def test_detects_hour_columns_no_prefix():
     assert len(out["suggestions"]) == 1
     s = out["suggestions"][0]
     assert s["pattern"] == "date_in_column_names"
-    assert s["dimensions"] == [{"name": "hour", "kind": "date_period"}]
+    assert s["dimensions"] == [{"name": "hour", "kind": "date_period", "dtype": "INTEGER"}]
     assert len(s["column_mappings"]) == 24
     assert s["value_column"] == "value"
     assert s["id_columns"] == ["plant_id", "date"]
@@ -178,7 +187,9 @@ def test_detects_quarter_columns():
     ]
     out = analyze_tidy_patterns(schema)
     assert len(out["suggestions"]) == 1
-    assert out["suggestions"][0]["dimensions"] == [{"name": "quarter", "kind": "date_period"}]
+    assert out["suggestions"][0]["dimensions"] == [
+        {"name": "quarter", "kind": "date_period", "dtype": "VARCHAR"}
+    ]
 
 
 def test_clean_table_produces_no_suggestions():
@@ -325,17 +336,23 @@ def test_reshape_sql_executes_in_duckdb(tmp_path):
     rows = conn.execute(
         "SELECT region, year, sales FROM sales_wide_long ORDER BY region, year"
     ).fetchall()
+    # Year column is INTEGER per the deterministic detector's dtype default,
+    # not VARCHAR — so a downstream filter like ``WHERE year >= 2022`` works
+    # without an explicit cast.
+    schema_rows = conn.execute("DESCRIBE sales_wide_long").fetchall()
     conn.close()
     assert rows == [
-        ("north", "2020", 10.0),
-        ("north", "2021", 20.0),
-        ("north", "2022", 30.0),
-        ("north", "2023", 40.0),
-        ("south", "2020", 5.0),
-        ("south", "2021", 15.0),
-        ("south", "2022", 25.0),
-        ("south", "2023", 35.0),
+        ("north", 2020, 10.0),
+        ("north", 2021, 20.0),
+        ("north", 2022, 30.0),
+        ("north", 2023, 40.0),
+        ("south", 2020, 5.0),
+        ("south", 2021, 15.0),
+        ("south", 2022, 25.0),
+        ("south", 2023, 35.0),
     ]
+    year_dtype = next(r[1] for r in schema_rows if r[0] == "year")
+    assert year_dtype == "INTEGER"
 
 
 # ---------------------------------------------------------------------------
@@ -430,6 +447,207 @@ def test_multi_pivot_reshape_round_trips_in_duckdb(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# include_nulls + dimension dtype: behavior pinning around the toggle.
+# ---------------------------------------------------------------------------
+
+
+def _wide_db_with_nulls(tmp_path) -> tuple[str, list[tuple]]:
+    """Build a single-table DuckDB with sparse nulls in pivoted columns.
+
+    Returns the path and the expected long-form rows when NULLs are kept.
+    """
+    db_path = tmp_path / "sparse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales ("
+        "region VARCHAR, "
+        "sales_2020 INTEGER, sales_2021 INTEGER, sales_2022 INTEGER)"
+    )
+    # north has data for all years; south skips 2021.
+    conn.execute("INSERT INTO sales VALUES ('north', 100, 110, 120), ('south', 200, NULL, 220)")
+    conn.close()
+    return str(db_path), [
+        ("north", 2020, 100),
+        ("north", 2021, 110),
+        ("north", 2022, 120),
+        ("south", 2020, 200),
+        ("south", 2021, None),
+        ("south", 2022, 220),
+    ]
+
+
+def test_include_nulls_default_drops_null_rows(tmp_path):
+    """The default ``include_nulls=False`` matches DuckDB UNPIVOT's native
+    behavior: rows where the pivoted value is NULL are dropped from the
+    long form. The dispatcher routes single-pivot table mode through the
+    terse UNPIVOT builder in this case."""
+    from datasight.tidy import _detect_period_groups
+
+    db_path, _ = _wide_db_with_nulls(tmp_path)
+
+    schema = [
+        _table(
+            "sales",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "INTEGER"),
+                ("sales_2021", "INTEGER"),
+                ("sales_2022", "INTEGER"),
+            ],
+            row_count=2,
+        )
+    ]
+    sugg = _detect_period_groups(schema[0])[0]
+    assert sugg.include_nulls is False
+    sql = sugg.build_sql("table")
+    # Single-pivot + table + drop-nulls is the only path that keeps UNPIVOT.
+    assert "UNPIVOT" in sql
+    assert "UNION ALL" not in sql
+
+    conn = duckdb.connect(db_path)
+    conn.execute(sql)
+    rows = conn.execute(
+        "SELECT region, year, sales FROM sales_long ORDER BY region, year"
+    ).fetchall()
+    conn.close()
+    # The NULL row for ('south', 2021) has been dropped.
+    assert rows == [
+        ("north", 2020, 100),
+        ("north", 2021, 110),
+        ("north", 2022, 120),
+        ("south", 2020, 200),
+        ("south", 2022, 220),
+    ]
+
+
+def test_include_nulls_true_preserves_null_rows(tmp_path):
+    """Opt-in ``include_nulls=True`` preserves NULL rows: the long form
+    mirrors the wide form's NULLs row-for-row (``rows × pivoted_columns``
+    rows). Routes through UNION ALL because DuckDB 1.5.2 ``UNPIVOT`` has
+    no INCLUDE NULLS clause."""
+    from datasight.tidy import _detect_period_groups
+
+    db_path, expected_full = _wide_db_with_nulls(tmp_path)
+
+    schema = [
+        _table(
+            "sales",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "INTEGER"),
+                ("sales_2021", "INTEGER"),
+                ("sales_2022", "INTEGER"),
+            ],
+            row_count=2,
+        )
+    ]
+    sugg = _detect_period_groups(schema[0])[0]
+    sugg.include_nulls = True
+    sql = sugg.build_sql("table")
+    # Strip the leading SQL comment block before checking — the comment
+    # explains *why* UNPIVOT is skipped here, so it mentions the keyword
+    # in prose. The actual DDL must not use UNPIVOT.
+    body = "\n".join(line for line in sql.splitlines() if not line.lstrip().startswith("--"))
+    assert "UNION ALL" in body
+    assert "UNPIVOT" not in body
+
+    conn = duckdb.connect(db_path)
+    conn.execute(sql)
+    rows = conn.execute(
+        "SELECT region, year, sales FROM sales_long ORDER BY region, year"
+    ).fetchall()
+    conn.close()
+    assert rows == expected_full
+
+
+def test_include_nulls_false_in_view_mode_uses_where_filter(tmp_path):
+    """View mode can't use UNPIVOT (DuckDB 1.5.2 view-binding bug), so
+    ``include_nulls=False`` falls back to UNION ALL with a per-branch
+    ``WHERE col IS NOT NULL`` filter that mirrors UNPIVOT's drop."""
+    from datasight.tidy import _detect_period_groups
+
+    db_path, _ = _wide_db_with_nulls(tmp_path)
+
+    schema = [
+        _table(
+            "sales",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "INTEGER"),
+                ("sales_2021", "INTEGER"),
+                ("sales_2022", "INTEGER"),
+            ],
+            row_count=2,
+        )
+    ]
+    sugg = _detect_period_groups(schema[0])[0]
+    sugg.include_nulls = False
+    sql = sugg.build_sql("view")
+    assert "UNION ALL" in sql
+    assert "IS NOT NULL" in sql
+
+    conn = duckdb.connect(db_path)
+    conn.execute(sql)
+    count = conn.execute("SELECT COUNT(*) FROM sales_long").fetchone()
+    conn.close()
+    assert count is not None
+    # 2 rows × 3 columns - 1 null = 5 surviving rows.
+    assert count[0] == 5
+
+
+def test_dimension_dtype_casts_literal_in_union_all_branches(tmp_path):
+    """Year-kind dimensions default to INTEGER. With ``include_nulls=True``
+    the dispatcher routes through the UNION ALL builder, where the
+    dimension literal in each branch is wrapped in ``CAST(... AS
+    INTEGER)`` rather than leaking VARCHAR into the long-form column."""
+    from datasight.tidy import _detect_period_groups
+
+    db_path, _ = _wide_db_with_nulls(tmp_path)
+    schema = [
+        _table(
+            "sales",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "INTEGER"),
+                ("sales_2021", "INTEGER"),
+                ("sales_2022", "INTEGER"),
+            ],
+            row_count=2,
+        )
+    ]
+    sugg = _detect_period_groups(schema[0])[0]
+    sugg.include_nulls = True  # force the UNION ALL path
+    sql = sugg.build_sql("table")
+    assert "CAST('2020' AS INTEGER)" in sql
+    assert "CAST('2021' AS INTEGER)" in sql
+    assert "CAST('2022' AS INTEGER)" in sql
+
+
+def test_dimension_dtype_casts_inside_unpivot_via_select_replace(tmp_path):
+    """With the new ``include_nulls=False`` default + single-pivot table
+    mode, the dispatcher picks UNPIVOT. The dimension column then gets
+    its dtype via ``SELECT * REPLACE`` wrapping the UNPIVOT result."""
+    from datasight.tidy import _detect_period_groups
+
+    schema = [
+        _table(
+            "sales",
+            [
+                ("region", "VARCHAR"),
+                ("sales_2020", "INTEGER"),
+                ("sales_2021", "INTEGER"),
+                ("sales_2022", "INTEGER"),
+            ],
+            row_count=2,
+        )
+    ]
+    sugg = _detect_period_groups(schema[0])[0]
+    sql = sugg.build_sql("table")
+    assert "UNPIVOT" in sql
+    assert 'CAST("year" AS INTEGER)' in sql
+
+
+# ---------------------------------------------------------------------------
 # CLI integration: `datasight quality` surfaces tidy suggestions
 # ---------------------------------------------------------------------------
 
@@ -461,7 +679,8 @@ def test_quality_cli_emits_tidy_suggestions_json(wide_project):
     assert len(data["tidy_suggestions"]) == 1
     s = data["tidy_suggestions"][0]
     assert s["table"] == "sales_wide"
-    assert s["dimensions"] == [{"name": "year", "kind": "date_period"}]
+    assert s["dimensions"] == [{"name": "year", "kind": "date_period", "dtype": "INTEGER"}]
+    # Default include_nulls=False + single-pivot + table → UNPIVOT.
     assert "UNPIVOT" in s["reshape_sql"]
 
 
@@ -471,7 +690,9 @@ def test_quality_cli_emits_tidy_suggestions_markdown(wide_project):
     assert result.exit_code == 0, result.output
     assert "Tidy Reshape Suggestions" in result.output
     assert "sales_wide" in result.output
-    assert "UNPIVOT" in result.output
+    # Suggestions table renders the source name; SQL details aren't shown
+    # in markdown summary.
+    assert "year" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -575,15 +796,21 @@ def test_tidy_view_sql_uses_union_all_workaround(tmp_path):
     assert "UNPIVOT" not in body
 
 
-def test_tidy_table_sql_uses_unpivot(tmp_path):
-    """Table mode uses the canonical UNPIVOT form (works because materialized
-    tables don't re-bind on query)."""
+def test_tidy_table_sql_uses_unpivot_by_default(tmp_path):
+    """``tidy table`` with the default ``include_nulls=False`` routes
+    single-pivot proposals through the terse UNPIVOT builder. UNION ALL
+    is reserved for view mode, multi-pivot, and the opt-in
+    ``include_nulls=True`` case — see the dispatcher in
+    ``_build_reshape_sql``."""
     project_dir, _ = _wide_project_dir(tmp_path)
     runner = CliRunner()
     result = runner.invoke(cli, ["tidy", "table", "--project-dir", project_dir, "--dry-run"])
     assert result.exit_code == 0, result.output
-    assert "UNPIVOT" in result.output
-    assert "UNION ALL" not in result.output
+    body = "\n".join(
+        line for line in result.output.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert "UNPIVOT" in body
+    assert "UNION ALL" not in body
 
 
 def test_tidy_view_actually_creates_view(tmp_path):
@@ -597,14 +824,14 @@ def test_tidy_view_actually_creates_view(tmp_path):
     ).fetchall()
     conn.close()
     assert rows == [
-        ("north", "2020", 10.0),
-        ("north", "2021", 20.0),
-        ("north", "2022", 30.0),
-        ("north", "2023", 40.0),
-        ("south", "2020", 5.0),
-        ("south", "2021", 15.0),
-        ("south", "2022", 25.0),
-        ("south", "2023", 35.0),
+        ("north", 2020, 10.0),
+        ("north", 2021, 20.0),
+        ("north", 2022, 30.0),
+        ("north", 2023, 40.0),
+        ("south", 2020, 5.0),
+        ("south", 2021, 15.0),
+        ("south", 2022, 25.0),
+        ("south", 2023, 35.0),
     ]
 
 
@@ -718,7 +945,9 @@ def test_tidy_suggest_accepts_csv_without_project(tmp_path):
     assert data["table_count"] == 1
     assert len(data["suggestions"]) == 1
     s = data["suggestions"][0]
-    assert s["dimensions"] == [{"name": "month", "kind": "date_period"}]
+    # Month words (jan/feb/...) stay VARCHAR — they're string codes, not
+    # numeric ordinals like ``month_num`` would be.
+    assert s["dimensions"] == [{"name": "month", "kind": "date_period", "dtype": "VARCHAR"}]
     assert len(s["column_mappings"]) == 12
     assert s["id_columns"] == ["plant_id", "fuel_type"]
 

--- a/tests/test_tidy_review.py
+++ b/tests/test_tidy_review.py
@@ -494,10 +494,12 @@ def test_apply_proposal_rename_source(tmp_path):
     assert "sales_long" in names
 
 
-def test_apply_proposal_drop_source(tmp_path):
-    """`--drop-source` drops the original wide table and renames the long
-    form into its place. Downstream consumers continue to query the same
-    table name; only the shape (and the data) has changed."""
+def test_apply_proposal_replace_source(tmp_path):
+    """``replace`` drops the original wide table and renames the long form
+    into its place. Downstream consumers continue to query the same table
+    name; only the shape (and the data) has changed. (Previously this
+    behavior was the ``drop`` mode; the rename was prompted by the user-
+    facing label being more accurate.)"""
     db_path = tmp_path / "wide.duckdb"
     _build_single_pivot_db(db_path)
     plan = load_plan(_write_plan(tmp_path, _single_pivot_plan_dict()))
@@ -507,7 +509,7 @@ def test_apply_proposal_drop_source(tmp_path):
             conn,
             plan.proposals[0],
             mode="table",
-            source_disposition=SourceDisposition(mode="drop"),
+            source_disposition=SourceDisposition(mode="replace"),
             dry_run=False,
         )
         names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
@@ -522,6 +524,32 @@ def test_apply_proposal_drop_source(tmp_path):
     assert result.final_target_name == "sales_wide"
     assert len(rows) == 8
     assert rows[0] == ("north", "2020", 10.0)
+
+
+def test_apply_proposal_drop_source_keeps_long_form_name(tmp_path):
+    """``drop`` is the bare-drop semantics: the source goes away but the
+    long form keeps its target name. Downstream code that referenced the
+    source name will fail; pick this when the new shape is the canonical
+    one going forward."""
+    db_path = tmp_path / "wide.duckdb"
+    _build_single_pivot_db(db_path)
+    plan = load_plan(_write_plan(tmp_path, _single_pivot_plan_dict()))
+    conn = duckdb.connect(str(db_path))
+    try:
+        result = apply_proposal(
+            conn,
+            plan.proposals[0],
+            mode="table",
+            source_disposition=SourceDisposition(mode="drop"),
+            dry_run=False,
+        )
+        names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
+    finally:
+        conn.close()
+    assert "sales_wide" not in names
+    assert "sales_long" in names  # kept its target name
+    assert result.final_target_name == "sales_long"
+    assert result.source_disposition == "drop"
 
 
 def test_apply_proposal_verification_failure_rolls_back(tmp_path):
@@ -574,6 +602,10 @@ def test_apply_proposal_verification_failure_rolls_back(tmp_path):
             "UNION ALL SELECT region, '2021', v_2021 FROM dup_wide "
             "UNION ALL SELECT region, '2022', v_2022 FROM dup_wide;"
         ),
+        # The strict ``count == source × mapped`` verify only fires for
+        # include_nulls=True; the bare-drop case relies on a looser range
+        # check that wouldn't trip on this synthetic mismatch.
+        include_nulls=True,
     )
 
     conn = duckdb.connect(str(db_path))
@@ -600,31 +632,42 @@ def test_apply_proposal_verification_failure_rolls_back(tmp_path):
 
 
 def test_resolve_source_disposition_default_keep():
-    d = resolve_source_disposition(keep=False, rename_to=None, drop=False)
+    d = resolve_source_disposition(keep=False, rename_to=None, replace=False, drop=False)
     assert d.mode == "keep"
 
 
 def test_resolve_source_disposition_explicit_keep():
-    d = resolve_source_disposition(keep=True, rename_to=None, drop=False)
+    d = resolve_source_disposition(keep=True, rename_to=None, replace=False, drop=False)
     assert d.mode == "keep"
 
 
 def test_resolve_source_disposition_rename():
-    d = resolve_source_disposition(keep=False, rename_to="raw_table", drop=False)
+    d = resolve_source_disposition(keep=False, rename_to="raw_table", replace=False, drop=False)
     assert d.mode == "rename"
     assert d.new_name == "raw_table"
 
 
+def test_resolve_source_disposition_replace():
+    """``--replace-source`` carries the original ``--drop-source`` semantics:
+    drop the source, long form takes over its name."""
+    d = resolve_source_disposition(keep=False, rename_to=None, replace=True, drop=False)
+    assert d.mode == "replace"
+
+
 def test_resolve_source_disposition_drop():
-    d = resolve_source_disposition(keep=False, rename_to=None, drop=True)
+    """``--drop-source`` is the bare drop: source goes away, long form keeps
+    its target name. (Breaking change from the prior CLI semantics.)"""
+    d = resolve_source_disposition(keep=False, rename_to=None, replace=False, drop=True)
     assert d.mode == "drop"
 
 
 def test_resolve_source_disposition_rejects_combination():
     with pytest.raises(ValueError, match="mutually exclusive"):
-        resolve_source_disposition(keep=False, rename_to="x", drop=True)
+        resolve_source_disposition(keep=False, rename_to="x", replace=False, drop=True)
     with pytest.raises(ValueError, match="mutually exclusive"):
-        resolve_source_disposition(keep=True, rename_to="x", drop=False)
+        resolve_source_disposition(keep=True, rename_to="x", replace=False, drop=False)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        resolve_source_disposition(keep=False, rename_to=None, replace=True, drop=True)
 
 
 # ---------------------------------------------------------------------------
@@ -665,8 +708,48 @@ def test_cli_review_from_plan_apply_all_keep_source(tmp_path):
     assert "sales_wide" in names  # default disposition is keep
 
 
+def test_cli_review_from_plan_replace_source(tmp_path):
+    """End-to-end ``--replace-source``: source dropped, long form renamed
+    to source's name. (Previously this was the ``--drop-source`` flag.)"""
+    db_path = tmp_path / "wide.duckdb"
+    _build_single_pivot_db(db_path)
+    project_dir = _project_with_db(tmp_path, db_path)
+    plan_path = _write_plan(tmp_path, _single_pivot_plan_dict())
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tidy",
+            "review",
+            "--project-dir",
+            project_dir,
+            "--from",
+            str(plan_path),
+            "--apply-all",
+            "--as",
+            "table",
+            "--replace-source",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    conn = duckdb.connect(str(db_path))
+    try:
+        names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
+        kind = conn.execute(
+            "SELECT table_type FROM information_schema.tables WHERE table_name = 'sales_wide'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert "sales_wide" in names  # the long form took the source's name
+    assert "sales_long" not in names
+    # And the surviving "sales_wide" really is the new long-form table.
+    assert kind is not None and kind[0] == "BASE TABLE"
+
+
 def test_cli_review_from_plan_drop_source(tmp_path):
-    """End-to-end --drop-source: source dropped, long form renamed to source's name."""
+    """``--drop-source`` after the breaking change: source goes away, long
+    form keeps its target name. Downstream queries against the source name
+    fail."""
     db_path = tmp_path / "wide.duckdb"
     _build_single_pivot_db(db_path)
     project_dir = _project_with_db(tmp_path, db_path)
@@ -691,15 +774,10 @@ def test_cli_review_from_plan_drop_source(tmp_path):
     conn = duckdb.connect(str(db_path))
     try:
         names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
-        kind = conn.execute(
-            "SELECT table_type FROM information_schema.tables WHERE table_name = 'sales_wide'"
-        ).fetchone()
     finally:
         conn.close()
-    assert "sales_wide" in names  # the long form took the source's name
-    assert "sales_long" not in names
-    # And the surviving "sales_wide" really is the new long-form table.
-    assert kind is not None and kind[0] == "BASE TABLE"
+    assert "sales_wide" not in names
+    assert "sales_long" in names  # long form kept its target name
 
 
 def test_cli_review_from_plan_rename_source(tmp_path):
@@ -1309,6 +1387,24 @@ async def test_propose_reshapes_user_message_includes_samples():
     assert "coal_mwh" in content
 
 
+def test_system_prompt_pins_value_column_to_value():
+    """The system prompt must steer the LLM toward ``value`` as the value
+    column name. Without this rule the model picks domain-specific names
+    like ``load_mwh`` per table, which makes downstream queries
+    inconsistent across reshapes."""
+    from datasight.tidy_llm import PROPOSE_RESHAPES_TOOL, SYSTEM_PROMPT
+
+    # Prompt-level rule.
+    assert "value column" in SYSTEM_PROMPT.lower()
+    assert "always use `value`" in SYSTEM_PROMPT.lower()
+    # Tool-schema rule (belt-and-braces — model weighs both).
+    value_desc = PROPOSE_RESHAPES_TOOL["input_schema"]["properties"]["proposals"]["items"][
+        "properties"
+    ]["value_column"]["description"]
+    assert "default to 'value'" in value_desc.lower()
+    assert "do not bake units" in value_desc.lower()
+
+
 # ---------------------------------------------------------------------------
 # CLI review with a fake LLMClient injected via monkeypatch
 # ---------------------------------------------------------------------------
@@ -1432,8 +1528,8 @@ async def test_propose_reshapes_live_llm_proposes_fuel_pivot():
 # ---------------------------------------------------------------------------
 
 
-def test_apply_proposal_drop_source_when_source_is_view(tmp_path):
-    """`--drop-source` must succeed when the source is a CSV-backed view.
+def test_apply_proposal_replace_source_when_source_is_view(tmp_path):
+    """``replace`` must succeed when the source is a CSV-backed view.
 
     Reproduces the user-reported failure: a view (typical when a project is
     set up by registering CSV files) cannot be dropped with `DROP TABLE`.
@@ -1449,7 +1545,7 @@ def test_apply_proposal_drop_source_when_source_is_view(tmp_path):
             conn,
             plan.proposals[0],
             mode="table",
-            source_disposition=SourceDisposition(mode="drop"),
+            source_disposition=SourceDisposition(mode="replace"),
             dry_run=False,
         )
         names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
@@ -1529,8 +1625,8 @@ def test_update_schema_yaml_for_apply_keep_appends_target(tmp_path):
     assert sales.get("columns") == ["region", "sales_2020"]
 
 
-def test_update_schema_yaml_for_apply_drop_clears_filter(tmp_path):
-    """`drop` disposition: entry name kept (long form took it over);
+def test_update_schema_yaml_for_apply_replace_clears_filter(tmp_path):
+    """``replace`` disposition: entry name kept (long form took it over);
     column / excluded_columns filters cleared because the shape changed."""
     (tmp_path / "schema.yaml").write_text(
         "tables:\n"
@@ -1543,7 +1639,7 @@ def test_update_schema_yaml_for_apply_drop_clears_filter(tmp_path):
         str(tmp_path),
         source_table="sales_wide",
         target_table="sales_long",
-        disposition_mode="drop",
+        disposition_mode="replace",
     )
     assert rewrote is True
     data = _read_schema_yaml(tmp_path)
@@ -1552,6 +1648,26 @@ def test_update_schema_yaml_for_apply_drop_clears_filter(tmp_path):
     sales = next(t for t in data["tables"] if t["name"] == "sales_wide")
     assert "columns" not in sales
     assert "excluded_columns" not in sales
+
+
+def test_update_schema_yaml_for_apply_drop_removes_source(tmp_path):
+    """``drop`` disposition: source entry removed, long form appended at
+    its target name. Reflects that downstream references to the source
+    name will break."""
+    (tmp_path / "schema.yaml").write_text(
+        "tables:\n  - name: sales_wide\n  - name: customers\n",
+        encoding="utf-8",
+    )
+    rewrote = update_schema_yaml_for_apply(
+        str(tmp_path),
+        source_table="sales_wide",
+        target_table="sales_long",
+        disposition_mode="drop",
+    )
+    assert rewrote is True
+    data = _read_schema_yaml(tmp_path)
+    names = [t["name"] for t in data["tables"]]
+    assert names == ["customers", "sales_long"]
 
 
 def test_update_schema_yaml_for_apply_rename_renames_and_appends(tmp_path):
@@ -1589,6 +1705,23 @@ def test_update_schema_yaml_for_apply_no_file_is_noop(tmp_path):
     assert not (tmp_path / "schema.yaml").exists()
 
 
+def test_update_schema_yaml_for_apply_creates_file_when_opt_in(tmp_path):
+    """``create_if_absent=True`` materializes a fresh schema.yaml seeded
+    with both the source and the new long-form table — used by the web
+    Apply button so an explicit user action persists across restarts."""
+    rewrote = update_schema_yaml_for_apply(
+        str(tmp_path),
+        source_table="sales_wide",
+        target_table="sales_long",
+        disposition_mode="keep",
+        create_if_absent=True,
+    )
+    assert rewrote is True
+    data = _read_schema_yaml(tmp_path)
+    names = [t["name"] for t in data["tables"]]
+    assert names == ["sales_wide", "sales_long"]
+
+
 def test_update_schema_yaml_for_apply_keep_skips_duplicate_target(tmp_path):
     """If the target is already listed, don't add it twice."""
     (tmp_path / "schema.yaml").write_text(
@@ -1606,8 +1739,8 @@ def test_update_schema_yaml_for_apply_keep_skips_duplicate_target(tmp_path):
     assert names == ["sales_wide", "sales_long"]
 
 
-def test_cli_review_drop_source_updates_schema_yaml(tmp_path):
-    """End-to-end: tidy review --drop-source rewrites schema.yaml so the
+def test_cli_review_replace_source_updates_schema_yaml(tmp_path):
+    """End-to-end: tidy review --replace-source rewrites schema.yaml so the
     long form (now under the source's old name) stays visible."""
     db_path = tmp_path / "wide.duckdb"
     _build_single_pivot_db(db_path)
@@ -1630,7 +1763,7 @@ def test_cli_review_drop_source_updates_schema_yaml(tmp_path):
             "--apply-all",
             "--as",
             "table",
-            "--drop-source",
+            "--replace-source",
         ],
     )
     assert result.exit_code == 0, result.output
@@ -1672,8 +1805,8 @@ def test_cli_review_keep_source_appends_target_to_schema_yaml(tmp_path):
     assert names == ["sales_wide", "sales_long"]
 
 
-def test_apply_proposal_rejects_view_mode_with_drop_source(tmp_path):
-    """``--as view`` + ``--drop-source`` is unsafe: dropping the source and
+def test_apply_proposal_rejects_view_mode_with_replace_source(tmp_path):
+    """``--as view`` + ``replace`` is unsafe: dropping the source and
     renaming the view into its slot leaves the view recursively
     self-referencing (DuckDB raises "infinite recursion detected" on the
     next bind). The apply path must reject the combo before any DDL runs.
@@ -1683,7 +1816,30 @@ def test_apply_proposal_rejects_view_mode_with_drop_source(tmp_path):
     plan = load_plan(_write_plan(tmp_path, _single_pivot_plan_dict()))
     conn = duckdb.connect(str(db_path))
     try:
-        with pytest.raises(ValueError, match="--drop-source requires --as table"):
+        with pytest.raises(ValueError, match="'replace' requires --as table"):
+            apply_proposal(
+                conn,
+                plan.proposals[0],
+                mode="view",
+                source_disposition=SourceDisposition(mode="replace"),
+                dry_run=False,
+            )
+        names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
+    finally:
+        conn.close()
+    # Database is untouched: the wide source survives, no view leaked through.
+    assert names == {"sales_wide"}
+
+
+def test_apply_proposal_rejects_view_mode_with_drop_source(tmp_path):
+    """``--as view`` + bare ``drop`` is unsafe: the view's body references
+    the source by name, so dropping the source leaves the view dangling."""
+    db_path = tmp_path / "wide.duckdb"
+    _build_single_pivot_db(db_path)
+    plan = load_plan(_write_plan(tmp_path, _single_pivot_plan_dict()))
+    conn = duckdb.connect(str(db_path))
+    try:
+        with pytest.raises(ValueError, match="'drop' requires --as table"):
             apply_proposal(
                 conn,
                 plan.proposals[0],
@@ -1694,7 +1850,6 @@ def test_apply_proposal_rejects_view_mode_with_drop_source(tmp_path):
         names = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
     finally:
         conn.close()
-    # Database is untouched: the wide source survives, no view leaked through.
     assert names == {"sales_wide"}
 
 
@@ -1706,7 +1861,7 @@ def test_apply_proposal_rejects_view_mode_with_rename_source(tmp_path):
     plan = load_plan(_write_plan(tmp_path, _single_pivot_plan_dict()))
     conn = duckdb.connect(str(db_path))
     try:
-        with pytest.raises(ValueError, match="--rename-source requires --as table"):
+        with pytest.raises(ValueError, match="'rename' requires --as table"):
             apply_proposal(
                 conn,
                 plan.proposals[0],
@@ -1730,9 +1885,10 @@ def _normalize_cli_output(output: str) -> str:
     return re.sub(r"\s+", " ", plain)
 
 
-def test_cli_review_view_mode_drop_source_is_a_usage_error(tmp_path):
-    """``datasight tidy review --drop-source`` (default ``--as view``) must
-    fail fast with a UsageError, not silently produce a recursive view."""
+def test_cli_review_view_mode_replace_source_is_a_usage_error(tmp_path):
+    """``datasight tidy review --replace-source`` (default ``--as view``)
+    must fail fast with a UsageError, not silently produce a recursive
+    view."""
     db_path = tmp_path / "wide.duckdb"
     _build_single_pivot_db(db_path)
     project_dir = _project_with_db(tmp_path, db_path)
@@ -1748,12 +1904,12 @@ def test_cli_review_view_mode_drop_source_is_a_usage_error(tmp_path):
             "--from",
             str(plan_path),
             "--apply-all",
-            # No --as flag → defaults to view, which is incompatible with drop.
-            "--drop-source",
+            # No --as flag → defaults to view, which is incompatible with replace.
+            "--replace-source",
         ],
     )
     assert result.exit_code != 0
-    assert "--drop-source requires '--as table'" in _normalize_cli_output(result.output)
+    assert "--replace-source requires '--as table'" in _normalize_cli_output(result.output)
     # No DDL ran.
     conn = duckdb.connect(str(db_path))
     try:
@@ -1761,6 +1917,31 @@ def test_cli_review_view_mode_drop_source_is_a_usage_error(tmp_path):
     finally:
         conn.close()
     assert names == {"sales_wide"}
+
+
+def test_cli_review_view_mode_drop_source_is_a_usage_error(tmp_path):
+    """``--drop-source`` (post-rename) on view mode also rejects: a view
+    referencing the source can't survive the source going away."""
+    db_path = tmp_path / "wide.duckdb"
+    _build_single_pivot_db(db_path)
+    project_dir = _project_with_db(tmp_path, db_path)
+    plan_path = _write_plan(tmp_path, _single_pivot_plan_dict())
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tidy",
+            "review",
+            "--project-dir",
+            project_dir,
+            "--from",
+            str(plan_path),
+            "--apply-all",
+            "--drop-source",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--drop-source requires '--as table'" in _normalize_cli_output(result.output)
 
 
 def test_cli_review_view_mode_rename_source_is_a_usage_error(tmp_path):
@@ -1787,10 +1968,10 @@ def test_cli_review_view_mode_rename_source_is_a_usage_error(tmp_path):
     assert "--rename-source requires '--as table'" in _normalize_cli_output(result.output)
 
 
-def test_cli_review_drop_source_view_end_to_end(tmp_path):
+def test_cli_review_replace_source_view_end_to_end(tmp_path):
     """The original user-reported flow: source is a CSV-backed view,
-    --drop-source must succeed AND schema.yaml must keep the entry under
-    the original name."""
+    ``--replace-source`` must succeed AND schema.yaml must keep the entry
+    under the original name. (Previously this flag was ``--drop-source``.)"""
     db_path = tmp_path / "wide.duckdb"
     csv_path = tmp_path / "sales.csv"
     _build_single_pivot_view_db(db_path, csv_path)
@@ -1812,7 +1993,7 @@ def test_cli_review_drop_source_view_end_to_end(tmp_path):
             "--apply-all",
             "--as",
             "table",
-            "--drop-source",
+            "--replace-source",
         ],
     )
     assert result.exit_code == 0, result.output

--- a/tests/test_web_tidy.py
+++ b/tests/test_web_tidy.py
@@ -156,10 +156,14 @@ def test_propose_streams_llm_proposals_only(loaded_state, monkeypatch):
         return ProposeResult(suggestions=[], raw_proposals=[], parse_warnings=[])
 
     monkeypatch.setattr(web_app, "propose_reshapes", fake_propose)
-    loaded_state.llm_client = cast(Any, object())
-    loaded_state.model = "stub"
 
+    # Set the LLM stub *inside* the TestClient context: FastAPI startup
+    # runs ``init_llm_client(state)`` which clears llm_client to None
+    # when the env has no API key (the case in CI). Setting after the
+    # context enters means our stub survives that re-init.
     with TestClient(web_app.app) as client:
+        loaded_state.llm_client = cast(Any, object())
+        loaded_state.model = "stub"
         response = client.post("/api/tidy/propose", json={"table": "sales"})
 
     assert response.status_code == 200
@@ -197,10 +201,13 @@ def test_propose_emits_llm_error_event_on_provider_failure(loaded_state, monkeyp
         raise RuntimeError("provider-down")
 
     monkeypatch.setattr(web_app, "propose_reshapes", boom)
-    loaded_state.llm_client = cast(Any, object())
-    loaded_state.model = "stub"
 
+    # See note in test_propose_streams_llm_proposals_only — set the LLM
+    # stub inside the TestClient context so it survives FastAPI startup's
+    # init_llm_client re-initialization.
     with TestClient(web_app.app) as client:
+        loaded_state.llm_client = cast(Any, object())
+        loaded_state.model = "stub"
         response = client.post("/api/tidy/propose", json={"table": "sales"})
 
     events = _parse_sse_events(response.text)

--- a/tests/test_web_tidy.py
+++ b/tests/test_web_tidy.py
@@ -1,0 +1,474 @@
+"""Tests for the per-table Tidy review endpoints.
+
+Covers POST /api/tidy/{propose,preview,apply}. The apply path opens a
+writable DuckDB connection, runs DDL, and re-introspects schema, so the
+fixture builds an isolated per-test DuckDB with a wide table the
+deterministic detector recognizes (``sales_2020`` … ``sales_2023``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import duckdb
+import pytest
+from fastapi.testclient import TestClient
+
+import datasight.web.app as web_app
+from datasight.runner import DuckDBRunner
+from datasight.tidy import _detect_period_groups
+from datasight.tidy_llm import ProposeResult
+
+from tests._env_helpers import scrub_datasight_env
+
+
+@pytest.fixture(autouse=True)
+def _scrub_datasight_env():
+    scrub_datasight_env()
+    web_app._state.clear_project()
+
+
+@pytest.fixture()
+def wide_db(tmp_path: Path) -> str:
+    """Build a per-test DuckDB with a recognizably-untidy wide table."""
+    db_path = tmp_path / "wide.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE sales (
+            region VARCHAR,
+            sales_2020 INTEGER,
+            sales_2021 INTEGER,
+            sales_2022 INTEGER,
+            sales_2023 INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO sales VALUES (?, ?, ?, ?, ?)",
+        [
+            ("north", 100, 110, 120, 130),
+            ("south", 200, 210, 220, 230),
+        ],
+    )
+    conn.close()
+    return str(db_path)
+
+
+@pytest.fixture()
+def loaded_state(wide_db: str):
+    """Point the global app state at the wide DB and restore on teardown."""
+    state = web_app._state
+    runner = DuckDBRunner(wide_db)
+    state.sql_runner = cast(Any, runner)
+    state.project_loaded = True
+    state.project_dir = str(Path(wide_db).parent)
+    state.sql_dialect = "duckdb"
+    state.schema_info = [
+        {
+            "name": "sales",
+            "row_count": 2,
+            "columns": [
+                {"name": "region", "dtype": "VARCHAR", "nullable": True},
+                {"name": "sales_2020", "dtype": "INTEGER", "nullable": True},
+                {"name": "sales_2021", "dtype": "INTEGER", "nullable": True},
+                {"name": "sales_2022", "dtype": "INTEGER", "nullable": True},
+                {"name": "sales_2023", "dtype": "INTEGER", "nullable": True},
+            ],
+        }
+    ]
+    state.schema_map = {"sales": {str(c["name"]) for c in state.schema_info[0]["columns"]}}
+    yield state
+    state.clear_project()
+
+
+def _parse_sse_events(text: str) -> list[tuple[str, dict[str, Any]]]:
+    """Parse an SSE response body into ``(event, data)`` pairs."""
+    events: list[tuple[str, dict[str, Any]]] = []
+    event = ""
+    data_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("event: "):
+            event = line[len("event: ") :]
+        elif line.startswith("data: "):
+            data_lines.append(line[len("data: ") :])
+        elif line == "":
+            if event:
+                payload = "\n".join(data_lines) or "{}"
+                events.append((event, json.loads(payload)))
+            event = ""
+            data_lines = []
+    return events
+
+
+def _suggestion_to_proposal_dict(s: Any) -> dict[str, Any]:
+    """Strip the wire-only fields (preview_sql, reshape_sql_*) from a payload."""
+    d = s.to_dict()
+    d.pop("reshape_sql", None)
+    return d
+
+
+def test_detect_returns_deterministic_proposals(loaded_state):
+    """GET /api/tidy/detect runs the regex detector synchronously, no LLM."""
+    with TestClient(web_app.app) as client:
+        response = client.get("/api/tidy/detect", params={"table": "sales"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"] is None
+    assert len(body["proposals"]) >= 1
+    first = body["proposals"][0]
+    assert first["table"] == "sales"
+    assert first["target_object_name"] == "sales_long"
+    mapped = {m["column"] for m in first["column_mappings"]}
+    assert mapped == {"sales_2020", "sales_2021", "sales_2022", "sales_2023"}
+    # Wire-only convenience fields the drawer relies on.
+    assert first["preview_sql"]
+    assert first["reshape_sql_view"]
+    assert first["reshape_sql_table"]
+
+
+def test_detect_rejects_non_duckdb(loaded_state):
+    loaded_state.sql_dialect = "sqlite"
+    with TestClient(web_app.app) as client:
+        response = client.get("/api/tidy/detect", params={"table": "sales"})
+    body = response.json()
+    assert body["proposals"] == []
+    assert body["error"] == "Tidy review requires DuckDB"
+
+
+def test_detect_rejects_unknown_table(loaded_state):
+    with TestClient(web_app.app) as client:
+        response = client.get("/api/tidy/detect", params={"table": "ghost"})
+    body = response.json()
+    assert body["proposals"] == []
+    assert "not found" in body["error"]
+
+
+def test_propose_streams_llm_proposals_only(loaded_state, monkeypatch):
+    """POST /api/tidy/propose no longer emits the deterministic event —
+    that's the detect endpoint's job. It runs the LLM advisor and emits
+    ``llm_started`` → ``llm_proposals`` → ``done`` (or ``llm_error``)."""
+
+    async def fake_propose(*args, **kwargs):  # noqa: ARG001
+        return ProposeResult(suggestions=[], raw_proposals=[], parse_warnings=[])
+
+    monkeypatch.setattr(web_app, "propose_reshapes", fake_propose)
+    loaded_state.llm_client = cast(Any, object())
+    loaded_state.model = "stub"
+
+    with TestClient(web_app.app) as client:
+        response = client.post("/api/tidy/propose", json={"table": "sales"})
+
+    assert response.status_code == 200
+    events = _parse_sse_events(response.text)
+    event_names = [e for e, _ in events]
+    assert "deterministic" not in event_names, (
+        "deterministic event should be gone — fetch via /api/tidy/detect"
+    )
+    assert "llm_started" in event_names
+    assert "llm_proposals" in event_names
+    assert "done" in event_names
+
+
+def test_propose_rejects_non_duckdb(loaded_state):
+    loaded_state.sql_dialect = "sqlite"
+    with TestClient(web_app.app) as client:
+        response = client.post("/api/tidy/propose", json={"table": "sales"})
+    assert response.status_code == 200
+    events = _parse_sse_events(response.text)
+    assert events == [("error", {"error": "Tidy review requires DuckDB"})]
+
+
+def test_propose_rejects_unknown_table(loaded_state):
+    with TestClient(web_app.app) as client:
+        response = client.post("/api/tidy/propose", json={"table": "unknown"})
+    events = _parse_sse_events(response.text)
+    assert events[0][0] == "error"
+    assert "not found" in events[0][1]["error"]
+
+
+def test_propose_emits_llm_error_event_on_provider_failure(loaded_state, monkeypatch):
+    """If the LLM call raises, the stream emits llm_error then done."""
+
+    async def boom(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("provider-down")
+
+    monkeypatch.setattr(web_app, "propose_reshapes", boom)
+    loaded_state.llm_client = cast(Any, object())
+    loaded_state.model = "stub"
+
+    with TestClient(web_app.app) as client:
+        response = client.post("/api/tidy/propose", json={"table": "sales"})
+
+    events = _parse_sse_events(response.text)
+    names = [e for e, _ in events]
+    assert "llm_error" in names
+    assert "done" in names
+    assert "provider-down" in next(d for e, d in events if e == "llm_error")["error"]
+
+
+def test_preview_returns_long_form_sample(loaded_state):
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post("/api/tidy/preview", json={"proposal": proposal})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"] is None
+    # 2 source rows × 4 mapped columns = 8 long-form rows; well under LIMIT 50.
+    assert body["row_count"] == 8
+    assert body["html"]
+    # The long form should expose the `year` dimension column the
+    # detector inferred from the YYYY suffixes.
+    assert "year" in body["html"]
+
+
+def test_preview_rejects_invalid_proposal(loaded_state):
+    with TestClient(web_app.app) as client:
+        response = client.post("/api/tidy/preview", json={"proposal": {"table": "sales"}})
+    body = response.json()
+    assert body["error"]
+    assert body["row_count"] == 0
+
+
+def test_apply_creates_long_form_view(loaded_state):
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "view",
+                "disposition": {"mode": "keep"},
+            },
+        )
+
+    body = response.json()
+    assert body["success"], body
+    assert body["result"]["object_type"] == "view"
+    assert body["result"]["row_count_target"] == 8
+    # Schema state should now include the long form alongside the source.
+    table_names = {t["name"] for t in body["schema_info"]}
+    assert {"sales", "sales_long"} <= table_names
+
+
+def test_apply_appends_long_form_to_schema_yaml(loaded_state):
+    """When schema.yaml exists, apply should register the long-form table."""
+    project_dir = Path(loaded_state.project_dir)
+    yaml_path = project_dir / "schema.yaml"
+    yaml_path.write_text("tables:\n  - name: sales\n", encoding="utf-8")
+
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "view",
+                "disposition": {"mode": "keep"},
+            },
+        )
+
+    assert response.json()["success"]
+    rewritten = yaml_path.read_text(encoding="utf-8")
+    assert "sales_long" in rewritten, rewritten
+
+
+def test_apply_creates_schema_yaml_when_absent(loaded_state):
+    """Applying should persist the long-form table even on projects that
+    didn't keep an allowlist before — the explicit Apply action means the
+    user wants the reshape registered."""
+    project_dir = Path(loaded_state.project_dir)
+    yaml_path = project_dir / "schema.yaml"
+    assert not yaml_path.exists()
+
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "view",
+                "disposition": {"mode": "keep"},
+            },
+        )
+
+    assert response.json()["success"]
+    assert yaml_path.exists(), "schema.yaml should have been created"
+    rewritten = yaml_path.read_text(encoding="utf-8")
+    assert "sales_long" in rewritten, rewritten
+
+
+def test_apply_respects_include_nulls_toggle(tmp_path: Path):
+    """End-to-end: a proposal with ``include_nulls=False`` produces a denser
+    long form than the same proposal with the default ``True``. Pins the
+    web endpoint round-trip of the toggle."""
+    db_path = tmp_path / "sparse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE sales ("
+        "region VARCHAR, sales_2020 INTEGER, sales_2021 INTEGER, sales_2022 INTEGER)"
+    )
+    conn.execute("INSERT INTO sales VALUES ('north', 100, 110, 120), ('south', 200, NULL, 220)")
+    conn.close()
+
+    state = web_app._state
+    runner = DuckDBRunner(str(db_path))
+    state.sql_runner = cast(Any, runner)
+    state.project_loaded = True
+    state.project_dir = str(tmp_path)
+    state.sql_dialect = "duckdb"
+    state.schema_info = [
+        {
+            "name": "sales",
+            "row_count": 2,
+            "columns": [
+                {"name": "region", "dtype": "VARCHAR", "nullable": True},
+                {"name": "sales_2020", "dtype": "INTEGER", "nullable": True},
+                {"name": "sales_2021", "dtype": "INTEGER", "nullable": True},
+                {"name": "sales_2022", "dtype": "INTEGER", "nullable": True},
+            ],
+        }
+    ]
+    state.schema_map = {"sales": {str(c["name"]) for c in state.schema_info[0]["columns"]}}
+
+    try:
+        suggestion = _detect_period_groups(state.schema_info[0])[0]
+        proposal = _suggestion_to_proposal_dict(suggestion)
+        proposal["include_nulls"] = False  # explicit drop
+
+        with TestClient(web_app.app) as client:
+            response = client.post(
+                "/api/tidy/apply",
+                json={
+                    "proposal": proposal,
+                    "mode": "table",
+                    "disposition": {"mode": "keep"},
+                },
+            )
+
+        body = response.json()
+        assert body["success"], body
+        # 2 rows × 3 cols = 6 expected; minus the 1 NULL = 5.
+        assert body["result"]["row_count_target"] == 5
+    finally:
+        state.clear_project()
+
+
+def test_apply_rejects_view_with_rename_disposition(loaded_state):
+    """Mirrors the CLI safety rule: view mode + rename leaves a dangling view."""
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "view",
+                "disposition": {"mode": "rename", "new_name": "sales_raw"},
+            },
+        )
+
+    body = response.json()
+    assert body["success"] is False
+    assert "table" in body["error"]
+
+
+def test_apply_rejects_when_target_collides(loaded_state):
+    """Schema cross-check should catch a target name that already exists."""
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+    proposal["target_object_name"] = "sales"  # collides with the source
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "view",
+                "disposition": {"mode": "keep"},
+            },
+        )
+
+    body = response.json()
+    assert body["success"] is False
+    assert "schema cross-check" in body["error"]
+
+
+def test_apply_rejects_invalid_mode(loaded_state):
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={"proposal": proposal, "mode": "TABEL", "disposition": {"mode": "keep"}},
+        )
+    body = response.json()
+    assert body["success"] is False
+    assert "mode must be" in body["error"]
+
+
+def test_apply_creates_table_with_replace_disposition(loaded_state):
+    """``replace`` disposition swaps the long form into the source's slot:
+    the long form takes the source's old name, the user-chosen target
+    name is just a transient intermediate."""
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "table",
+                "disposition": {"mode": "replace"},
+            },
+        )
+
+    body = response.json()
+    assert body["success"], body
+    # After replace, the long form takes the source's old name.
+    assert body["result"]["final_target_name"] == "sales"
+    table_names = {t["name"] for t in body["schema_info"]}
+    assert "sales" in table_names
+    assert "sales_long" not in table_names
+    # The new shape is long: it should have a `year` column.
+    sales_cols = next(t["columns"] for t in body["schema_info"] if t["name"] == "sales")
+    assert any(c["name"] == "year" for c in sales_cols)
+
+
+def test_apply_creates_table_with_bare_drop_disposition(loaded_state):
+    """``drop`` disposition (post-rename) is the bare drop: source goes
+    away but the long form keeps its target name. Downstream code that
+    referenced the source by name will break — that's the user's call."""
+    suggestion = _detect_period_groups(loaded_state.schema_info[0])[0]
+    proposal = _suggestion_to_proposal_dict(suggestion)
+
+    with TestClient(web_app.app) as client:
+        response = client.post(
+            "/api/tidy/apply",
+            json={
+                "proposal": proposal,
+                "mode": "table",
+                "disposition": {"mode": "drop"},
+            },
+        )
+
+    body = response.json()
+    assert body["success"], body
+    assert body["result"]["final_target_name"] == "sales_long"
+    table_names = {t["name"] for t in body["schema_info"]}
+    assert "sales" not in table_names
+    assert "sales_long" in table_names


### PR DESCRIPTION
## Summary

- New per-table **Tidy review drawer** in the web UI: chip in the schema sidebar opens a right-side panel with deterministic detector results, an opt-in **Run agent** button for the LLM advisor, an SVG melt diagram per proposal, inline editing, live SQL preview, row preview, and one batched **Apply** button. DuckDB-only.
- **Source disposition reworked** into four modes: `keep` / `rename` / `replace` / `drop`. `replace` carries the old `drop` semantics (drop source, long form takes its name); `drop` is now the bare drop. **Breaking CLI change**: `--drop-source` flag changed meaning — scripts using it for the old behavior should switch to `--replace-source`.
- **`include_nulls` toggle** per proposal (default `false`). Most NULLs in wide tables are structural placeholders, so dropping by default produces the denser long form analysts actually want; toggle on for sensor / survey data where NULL is a meaningful gap. Single-pivot + table + drop-nulls now routes through DuckDB `UNPIVOT` for terser DDL; every other combination uses UNION ALL with `WHERE col IS NOT NULL` per branch when needed, so view/table mode parity holds.
- **Dimension dtypes**: the deterministic detector picks `INTEGER` for numeric period kinds (year, hour, day, month_num) so `WHERE year >= 2022` works without casts. LLM prompt also steers proposals toward generic `value` as the value-column name for predictability across reshapes.
- `schema.yaml` allowlist gains a `create_if_absent` flag the web Apply uses, so projects without an existing allowlist still get the long form persisted across restarts.

## Test plan

- [x] `pytest -q -m "not integration"` — 1481 passed
  - 17 new tests in `tests/test_web_tidy.py` covering detect / propose / preview / apply / render-sql, schema.yaml round-trip, all four dispositions, and the `include_nulls` toggle
  - existing tidy + tidy_review tests updated for the disposition rename and flipped null default
- [x] `cd frontend && npm test -- --run tidy` — 12 passed (store lifecycle: start, runAgent, skip, edit, applyAll, error paths)
- [x] `cd frontend && ./node_modules/.bin/playwright test e2e/tidy.spec.ts` — passed (full chip → drawer → Run agent flow with mocked endpoints)
- [x] `cd frontend && npm run check` — 0 errors, 0 warnings
- [x] `prek run --all-files` — ruff / ruff-format / ty / docs CLI reference drift all pass
- [x] `zensical build` — no broken links
- [ ] Manual smoke: open `datasight run` against a project with a wide CSV, verify the Tidy chip appears, drawer opens with the deterministic proposal, Run agent works, Show SQL reflects view/table toggle and edits, Apply produces the expected long form and refreshes the schema sidebar

## Notes for reviewers

- The CLI breaking change (`--drop-source` semantics) is documented in a `!!! warning` callout in the how-to. Suggest naming this prominently in the release notes.
- `include_nulls` default flip is intentional and energy-domain motivated (structural NAs dominate in wide pivots like `<fuel> × <end_use>`); toggle is exposed per card so users with sensor / survey data can opt in.
- The melt diagram is a hand-rolled SVG with `<title>` tooltips; column names that exceed tile width are visible on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)