### PR TITLE
Pass --model CLI override to create_llm_client log line

### DIFF
--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -130,7 +130,7 @@ async def run_ask_pipeline(
         api_key=settings.llm.api_key,
         base_url=settings.llm.base_url,
         timeout=settings.llm.timeout,
-        model=settings.llm.model,
+        model=resolved_model,
     )
     sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
 

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -309,7 +309,7 @@ def generate(  # noqa: C901
             api_key=settings.llm.api_key,
             base_url=settings.llm.base_url,
             timeout=settings.llm.timeout,
-            model=settings.llm.model,
+            model=resolved_model,
         )
 
         if sqlite_source_path is not None:

--- a/src/datasight/cli_commands/verify.py
+++ b/src/datasight/cli_commands/verify.py
@@ -97,7 +97,7 @@ def verify(project_dir, model, queries_path):  # noqa: C901
             api_key=settings.llm.api_key,
             base_url=settings.llm.base_url,
             timeout=settings.llm.timeout,
-            model=settings.llm.model,
+            model=resolved_model,
         )
         sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
 


### PR DESCRIPTION
## Summary
The `ask`, `generate`, and `verify` commands all accept a `--model` flag that `resolve_settings` returns as `resolved_model`. Each command then calls `create_llm_client` with `settings.llm.model` (the .env value) instead of `resolved_model`, so the **\"Using {provider} LLM backend (model=…)\"** log line in `llm.py:952` shows the .env model rather than the override the user actually requested.

This was **logging-only** — the actual API calls in `run_agent_loop` already use `resolved_model` correctly (cli.py:231, generate.py:411, verify.py:118/125) — but the misleading log line made it look like the override wasn't being applied.

## Files changed
- `src/datasight/cli.py:133` — `run_ask_pipeline`
- `src/datasight/cli_commands/generate.py:312`
- `src/datasight/cli_commands/verify.py:100`

## Test plan
- [x] `prek run --all-files` passes
- [x] `pytest -m \"not integration\"` passes (1481 tests)
- [ ] Manual verification: `datasight ask --model=X --file q.txt` shows `model=X` in the startup log

🤖 Generated with [Claude Code](https://claude.com/claude-code)