### PR TITLE
Enable B904, T201, RUF012 ruff rules and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,12 +111,15 @@ target-version = "py311"
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 select = [
+    "B904",   # raise ... from err inside except
     "C901",   # McCabe complexity
     "E4",     # Subset of pycodestyle (E)
     "E7",
     "E9",
     "EM",     # string formatting in an exception message
     "F",      # Pyflakes
+    "RUF012", # mutable class default
+    "T201",   # print statements
     "W",      # pycodestyle warnings
 ]
 ignore = []

--- a/src/datasight/runner.py
+++ b/src/datasight/runner.py
@@ -144,7 +144,7 @@ class DuckDBRunner:
                 f"Query timed out after {self._query_timeout:.0f}s. "
                 "Try a simpler query or add filters to reduce the result set."
             )
-            raise QueryTimeoutError(msg)
+            raise QueryTimeoutError(msg) from None
 
 
 class EphemeralDuckDBRunner:
@@ -228,7 +228,7 @@ class EphemeralDuckDBRunner:
                 f"Query timed out after {self._query_timeout:.0f}s. "
                 "Try a simpler query or add filters to reduce the result set."
             )
-            raise QueryTimeoutError(msg)
+            raise QueryTimeoutError(msg) from None
 
 
 class SQLiteRunner:
@@ -305,7 +305,7 @@ class SQLiteRunner:
                 f"Query timed out after {self._query_timeout:.0f}s. "
                 "Try a simpler query or add filters to reduce the result set."
             )
-            raise QueryTimeoutError(msg)
+            raise QueryTimeoutError(msg) from None
 
 
 class PostgresRunner:
@@ -409,7 +409,7 @@ class PostgresRunner:
                 f"Query timed out after {self._query_timeout:.0f}s. "
                 "Try a simpler query or add filters to reduce the result set."
             )
-            raise QueryTimeoutError(msg)
+            raise QueryTimeoutError(msg) from None
 
 
 class FlightSqlRunner:
@@ -525,7 +525,7 @@ class FlightSqlRunner:
                 f"Query timed out after {self.timeout:.0f}s. "
                 "Try a simpler query or add filters to reduce the result set."
             )
-            raise QueryTimeoutError(msg)
+            raise QueryTimeoutError(msg) from None
 
 
 class SparkConnectRunner:
@@ -618,7 +618,7 @@ class SparkConnectRunner:
                 "(start-connect-server.sh on the cluster, then re-check the "
                 "URI in your .env)"
             )
-            raise ConnectionError(msg)
+            raise ConnectionError(msg) from None
         if status == "error":
             msg = f"Spark Connect server at {remote} rejected the handshake: {payload}"
             raise ConnectionError(msg)
@@ -994,7 +994,7 @@ class SparkConnectRunner:
                     f"Query timed out after {self._query_timeout:.0f}s. "
                     "Try a simpler query or add filters to reduce the result set."
                 )
-                raise QueryTimeoutError(msg)
+                raise QueryTimeoutError(msg) from None
         finally:
             # wait=False: if the worker thread is still blocked on a gRPC
             # call, do not block shutdown. The thread will exit after the

--- a/src/datasight/web/app.py
+++ b/src/datasight/web/app.py
@@ -1174,9 +1174,9 @@ async def _startup() -> None:
     else:
         logger.info(f"datasight ready (model={_state.model}, no project loaded)")
     if socket_path:
-        print(f"\n  Ready — listening on UNIX socket {socket_path}\n")
+        print(f"\n  Ready — listening on UNIX socket {socket_path}\n")  # noqa: T201
     else:
-        print(f"\n  Ready — open http://localhost:{port} in your browser\n")
+        print(f"\n  Ready — open http://localhost:{port} in your browser\n")  # noqa: T201
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 
 import pandas as pd
 import pytest
@@ -1700,7 +1701,7 @@ def test_ask_print_sql_keeps_json_stdout_parseable(monkeypatch, project_dir):
 
     class FakeFrame:
         empty = False
-        columns = ["count"]
+        columns: ClassVar[list[str]] = ["count"]
 
         def __len__(self):
             return 1
@@ -1805,7 +1806,7 @@ def test_ask_sql_script_keeps_json_stdout_parseable(monkeypatch, project_dir, tm
 
     class FakeFrame:
         empty = False
-        columns = ["count"]
+        columns: ClassVar[list[str]] = ["count"]
 
         def __len__(self):
             return 1


### PR DESCRIPTION
Stacked on top of #66.

## Summary
- **B904** (7 sites in `runner.py`): timeouts and Spark Connect handshake failures now use `raise X from None` to suppress the irrelevant internal `TimeoutError` / `queue.Empty` traceback chain.
- **T201** (2 sites in `web/app.py`): user-facing startup banner `print()` calls are intentional UX (paired with logger.info for log capture); marked with `# noqa: T201`.
- **RUF012** (2 sites in `tests/test_cli_tools.py`): annotated test-fake `columns` class attribute as `ClassVar[list[str]]`.

## Considered but skipped
- **TRY004** (13 sites in `session_archive.py` and `tidy_review.py`): the parsers have an established convention of raising `ValueError` for all validation errors, with CLI handlers and tests depending on it. Not enabled.

## Test plan
- [x] `prek run --all-files` passes (ruff, ruff-format, ty, docs CLI drift)
- [x] `pytest -m "not integration"` passes (1481 tests)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)