### PR TITLE
Close LLM client httpx pool before asyncio.run exits

### DIFF
--- a/src/datasight/cli.py
+++ b/src/datasight/cli.py
@@ -132,148 +132,156 @@ async def run_ask_pipeline(
         timeout=settings.llm.timeout,
         model=resolved_model,
     )
-    sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
+    # Close the SDK's httpx pool before the event loop shuts down.
+    # Without this, asyncio.run closes the loop, the GC later finalizes
+    # the httpx client, and its scheduled aclose() trips
+    # "RuntimeError: Event loop is closed" — noisy, especially in
+    # `datasight ask --files` where this runs once per question.
+    try:
+        sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
 
-    schema_config = load_schema_config(None, project_dir)
-    allowed_tables: set[str] | None = None
-    if schema_config is not None:
-        allowed_tables = {
-            e["name"] for e in schema_config.get("tables", []) if e.get("name")
-        } or None
-    tables = await introspect_schema(
-        sql_runner.run_sql,
-        runner=sql_runner,
-        allowed_tables=allowed_tables,
-    )
-    if schema_config is not None:
-        tables = filter_tables(tables, schema_config)
-    from datasight.identifiers import configure_runner_identifier_quoting
+        schema_config = load_schema_config(None, project_dir)
+        allowed_tables: set[str] | None = None
+        if schema_config is not None:
+            allowed_tables = {
+                e["name"] for e in schema_config.get("tables", []) if e.get("name")
+            } or None
+        tables = await introspect_schema(
+            sql_runner.run_sql,
+            runner=sql_runner,
+            allowed_tables=allowed_tables,
+        )
+        if schema_config is not None:
+            tables = filter_tables(tables, schema_config)
+        from datasight.identifiers import configure_runner_identifier_quoting
 
-    configure_runner_identifier_quoting(
-        sql_runner,
-        [
-            {
-                "name": t.name,
-                "columns": [{"name": c.name} for c in t.columns],
-            }
-            for t in tables
-        ],
-    )
-    user_desc = load_schema_description(None, project_dir)
-    user_desc = await resolve_schema_description_links(user_desc)
-    example_queries = load_example_queries(None, project_dir)
-    measure_overrides = load_measure_overrides(None, project_dir)
-    time_series_configs = load_time_series_config(None, project_dir)
-    measure_rules = build_measure_rule_map(measure_overrides)
-    schema_text = format_schema_context(tables, user_desc)
-    if example_queries:
-        schema_text += format_example_queries(example_queries)
-
-    measure_text = format_measure_prompt_context(
-        await build_measure_overview(
+        configure_runner_identifier_quoting(
+            sql_runner,
             [
                 {
                     "name": t.name,
-                    "row_count": t.row_count,
-                    "columns": [
-                        {"name": c.name, "dtype": c.dtype, "nullable": c.nullable}
-                        for c in t.columns
-                    ],
+                    "columns": [{"name": c.name} for c in t.columns],
                 }
                 for t in tables
             ],
-            sql_runner.run_sql,
-            measure_overrides,
         )
-    )
-    if measure_text:
-        schema_text += measure_text
+        user_desc = load_schema_description(None, project_dir)
+        user_desc = await resolve_schema_description_links(user_desc)
+        example_queries = load_example_queries(None, project_dir)
+        measure_overrides = load_measure_overrides(None, project_dir)
+        time_series_configs = load_time_series_config(None, project_dir)
+        measure_rules = build_measure_rule_map(measure_overrides)
+        schema_text = format_schema_context(tables, user_desc)
+        if example_queries:
+            schema_text += format_example_queries(example_queries)
 
-    ts_text = format_time_series_prompt_context(time_series_configs)
-    if ts_text:
-        schema_text += ts_text
+        measure_text = format_measure_prompt_context(
+            await build_measure_overview(
+                [
+                    {
+                        "name": t.name,
+                        "row_count": t.row_count,
+                        "columns": [
+                            {"name": c.name, "dtype": c.dtype, "nullable": c.nullable}
+                            for c in t.columns
+                        ],
+                    }
+                    for t in tables
+                ],
+                sql_runner.run_sql,
+                measure_overrides,
+            )
+        )
+        if measure_text:
+            schema_text += measure_text
 
-    schema_info = [
-        {
-            "name": t.name,
-            "columns": [{"name": c.name, "dtype": c.dtype} for c in t.columns],
-        }
-        for t in tables
-    ]
-    schema_map = build_schema_map(schema_info)
+        ts_text = format_time_series_prompt_context(time_series_configs)
+        if ts_text:
+            schema_text += ts_text
 
-    sys_prompt = build_system_prompt(
-        schema_text,
-        mode="web",
-        clarify_sql=False,
-        dialect=sql_dialect,
-        headless=True,
-    )
+        schema_info = [
+            {
+                "name": t.name,
+                "columns": [{"name": c.name, "dtype": c.dtype} for c in t.columns],
+            }
+            for t in tables
+        ]
+        schema_map = build_schema_map(schema_info)
 
-    log_path = os.environ.get(
-        "QUERY_LOG_PATH",
-        os.path.join(project_dir, ".datasight", "query_log.jsonl"),
-    )
-    query_logger = QueryLogger(path=log_path)
-    # Microseconds + a short random suffix prevent collisions when several
-    # `datasight ask` runs (e.g. a fast batch or test sweep) start within
-    # the same wall-clock second.
-    import secrets
+        sys_prompt = build_system_prompt(
+            schema_text,
+            mode="web",
+            clarify_sql=False,
+            dialect=sql_dialect,
+            headless=True,
+        )
 
-    session_id = (
-        f"cli-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%f')}-{secrets.token_hex(3)}"
-    )
-    turn_id = str(uuid.uuid4())
+        log_path = os.environ.get(
+            "QUERY_LOG_PATH",
+            os.path.join(project_dir, ".datasight", "query_log.jsonl"),
+        )
+        query_logger = QueryLogger(path=log_path)
+        # Microseconds + a short random suffix prevent collisions when several
+        # `datasight ask` runs (e.g. a fast batch or test sweep) start within
+        # the same wall-clock second.
+        import secrets
 
-    result = await run_agent_loop(
-        question=question,
-        llm_client=llm_client,
-        model=resolved_model,
-        system_prompt=sys_prompt,
-        run_sql=sql_runner.run_sql,
-        schema_map=schema_map,
-        dialect=sql_dialect,
-        measure_rules=measure_rules,
-        query_logger=query_logger,
-        session_id=session_id,
-        turn_id=turn_id,
-        max_cost_usd=settings.app.max_cost_usd_per_turn,
-        provider=settings.llm.provider,
-        max_tokens=settings.app.max_output_tokens,
-    )
+        session_id = (
+            f"cli-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%f')}-{secrets.token_hex(3)}"
+        )
+        turn_id = str(uuid.uuid4())
 
-    # Mirror the web app: emit a turn-level cost summary so `datasight log
-    # --cost` reflects CLI usage too.
-    log_query_cost(
-        resolved_model,
-        result.api_calls,
-        result.total_input_tokens,
-        result.total_output_tokens,
-        cache_creation_input_tokens=result.total_cache_creation_input_tokens,
-        cache_read_input_tokens=result.total_cache_read_input_tokens,
-        provider=settings.llm.provider,
-    )
-    cost_data = build_cost_data(
-        resolved_model,
-        result.api_calls,
-        result.total_input_tokens,
-        result.total_output_tokens,
-        cache_creation_input_tokens=result.total_cache_creation_input_tokens,
-        cache_read_input_tokens=result.total_cache_read_input_tokens,
-        provider=settings.llm.provider,
-    )
-    query_logger.log_cost(
-        session_id=session_id,
-        user_question=question,
-        api_calls=result.api_calls,
-        input_tokens=result.total_input_tokens,
-        output_tokens=result.total_output_tokens,
-        cache_creation_input_tokens=result.total_cache_creation_input_tokens,
-        cache_read_input_tokens=result.total_cache_read_input_tokens,
-        estimated_cost=cost_data.get("estimated_cost"),
-        turn_id=turn_id,
-    )
-    return result
+        result = await run_agent_loop(
+            question=question,
+            llm_client=llm_client,
+            model=resolved_model,
+            system_prompt=sys_prompt,
+            run_sql=sql_runner.run_sql,
+            schema_map=schema_map,
+            dialect=sql_dialect,
+            measure_rules=measure_rules,
+            query_logger=query_logger,
+            session_id=session_id,
+            turn_id=turn_id,
+            max_cost_usd=settings.app.max_cost_usd_per_turn,
+            provider=settings.llm.provider,
+            max_tokens=settings.app.max_output_tokens,
+        )
+
+        # Mirror the web app: emit a turn-level cost summary so `datasight log
+        # --cost` reflects CLI usage too.
+        log_query_cost(
+            resolved_model,
+            result.api_calls,
+            result.total_input_tokens,
+            result.total_output_tokens,
+            cache_creation_input_tokens=result.total_cache_creation_input_tokens,
+            cache_read_input_tokens=result.total_cache_read_input_tokens,
+            provider=settings.llm.provider,
+        )
+        cost_data = build_cost_data(
+            resolved_model,
+            result.api_calls,
+            result.total_input_tokens,
+            result.total_output_tokens,
+            cache_creation_input_tokens=result.total_cache_creation_input_tokens,
+            cache_read_input_tokens=result.total_cache_read_input_tokens,
+            provider=settings.llm.provider,
+        )
+        query_logger.log_cost(
+            session_id=session_id,
+            user_question=question,
+            api_calls=result.api_calls,
+            input_tokens=result.total_input_tokens,
+            output_tokens=result.total_output_tokens,
+            cache_creation_input_tokens=result.total_cache_creation_input_tokens,
+            cache_read_input_tokens=result.total_cache_read_input_tokens,
+            estimated_cost=cost_data.get("estimated_cost"),
+            turn_id=turn_id,
+        )
+        return result
+    finally:
+        await llm_client.aclose()
 
 
 def write_or_print(text: str, output_path: str | None) -> None:

--- a/src/datasight/cli_commands/generate.py
+++ b/src/datasight/cli_commands/generate.py
@@ -311,112 +311,120 @@ def generate(  # noqa: C901
             timeout=settings.llm.timeout,
             model=resolved_model,
         )
+        # Close the SDK's httpx pool before asyncio.run tears down the
+        # event loop. See `cli.run_ask_pipeline` for the rationale.
+        try:
+            if sqlite_source_path is not None:
+                from datasight.runner import SQLiteRunner
 
-        if sqlite_source_path is not None:
-            from datasight.runner import SQLiteRunner
+                sql_runner = SQLiteRunner(str(sqlite_source_path))
+                tables_info = []
+            elif duckdb_source_path is not None:
+                from datasight.runner import DuckDBRunner
 
-            sql_runner = SQLiteRunner(str(sqlite_source_path))
-            tables_info = []
-        elif duckdb_source_path is not None:
-            from datasight.runner import DuckDBRunner
-
-            sql_runner = DuckDBRunner(str(duckdb_source_path))
-            tables_info = []
-        elif (
-            use_files and settings.database.mode == "duckdb" and normalized_import_mode == "table"
-        ):
-            from datasight.explore import (
-                build_persistent_duckdb,
-                create_files_session_for_settings,
-            )
-            from datasight.runner import DuckDBRunner
-
-            planning_runner, planning_tables_info = create_files_session_for_settings(
-                list(files), settings.database, import_mode="auto"
-            )
-            planning_runner.close()
-            persistent_tables_info = []
-            for table_info in planning_tables_info:
-                updated = dict(table_info)
-                if updated.get("type") not in {"duckdb", "xlsx"}:
-                    updated["import_mode"] = "table"
-                persistent_tables_info.append(updated)
-
-            assert db_target is not None
-            try:
-                build_persistent_duckdb(db_target, persistent_tables_info, overwrite=overwrite)
-            except FileExistsError:
-                click.echo(
-                    f"Error: Database file already exists: {db_target}.",
-                    err=True,
+                sql_runner = DuckDBRunner(str(duckdb_source_path))
+                tables_info = []
+            elif (
+                use_files
+                and settings.database.mode == "duckdb"
+                and normalized_import_mode == "table"
+            ):
+                from datasight.explore import (
+                    build_persistent_duckdb,
+                    create_files_session_for_settings,
                 )
-                sys.exit(1)
-            created_persistent_db = db_target
-            sql_runner = DuckDBRunner(str(db_target))
-            tables_info = persistent_tables_info
-        elif use_files:
-            from datasight.explore import create_files_session_for_settings
+                from datasight.runner import DuckDBRunner
 
-            sql_runner, tables_info = create_files_session_for_settings(
-                list(files), settings.database, import_mode=normalized_import_mode
-            )
-        else:
-            sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
-            tables_info = []
-
-        # Introspect schema
-        click.echo("Introspecting database schema...")
-        tables = await introspect_schema(sql_runner.run_sql, runner=sql_runner)
-
-        # Filter to specified tables if --table was provided
-        if table:
-            table_set = {t.lower() for t in table}
-            found_lower = {t.name.lower() for t in tables}
-            missing = [t for t in table if t.lower() not in found_lower]
-            tables = [t for t in tables if t.name.lower() in table_set]
-            if not tables:
-                click.echo(f"Error: No matching tables found for: {', '.join(table)}", err=True)
-                sys.exit(1)
-            if missing:
-                click.echo(
-                    f"Warning: --table values not found: {', '.join(missing)}",
-                    err=True,
+                planning_runner, planning_tables_info = create_files_session_for_settings(
+                    list(files), settings.database, import_mode="auto"
                 )
+                planning_runner.close()
+                persistent_tables_info = []
+                for table_info in planning_tables_info:
+                    updated = dict(table_info)
+                    if updated.get("type") not in {"duckdb", "xlsx"}:
+                        updated["import_mode"] = "table"
+                    persistent_tables_info.append(updated)
 
-        click.echo(f"  Found {len(tables)} tables")
+                assert db_target is not None
+                try:
+                    build_persistent_duckdb(db_target, persistent_tables_info, overwrite=overwrite)
+                except FileExistsError:
+                    click.echo(
+                        f"Error: Database file already exists: {db_target}.",
+                        err=True,
+                    )
+                    sys.exit(1)
+                created_persistent_db = db_target
+                sql_runner = DuckDBRunner(str(db_target))
+                tables_info = persistent_tables_info
+            elif use_files:
+                from datasight.explore import create_files_session_for_settings
 
-        # Sample low-cardinality string columns for enum/code detection
-        click.echo("Sampling code/enum columns...")
-        samples_text = await sample_enum_columns(sql_runner.run_sql, tables)
+                sql_runner, tables_info = create_files_session_for_settings(
+                    list(files), settings.database, import_mode=normalized_import_mode
+                )
+            else:
+                sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
+                tables_info = []
 
-        # Sample timestamp/date columns so the LLM can infer epoch units
-        # and actual time range
-        click.echo("Sampling timestamp columns...")
-        timestamps_text = await sample_timestamp_columns(sql_runner.run_sql, tables)
+            # Introspect schema
+            click.echo("Introspecting database schema...")
+            tables = await introspect_schema(sql_runner.run_sql, runner=sql_runner)
 
-        # Build LLM prompt and call
-        click.echo("Generating documentation (this may take a moment)...")
-        system_prompt, user_msg = build_generation_context(
-            tables, sql_dialect, samples_text, timestamps_text=timestamps_text
-        )
+            # Filter to specified tables if --table was provided
+            if table:
+                table_set = {t.lower() for t in table}
+                found_lower = {t.name.lower() for t in tables}
+                missing = [t for t in table if t.lower() not in found_lower]
+                tables = [t for t in tables if t.name.lower() in table_set]
+                if not tables:
+                    click.echo(
+                        f"Error: No matching tables found for: {', '.join(table)}", err=True
+                    )
+                    sys.exit(1)
+                if missing:
+                    click.echo(
+                        f"Warning: --table values not found: {', '.join(missing)}",
+                        err=True,
+                    )
 
-        from datasight.llm import TextBlock, default_max_output_tokens
+            click.echo(f"  Found {len(tables)} tables")
 
-        budget = (
-            max_tokens
-            if max_tokens is not None
-            else default_max_output_tokens(settings.llm.provider)
-        )
-        response = await llm_client.create_message(
-            model=resolved_model,
-            system=system_prompt,
-            messages=[{"role": "user", "content": user_msg}],
-            tools=[],
-            max_tokens=budget,
-        )
+            # Sample low-cardinality string columns for enum/code detection
+            click.echo("Sampling code/enum columns...")
+            samples_text = await sample_enum_columns(sql_runner.run_sql, tables)
 
-        parts = [block.text for block in response.content if isinstance(block, TextBlock)]
-        return "".join(parts), response.stop_reason, sql_runner, tables_info, tables
+            # Sample timestamp/date columns so the LLM can infer epoch units
+            # and actual time range
+            click.echo("Sampling timestamp columns...")
+            timestamps_text = await sample_timestamp_columns(sql_runner.run_sql, tables)
+
+            # Build LLM prompt and call
+            click.echo("Generating documentation (this may take a moment)...")
+            system_prompt, user_msg = build_generation_context(
+                tables, sql_dialect, samples_text, timestamps_text=timestamps_text
+            )
+
+            from datasight.llm import TextBlock, default_max_output_tokens
+
+            budget = (
+                max_tokens
+                if max_tokens is not None
+                else default_max_output_tokens(settings.llm.provider)
+            )
+            response = await llm_client.create_message(
+                model=resolved_model,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_msg}],
+                tools=[],
+                max_tokens=budget,
+            )
+
+            parts = [block.text for block in response.content if isinstance(block, TextBlock)]
+            return "".join(parts), response.stop_reason, sql_runner, tables_info, tables
+        finally:
+            await llm_client.aclose()
 
     text, stop_reason, sql_runner, tables_info, generated_tables = asyncio.run(_run())
 

--- a/src/datasight/cli_commands/tidy.py
+++ b/src/datasight/cli_commands/tidy.py
@@ -661,13 +661,18 @@ def _propose_via_llm(
     )
 
     async def _call():
-        return await propose_reshapes(
-            llm_client,
-            model=settings.llm.model,
-            schema_info=schema_info,
-            deterministic_hits=deterministic_hits,
-            samples=samples or None,
-        )
+        # Close the SDK's httpx pool before asyncio.run tears down the
+        # event loop. See `cli.run_ask_pipeline` for the rationale.
+        try:
+            return await propose_reshapes(
+                llm_client,
+                model=settings.llm.model,
+                schema_info=schema_info,
+                deterministic_hits=deterministic_hits,
+                samples=samples or None,
+            )
+        finally:
+            await llm_client.aclose()
 
     result = asyncio.run(_call())
     for warning in result.parse_warnings:

--- a/src/datasight/cli_commands/verify.py
+++ b/src/datasight/cli_commands/verify.py
@@ -99,34 +99,39 @@ def verify(project_dir, model, queries_path):  # noqa: C901
             timeout=settings.llm.timeout,
             model=resolved_model,
         )
-        sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
+        # Close the SDK's httpx pool before asyncio.run tears down the
+        # event loop. See `cli.run_ask_pipeline` for the rationale.
+        try:
+            sql_runner = create_sql_runner_from_settings(settings.database, project_dir)
 
-        # Build system prompt
-        tables = await introspect_schema(sql_runner.run_sql, runner=sql_runner)
-        user_desc = load_schema_description(None, project_dir)
-        user_desc = await resolve_schema_description_links(user_desc)
-        schema_text = format_schema_context(tables, user_desc)
-        schema_text += format_example_queries(queries)
+            # Build system prompt
+            tables = await introspect_schema(sql_runner.run_sql, runner=sql_runner)
+            user_desc = load_schema_description(None, project_dir)
+            user_desc = await resolve_schema_description_links(user_desc)
+            schema_text = format_schema_context(tables, user_desc)
+            schema_text += format_example_queries(queries)
 
-        sys_prompt = build_system_prompt(schema_text, mode="verify", dialect=sql_dialect)
+            sys_prompt = build_system_prompt(schema_text, mode="verify", dialect=sql_dialect)
 
-        # Phase 1: Ambiguity analysis
-        ambiguity_results = await run_ambiguity_analysis(
-            queries=queries,
-            schema_context=schema_text,
-            llm_client=llm_client,
-            model=resolved_model,
-        )
+            # Phase 1: Ambiguity analysis
+            ambiguity_results = await run_ambiguity_analysis(
+                queries=queries,
+                schema_context=schema_text,
+                llm_client=llm_client,
+                model=resolved_model,
+            )
 
-        # Phase 2: SQL verification
-        results = await run_verification(
-            queries=queries,
-            llm_client=llm_client,
-            model=resolved_model,
-            system_prompt=sys_prompt,
-            run_sql=sql_runner.run_sql,
-        )
-        return results, ambiguity_results
+            # Phase 2: SQL verification
+            results = await run_verification(
+                queries=queries,
+                llm_client=llm_client,
+                model=resolved_model,
+                system_prompt=sys_prompt,
+                run_sql=sql_runner.run_sql,
+            )
+            return results, ambiguity_results
+        finally:
+            await llm_client.aclose()
 
     results, ambiguity_results = asyncio.run(_run())
 

--- a/src/datasight/llm.py
+++ b/src/datasight/llm.py
@@ -213,6 +213,16 @@ class LLMClient(Protocol):
         """
         ...
 
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool.
+
+        Call this before the event loop shuts down. Without it the
+        SDK's httpx client gets garbage-collected after the loop is
+        already closed, which prints a noisy "Event loop is closed"
+        traceback from asyncio.
+        """
+        ...
+
 
 # ---------------------------------------------------------------------------
 # Anthropic implementation
@@ -389,6 +399,10 @@ class AnthropicLLMClient:
             usage=usage,
             call_stats=CallStats(retries_performed=retries),
         )
+
+    async def aclose(self) -> None:
+        """Close the SDK's httpx connection pool."""
+        await self._client.close()
 
 
 # ---------------------------------------------------------------------------
@@ -729,6 +743,10 @@ class _OpenAICompatibleClient:
             usage=usage,
             call_stats=CallStats(retries_performed=retries),
         )
+
+    async def aclose(self) -> None:
+        """Close the SDK's httpx connection pool."""
+        await self._client.close()
 
 
 class OllamaLLMClient(_OpenAICompatibleClient):

--- a/tests/test_agent_extra.py
+++ b/tests/test_agent_extra.py
@@ -227,6 +227,9 @@ class _FakeLLMClient:
     ) -> LLMResponse:
         return self.responses.pop(0)
 
+    async def aclose(self) -> None:
+        return None
+
 
 @pytest.mark.asyncio
 async def test_run_agent_loop_simple_text_response(test_duckdb_path):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -512,6 +512,9 @@ def test_generate_rewrites_project_files(monkeypatch, tv_project_isolated):
                 usage=SimpleNamespace(input_tokens=1, output_tokens=1),
             )
 
+        async def aclose(self) -> None:
+            return None
+
     monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: _StubClient())
 
     runner = CliRunner()

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -13,6 +13,15 @@ from datasight.cli import cli
 from datasight.llm import LLMResponse, TextBlock, ToolUseBlock, Usage
 
 
+class _StubLLM:
+    """Minimal LLMClient stand-in for tests that stub out `run_agent_loop`
+    and never actually invoke the client. Only needs `aclose` so the
+    pipeline's teardown try/finally has something to await."""
+
+    async def aclose(self) -> None:
+        return None
+
+
 def test_profile_dataset(project_dir):
     runner = CliRunner()
     result = runner.invoke(cli, ["profile", "--project-dir", project_dir])
@@ -1388,6 +1397,9 @@ def test_generate_seeds_measure_overrides(project_dir, monkeypatch):
                 stop_reason="end_turn",
             )
 
+        async def aclose(self) -> None:
+            return None
+
     monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: StubClient())
 
     project_path = Path(project_dir)
@@ -1987,7 +1999,7 @@ def test_run_ask_pipeline_logs_cost_entry(monkeypatch, project_dir):
         async def run_sql(self, sql, **kwargs):  # noqa: ARG002
             return None
 
-    monkeypatch.setattr(cli_module, "create_llm_client", lambda **kwargs: object())
+    monkeypatch.setattr(cli_module, "create_llm_client", lambda **kwargs: _StubLLM())
     monkeypatch.setattr(
         cli_module,
         "create_sql_runner_from_settings",
@@ -2054,7 +2066,7 @@ def test_run_ask_pipeline_includes_measure_guidance_in_prompt(monkeypatch, proje
         async def run_sql(self, sql, **kwargs):  # noqa: ARG002
             return None
 
-    monkeypatch.setattr(cli_module, "create_llm_client", lambda **kwargs: object())
+    monkeypatch.setattr(cli_module, "create_llm_client", lambda **kwargs: _StubLLM())
     monkeypatch.setattr(
         cli_module,
         "create_sql_runner_from_settings",
@@ -2197,6 +2209,9 @@ def test_run_ask_pipeline_uses_measure_semantics_for_energy_power_weighted_and_c
                 usage=Usage(),
             )
 
+        async def aclose(self) -> None:
+            return None
+
     monkeypatch.setattr(
         cli_module, "create_llm_client", lambda **kwargs: SemanticAwareFakeClient()
     )
@@ -2331,6 +2346,9 @@ def test_run_agent_loop_regenerates_sql_after_measure_validation_failure():
                 usage=Usage(),
             )
 
+        async def aclose(self) -> None:
+            return None
+
     async def fake_run_sql(sql, **kwargs):  # noqa: ARG001
         executed_sql.append(sql)
         return pd.DataFrame([{"report_date": "2024-01-01", "wind_generation_mwh": 123.0}])
@@ -2389,7 +2407,7 @@ def test_run_ask_pipeline_session_ids_unique_within_second(monkeypatch, project_
         async def run_sql(self, sql, **kwargs):  # noqa: ARG002
             return None
 
-    monkeypatch.setattr(cli_module, "create_llm_client", lambda **kwargs: object())
+    monkeypatch.setattr(cli_module, "create_llm_client", lambda **kwargs: _StubLLM())
     monkeypatch.setattr(
         cli_module,
         "create_sql_runner_from_settings",
@@ -2658,6 +2676,9 @@ def test_generate_seeds_time_series(project_dir, monkeypatch):
                 ],
                 stop_reason="end_turn",
             )
+
+        async def aclose(self) -> None:
+            return None
 
     monkeypatch.setattr("datasight.cli.create_llm_client", lambda **kwargs: StubClient())
 

--- a/tests/test_generate_persist_db.py
+++ b/tests/test_generate_persist_db.py
@@ -160,6 +160,9 @@ class _StubLLMClient:
             usage=SimpleNamespace(input_tokens=1, output_tokens=1),
         )
 
+    async def aclose(self) -> None:
+        return None
+
 
 @pytest.fixture
 def stub_llm(monkeypatch):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -760,6 +760,38 @@ def test_create_llm_client_unknown_provider():
         create_llm_client("nonexistent")
 
 
+@pytest.mark.asyncio
+async def test_anthropic_client_aclose_closes_sdk_pool():
+    """`aclose` must await the underlying SDK's `close` so httpx's
+    connection pool shuts down before the event loop exits — otherwise
+    the GC's later finalizer trips "Event loop is closed" noise on every
+    `datasight ask` call."""
+    with patch("datasight.llm.anthropic.AsyncAnthropic") as fake_ctor:
+        fake_sdk = MagicMock()
+        fake_sdk.close = AsyncMock()
+        fake_ctor.return_value = fake_sdk
+
+        client = create_llm_client("anthropic", api_key="sk-test")
+        await client.aclose()
+
+    fake_sdk.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ollama_client_aclose_closes_sdk_pool():
+    """Same contract for the OpenAI-compatible backends (Ollama / GitHub
+    Models / OpenAI all share `_OpenAICompatibleClient`)."""
+    fake_module = MagicMock()
+    fake_sdk = MagicMock()
+    fake_sdk.close = AsyncMock()
+    fake_module.AsyncOpenAI = MagicMock(return_value=fake_sdk)
+    with patch.dict("sys.modules", {"openai": fake_module}):
+        client = create_llm_client("ollama")
+        await client.aclose()
+
+    fake_sdk.close.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Dataclasses
 # ---------------------------------------------------------------------------

--- a/tests/test_tidy_review.py
+++ b/tests/test_tidy_review.py
@@ -1289,6 +1289,9 @@ class _FakeLLMClient:
             return LLMResponse(content=[TextBlock(text="done")], stop_reason="end_turn")
         return self._responses.pop(0)
 
+    async def aclose(self) -> None:
+        return None
+
 
 def _propose_response(proposals: list[dict]):
     from datasight.llm import LLMResponse, ToolUseBlock, Usage

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -58,6 +58,9 @@ class FakeLLMClient:
             return LLMResponse(content=[TextBlock(text="done")], stop_reason="end_turn")
         return self._responses.pop(0)
 
+    async def aclose(self) -> None:
+        return None
+
 
 def _tool_use(sql: str, name: str = "run_sql", tool_id: str = "tu_1") -> LLMResponse:
     return LLMResponse(
@@ -371,6 +374,9 @@ async def test_run_single_verification_outer_exception(monkeypatch):
         async def create_message(self, **kwargs):
             msg = "kaboom"
             raise RuntimeError(msg)
+
+        async def aclose(self) -> None:
+            return None
 
     async def _run(sql: str) -> pd.DataFrame:
         return pd.DataFrame()


### PR DESCRIPTION
## Summary
- Add `aclose()` to the `LLMClient` protocol and implement it on `AnthropicLLMClient` and `_OpenAICompatibleClient` (delegates to the SDK's async `close()`, which drains the underlying `httpx.AsyncClient` connection pool).
- Wrap the body of `cli.run_ask_pipeline`, `generate._run`, and `tidy._call` in `try`/`finally: await llm_client.aclose()` so the pool is closed inside the same event loop that uses it — before `asyncio.run` shuts the loop down.

Without this, the SDK's httpx client gets garbage-collected after the loop is already closed, and its scheduled `aclose()` trips `RuntimeError: Event loop is closed`. asyncio prints that as a "Task exception was never retrieved" traceback. Particularly noisy with `datasight ask --files`, which spawns one event loop per question — every row in a benchmark batch produced the traceback.

The fix also covers `datasight generate` and `datasight tidy review`, which had the same teardown pattern.

## Test plan
- [x] `pytest -m "not integration"` — 1492 passed.
- [x] `prek run --all-files` — ruff / ruff-format / ty all clean.
- [x] New `tests/test_llm.py` cases assert that `AnthropicLLMClient.aclose()` and `OllamaLLMClient.aclose()` actually invoke the SDK's `close()`.
- [ ] Manual: run `datasight ask --files=questions.txt` and confirm no "Event loop is closed" traceback at the end of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)